### PR TITLE
Update telegram-alpha to 3.9.2-126334,1058

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-126293,1057'
-  sha256 'cd249c1d6b3d321c53698c43096adc5ebf98ae0e1375f84a34963cf3f57a51d6'
+  version '3.9.2-126334,1058'
+  sha256 '03b86b0a1741bcfb7dd2c3b8405a873716e5452335f9d9dc7c2dfa5231a1d148'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: 'b32247e7d2aecf99bdb2fd9167fbd317b5e28e1f22ff3a9c94dfde20257b4cea'
+          checkpoint: '91ed7e5a117781acc38ce4e7fcb49412a9576ed8bb7c5df31d127c6814e04dc4'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.