### PR TITLE
Update telegram-alpha to 3.9.1-125917,1048

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.1-125465,1046'
-  sha256 '730c7f1ebf873fb2e2db797f512294b668d00f22f96263a17872a76e2ff14443'
+  version '3.9.1-125917,1048'
+  sha256 '08d3337f80c24bf858df994b849f62345bc9f79c0eb958b9e8ff0bc10fb7b9a9'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'da555d564d2b36a3a86c465c68c0ce8e5b2643bb75fa3bca6600a3c09b73ab49'
+          checkpoint: '1966117aff263cbb0910681dd4654273def9948fef2ddc9cfbe09b0f8815900e'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.