### PR TITLE
Update toggl-dev to 7.4.180

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,11 +1,11 @@
 cask 'toggl-dev' do
-  version '7.4.179'
-  sha256 'e57095b9a7305ac80b3fdf3c8360a09326d1ea291dfa3979156f93dd47530aa0'
+  version '7.4.180'
+  sha256 'd503f1aca10730c6eac2315b1aee27e92f44929aeabff11888a4f3c146c26926'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_dev_appcast.xml',
-          checkpoint: 'f382bcc1c83e808a0df38104a8626c6ffcde1de3101e8130dbba3e713e79187c'
+          checkpoint: '37d0146af6a8b019c8ec28eda91cd8e3d2162bb1726908ab83f1d2e2f5441967'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.