### PR TITLE
Update telegram-alpha to 3.9.2-129915,1071

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-128895,1066'
-  sha256 'c63965075887b65f7255fb9129003d088569f0daddb7da873bb2bfb944137f53'
+  version '3.9.2-129915,1071'
+  sha256 '14c2365205ea5d029933bc66ed90df154f6701d571d0e551078af60ced18ace7'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '2ffa64e7bfa48bdd185a2cad84ded2ed7de2f741ee8ba77a2657fe086a3d6bb6'
+          checkpoint: '0aaf2d1fabd2e95dbe21a1cf6776366825cdf4efa2ae88fa7698efbc6dbff56a'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.