### PR TITLE
Update telegram-alpha to 3.9.2-126087,1053

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-126084,1052'
-  sha256 'f93fd4d8430ff20c0f826b9b9bb8d44d248750e2b741b1f501bec481a8952cca'
+  version '3.9.2-126087,1053'
+  sha256 'bbe9d741360edafdbc991d3117e30b11747555e9ef00e11ec27ec0c1c92e6f1a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '212be9872acc4e6c8610271daa9f60975d13d556639d24ce4a97d848c64188b8'
+          checkpoint: '1b39b30d1359eb730f8d0a05a8e572f6165df0f16b90323e6b51351bd2ee75b7'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.