### PR TITLE
Update telegram-alpha to 3.9.1-125974,1049

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.1-125917,1048'
-  sha256 '08d3337f80c24bf858df994b849f62345bc9f79c0eb958b9e8ff0bc10fb7b9a9'
+  version '3.9.1-125974,1049'
+  sha256 '285d0890a57db002382acc9cc38f8dfc7c2b06e7157acf198411aa51a32838c3'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '1966117aff263cbb0910681dd4654273def9948fef2ddc9cfbe09b0f8815900e'
+          checkpoint: 'dd6f4a0d0f83746b5b6a7c47cb138d3f9ad4a6ea6575a8621e6d3b6d62133b13'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.