### PR TITLE
Update telegram-alpha to 3.9.2-126293,1057

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-126252,1056'
-  sha256 '74c4249841c993ec148d0f42755b0463180e6813d621f8ae23634c78f4a2b850'
+  version '3.9.2-126293,1057'
+  sha256 'cd249c1d6b3d321c53698c43096adc5ebf98ae0e1375f84a34963cf3f57a51d6'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'c88ba66e01f186273537e1dcff11a0c8a6a549503bc20ef8151da5865c679b80'
+          checkpoint: 'b32247e7d2aecf99bdb2fd9167fbd317b5e28e1f22ff3a9c94dfde20257b4cea'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.