### PR TITLE
Update toggl-dev to 7.4.179

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.178'
-  sha256 '2ca1195163fe4abd916858988e2d0c7688b7651a0b676bad4a33f5c1a2b04a27'
+  version '7.4.179'
+  sha256 'e57095b9a7305ac80b3fdf3c8360a09326d1ea291dfa3979156f93dd47530aa0'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: '24531e270a408ec217d024870c03f7854668956ea3676405b8c03522bbe0ed03'
+          checkpoint: 'f382bcc1c83e808a0df38104a8626c6ffcde1de3101e8130dbba3e713e79187c'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.