### PR TITLE
Update telegram-alpha to 3.9.2-128828,1065

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-126579,1061'
-  sha256 'db0e1eab300f06d2c78327b8b9c7be49c32e83e53e619c25047a7e7dc84c11c0'
+  version '3.9.2-128828,1065'
+  sha256 '75f51ccb5cf6d926ee443bc1f21b7080763ef4dcd0e8782dd93cff8220c74cd2'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '50f29a9b82299c9ff181d2663f7e9a4d82f4f9e473b66b5778e9702592d1a786'
+          checkpoint: 'bf1aa21299028ef93ef63aad00d21ee0699677aed1513d99924c937ec2de5c9d'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.