### PR TITLE
Update tower-beta to 3.0.0-149,149-d345be9a

### DIFF
--- a/Casks/tower-beta.rb
+++ b/Casks/tower-beta.rb
@@ -1,11 +1,11 @@
 cask 'tower-beta' do
-  version '3.0.0-148,148-85e6ba61'
-  sha256 '851386b8d1e8f4d5a0864557e09c4c83b8ffc7e5c858fe5b608a3e4b7c2f72e8'
+  version '3.0.0-149,149-d345be9a'
+  sha256 '83993cf8fa7ac41ca5dbb32e7a081fb9d0797c4c9fa255f3453a6b59c681929a'
 
   # amazonaws.com/apps/tower3-mac was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower3-mac/#{version.after_comma}/Tower-#{version.before_comma}.zip"
   appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/beta",
-          checkpoint: 'b1ba8b77208f78d9668b76396d8e06852d6ec43ba81c6bab7c678d87691c9f0c'
+          checkpoint: '63f8e3cc8ab85fa946b910d065c43cfd8bfdec3d1d412c2d14a3a512a050e7eb'
   name 'Tower'
   homepage 'https://www.git-tower.com/public-beta-2018'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.