### PR TITLE
Update toggl-beta to 7.4.170

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,11 +1,11 @@
 cask 'toggl-beta' do
-  version '7.4.159'
-  sha256 'ce9ccd1b0be4ee05b1cd5553f38421305e8740836ee997b9ba98c7a53e804e79'
+  version '7.4.170'
+  sha256 '7534036ac0cf7c1ce1859029cf635dbf7197345266ec15593cddefd49fa7d762'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml',
-          checkpoint: 'bbcd4b6f700eee2aefb52de49b84ba74bf8a6754f10a7bbe27d50588d9e05085'
+          checkpoint: '5c1d8cfcf14658ea3dec3c9354e8bf446057eb0ed945ed5e3ef241f91ae9288b'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.