### PR TITLE
Update safari-technology-preview: set sha256 for each macos release

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,11 +1,12 @@
 cask 'safari-technology-preview' do
   version '58'
-  sha256 :no_check
 
   if MacOS.version <= :high_sierra
     url 'https://secure-appldnld.apple.com/STP/091-87399-20180606-FBA72DC9-E8A3-446A-A4E2-B32DBB7175AB/SafariTechnologyPreview.dmg'
+    sha256 '0f85e2b97802854034e22c7f133987dcb47e811bf6bff563c31e6753a5336eb6'
   else
     url 'https://secure-appldnld.apple.com/STP/091-81948-20180606-A6156C55-3298-4E25-9905-10135203B756/SafariTechnologyPreview.dmg'
+    sha256 '5ca5557516b11dfd7b34dd442c9f97f5ac3aca7eb77dbc75d89ac839c9b3fb3f'
   end
 
   name 'Safari Technology Preview'

--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,6 +1,6 @@
 cask 'safari-technology-preview' do
   version '58'
-  sha256 '0f85e2b97802854034e22c7f133987dcb47e811bf6bff563c31e6753a5336eb6'
+  sha256 :no_check
 
   if MacOS.version <= :high_sierra
     url 'https://secure-appldnld.apple.com/STP/091-87399-20180606-FBA72DC9-E8A3-446A-A4E2-B32DBB7175AB/SafariTechnologyPreview.dmg'


### PR DESCRIPTION
Since Safari Technology Preview for macOS Mojave has another checksum than the High Sierra Version of Safari TP...

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
