### PR TITLE
Update emacs-pretest to 26.1-rc1-1

### DIFF
--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -1,10 +1,10 @@
 cask 'emacs-pretest' do
-  version '26.1-rc1'
-  sha256 '8d921bece3244d911e975d71d7ef1b0f80e18c81f0b500e9c854d03b28ea2267'
+  version '26.1-rc1-1'
+  sha256 '722187515f514c748d36999ef4d638aac8e4352bf3c7c39d4c7266e913a493d2'
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
   appcast 'https://emacsformacosx.com/atom/pretest',
-          checkpoint: '43d1a12e3ae12b9b66a3c5717039e9496ac3cad091077d750ab9237b8e19af9d'
+          checkpoint: 'f876987516179bd3171d32a4a00cc1641716d9d55c22ef23c326d30b87534f27'
   name 'Emacs'
   homepage 'https://emacsformacosx.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.