### PR TITLE
Update telegram-alpha to 3.9.2-126564,1060

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-126379,1059'
-  sha256 'dea48df1438111b5a13637f073045c9211f925266faa3d9672a9a71438f0ebef'
+  version '3.9.2-126564,1060'
+  sha256 '899f8440bd2835170b682a411d92b4f4b49db53c7d6fddc0b4a5a2e38b1235c8'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '969ef39ee70714491d1168e51cce2d74cb67b18df7c9354af46dd3b6b7e919dd'
+          checkpoint: '9baa0672461c76af7808249b1332f3ceb07d435ebcfed59924f58107318e56c1'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.