### PR TITLE
Update toggl-dev to 7.4.163

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.161'
-  sha256 'aa236d077335b7d36b88e980a6c267d47aabc4ad700649de8f4e0e8804bee6b7'
+  version '7.4.163'
+  sha256 '6345f4a1d414f69063b2ee646d08ef0ed24aaf087ebc4b0cd4fc6643eb26e406'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'd3174c7015550f570106d3d250c0f0d35230ba00e7131cca0d80f7ca8a9acffb'
+          checkpoint: '3bd0ae6acac638073d03f92e5167e15a0a4f0fa17cd31df1dea76f650dbc4a19'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.