### PR TITLE
Update prince-latest to 20180524

### DIFF
--- a/Casks/prince-latest.rb
+++ b/Casks/prince-latest.rb
@@ -1,10 +1,10 @@
 cask 'prince-latest' do
-  version '20180328'
-  sha256 '0458b1837225a6285d2f304a68fafa9025020d6784ac254d1317dcb157799d78'
+  version '20180524'
+  sha256 '533789e4548c6f42303cfc375bfe6ede03399920040bef1d40c775c8d8797f88'
 
   url "https://www.princexml.com/download/prince-#{version}-macosx.tar.gz"
   appcast 'https://www.princexml.com/latest/',
-          checkpoint: '9933d0cf8d8fe54f66dce9ffede5f794ee8de4a70dd6ea753c25a77c82fb35d5'
+          checkpoint: 'd5f1f8130e762c2e556a3725554c433f7ee9f58613846ae431e4e2748cc368e6'
   name 'Prince'
   homepage 'https://www.princexml.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.