### PR TITLE
Update telegram-alpha to 3.9.2-126252,1056

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-126166,1054'
-  sha256 '8fd916896d04c4b48e6b2c0589b9ce4eb0921f726edb11b105bfc7a86e2ee038'
+  version '3.9.2-126252,1056'
+  sha256 '74c4249841c993ec148d0f42755b0463180e6813d621f8ae23634c78f4a2b850'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '460cd668e60e3e88a305edc13fc4326932df31fd30c6e452c3bbee4191d65d5c'
+          checkpoint: 'c88ba66e01f186273537e1dcff11a0c8a6a549503bc20ef8151da5865c679b80'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.