### PR TITLE
Blender beta version

### DIFF
--- a/Casks/blender-beta.rb
+++ b/Casks/blender-beta.rb
@@ -7,7 +7,7 @@ cask 'blender-beta' do
     base_url = 'https://builder.blender.org/download/'
     latest_build = ''
     URI(base_url).open do |io|
-      latest_build = io.read.scan(%r/blender-2.8-[0-9a-z-]+OSX[-._0-9a-z]+/)[0]
+      latest_build = io.read.scan(%r/blender-2.8[0-9a-z-]+OSX[-._0-9a-z]+/)[0]
     end
     "#{base_url}#{latest_build}"
   end

--- a/Casks/blender-beta.rb
+++ b/Casks/blender-beta.rb
@@ -1,0 +1,45 @@
+cask 'blender-beta' do
+  version :latest
+  sha256 :no_check
+
+  url do
+    require 'open-uri'
+    base_url = 'https://builder.blender.org/download/'
+    latest_build = ''
+    URI(base_url).open do |io|
+      latest_build = io.read.scan(%r/blender-2.8-[0-9a-z-]+OSX[-._0-9a-z]+/)[0]
+    end
+    "#{base_url}#{latest_build}"
+  end
+  def build_file
+    require 'open-uri'
+    URI('https://builder.blender.org/download/').open do |io|
+      src = io.read.scan(%r/blender-2.8[-0-9a-z]+OSX-[0-9a-z_.-]+[<>\/a-z]+[0-9.A-Z]+[<>\/a-z]+[A-Za-z0-9 :]+/)[0]
+      file_parts = src.split('-')
+      return "#{file_parts[0]}-#{file_parts[1]}.0-git#{build_date(src)}.#{file_parts[2]}-#{file_parts[5][0..5]}"
+    end
+  end
+
+  def build_date(src)
+    require 'date'
+    date_parts = src.split('<td>')[-1].split(' ')
+    build_month = Date::ABBR_MONTHNAMES.index(date_parts[0]).to_s
+    build_month = '0' << build_month if build_month.length == 1
+    "#{date_parts[2]}#{build_month}#{date_parts[1]}"
+  end
+
+  name 'blender'
+  homepage 'https://blender.org/'
+
+  app "#{build_file}/blender.app", target: 'Blender-Beta.app'
+  shimscript = "#{staged_path}/blender_wrapper.sh"
+  binary shimscript, target: 'blender'
+
+  preflight do
+    FileUtils.chmod 'u+w', Dir.glob("#{staged_path}/*app/**/__pycache__")
+    IO.write shimscript, <<~EOS
+      #!/bin/bash
+      '#{appendir}/Blender.app/Contents/MacOS/blender' "$@"
+    EOS
+  end
+end


### PR DESCRIPTION
Fixed the regular expression for the generated download link, because of the fast update frequency.
---
Had to fix this, even before I was able to do a pull request for my newly added blender-beta cask for version 2.8x (2.80 just right now). It installs automatically the newest 2.8x version of blender for mac, the download url is generated from the html code using a regular expression. Had to do that with the file url to, because the download url is different than the file name (had to get the build date from the html document and add it to add it to the file url while removing 'OSX-10.9' and some other sub strings)
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

Unfortunately it's not able to complete the brew cask style task, because it tells me to use curly brackets when using %r for marking a regular expression. 

`latest_build = io.read.scan(%r/blender-2.8[0-9a-z-]+OSX[-._0-9a-z]+/)[0]`

> == Casks/blender-beta.rb ==
> C: 10: 35: Style/PercentLiteralDelimiters: %r-literals should be delimited by { and }.
> C: 17: 26: Style/PercentLiteralDelimiters: %r-literals should be delimited by { and }.


If I add them the download url and the file url are getting nil (the regex can't find such the occurrence for the download url), so the cask crashes. 

`latest_build = io.read.scan(%r{/blender-2.8[0-9a-z-]+OSX[-._0-9a-z]+/})[0]`

> Error: undefined method `split' for nil:NilClass

If I leave them away the command tells me to mark regular expressions with %r.

`latest_build = io.read.scan(/blender-2.8[0-9a-z-]+OSX[-._0-9a-z]+/)[0]`

> == Casks/blender-beta.rb ==
C: 10: 35: Style/RegexpLiteral: Use %r around regular expression.
C: 17: 26: Style/RegexpLiteral: Use %r around regular expression.

So I decided to leave the curly brackets away, apart from that everything works fine.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
