### PR TITLE
Update iterm2-beta to 3.2.0beta3

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,11 +1,11 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.0beta2'
-  sha256 '10618e4f5a04016b741f2fb3479755c33bbbd795eaa87a93bc4a5438a0a5a2e9'
+  version '3.2.0beta3'
+  sha256 '6ddc635caf7ada8c4b93c2c01bce81cfcdf932c4ec71ba2669faeb2ca6cf68c6'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml',
-          checkpoint: '1825f6659626f03f831119fdb5d84a81b6fd328f0594a9658ccb85b0b3ab7e38'
+          checkpoint: '5492d6993634fbdccb90306e5625c63d37f483dc709c42c7a26e0c46cdb90df2'
   name 'iTerm2'
   homepage 'https://www.iterm2.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.