### PR TITLE
Update firefox-esr to 60.0.2

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.0'
+  version '60.0.2'
 
   language 'cs' do
-    sha256 '087c7770b2e690850d5416b114e2dfe2920b3094fa754fe3a042fd186ae89e45'
+    sha256 '583b9ebb7613aabd33a29feac303f094f3106b69afd5c83e1c46d421788c03e4'
     'cs'
   end
 
   language 'de' do
-    sha256 '51540143d4748a7360f7be8ac6a0d96781524ea8ca9b417aa17f9dafdc8c067d'
+    sha256 '5771e026e543587f92dc245033e23b2f61d737857427ed8a00d0ebd6b8be90c6'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '9ab6d1d7a00ae09428505a51bf1e4246cc1eb828bee21b8e209c5dfaf4a23096'
+    sha256 'f3f4cad9705088d1186d2802d9f12c96a89e16dbafa83b2217b56b763c12208b'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'f6e40c42e2e4fbc70929c78cb41acf3e2ed7754aa151efb43f21ba259332d63c'
+    sha256 'd8d14cf9b7d2ccfffec022ad37c92eb366d8eaa7900c7c21e60e16cb0270c10f'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '8ecdb911a93ac81119f6638aa1d5f1969f309f425dcf848ee551f2c3b3ee9979'
+    sha256 '6b7d12ac2a44377535dda6426f9f69bc29c7a176b14bae032b58ed1c83a5fe8e'
     'fr'
   end
 
   language 'gl' do
-    sha256 '3040bed617a1e353fdd118293d374132e4fa9edcd2f2231e92dd2c79bc6c6c28'
+    sha256 '5820457dc7ca6be0662b3772058cba2a9a90cd6b58e9d897aaa01453c7810c8f'
     'gl'
   end
 
   language 'it' do
-    sha256 '9deb066300f99718f46869ed205eb6f1e121c7f565e6d629758f4e96d04e3eaf'
+    sha256 '9c925ca5193dfa592c8465631352066a1421127130386b5b2a7c7849a895b47b'
     'it'
   end
 
   language 'ja' do
-    sha256 '97f8d418abb98f7a7b8727d011fb187d6c6a38cd7d0ba1d5b86e63579a417160'
+    sha256 'df9e5a42ca0a2ff81d6f1e8e440f79540201fb4ab535899a37cfd669c7855366'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'a96e6e99b199c7071ff25e5df0ef9dde3cf2617bdfa3911895e32fc9c5d09834'
+    sha256 'b2a49a01a5acf2c7fc28a4d1c8794dff3f0db04d11b6de153083974a402ae6ca'
     'nl'
   end
 
   language 'pl' do
-    sha256 'c9722d0f4896956e7ae9d9ff2723c22a900eddf3337bd3c3636b3b504bc38f2c'
+    sha256 'c1f8f17854cc4dfd0189de1f0111f8209f42ddacc31cdb002bf0aa78c773c083'
     'pl'
   end
 
   language 'pt' do
-    sha256 '3b57300e703c34fd3e06f52c6dd510fc6945d99e4d24249732bf7165b5dc629b'
+    sha256 'd61da941f10ef2762f126fff1c1cb7a515dd41c73e11b6b364d76b8647a6c8aa'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '9b5b139c2eb17c44190c1c71f5113d549c0f1e447312337a3fa973569cc5b42a'
+    sha256 '963c648a42d3965ce02c9e5646de4463beb3c620cb2dc8cd2d72089689f7f365'
     'ru'
   end
 
   language 'uk' do
-    sha256 '1e3bdb26b9981fecc38fdf717eb6b64cfb7301a480b6ccf702951b9148c84ded'
+    sha256 '5df17ac82ac064ce4fb29293a2dcca2a5892979125afe5a3302e8c43830ab89f'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'c2768cfac20f5390eb276b527b62b9b0d06d413ca3de735a2c4f56d5af3b8be6'
+    sha256 '4da879e142d14b12e9b24ddfe8101cdb224229a8cbb6160bab734f8f855c1523'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '92cfc3b09d1f851133dfefc0c90620ba24d353cd7e6a82f82aa4d7345b7bbb39'
+    sha256 '20217f4428c05499f9dbdd67c50d1ef39bf41e0a9ab7f05ba250143ea00ae09c'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
