### PR TITLE
Update telegram-alpha to 3.9.2-129932,1073

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,11 +1,11 @@
 cask 'telegram-alpha' do
-  version '3.9.2-129915,1071'
-  sha256 '14c2365205ea5d029933bc66ed90df154f6701d571d0e551078af60ced18ace7'
+  version '3.9.2-129932,1073'
+  sha256 '67be492e7b4a583fa0b43b1c573ce2c1c25e72edcf6fdae1c392d2b8d55aec37'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f',
-          checkpoint: '0aaf2d1fabd2e95dbe21a1cf6776366825cdf4efa2ae88fa7698efbc6dbff56a'
+          checkpoint: '7dbbf18c49a8258f03d6651fda2c8589801ce49a2e5243663e9e38c039bd9392'
   name 'Telegram for macOS'
   name 'Telegram Swift'
   homepage 'https://macos.telegram.org/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.