### PR TITLE
Update toggl-dev to 7.4.178

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.176'
-  sha256 'e65b2c00214bfbb185bfb1818de2fe5d063cb13fe549940292b60e967e67cad3'
+  version '7.4.178'
+  sha256 '2ca1195163fe4abd916858988e2d0c7688b7651a0b676bad4a33f5c1a2b04a27'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'b20eebfd4c00bcb6e55f57fe3f1543564a949545f4d0e8e12db2212f482e0a94'
+          checkpoint: '24531e270a408ec217d024870c03f7854668956ea3676405b8c03522bbe0ed03'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.