### PR TITLE
Update telegram-alpha to 3.9.2-126187,1055

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-126166,1054'
-  sha256 '8fd916896d04c4b48e6b2c0589b9ce4eb0921f726edb11b105bfc7a86e2ee038'
+  version '3.9.2-126187,1055'
+  sha256 'd12e9d1106c8d016572d7247d4353289231aa9d8256ff3bf1a1ce7c9a4e2ab2d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '460cd668e60e3e88a305edc13fc4326932df31fd30c6e452c3bbee4191d65d5c'
+          checkpoint: '187d0f2fc4eb35f3f0b1b4a10bc6cfd2b2b6a0142b356f52d92ea8cc69dfb46a'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.