### PR TITLE
Update signal-beta to 1.12.0-beta.2

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,10 +1,10 @@
 cask 'signal-beta' do
-  version '1.12.0-beta.1'
-  sha256 '72ec6f288df664b39593b7db688efa97af0c16aef5b078b897b897ba54364e7c'
+  version '1.12.0-beta.2'
+  sha256 '7827ef8045c4980bca70b62af57a697a95aff7a96da6aab7cb2fef5a7078a682'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom',
-          checkpoint: 'dc91021114a102013ef1203e31f336796950e15212702b4fb534d9451ca11928'
+          checkpoint: 'f94ef7c6125947a995b418109c23b4fcf23ccbc55d79184b645ad32b2bca3923'
   name 'Signal Beta'
   homepage 'https://signal.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.