### PR TITLE
Update vivaldi-snapshot to 1.16.1206.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,10 +1,10 @@
 cask 'vivaldi-snapshot' do
-  version '1.16.1195.3'
-  sha256 '758d4d57e19433c852d882be30f6671bbf516a75cd6b391434878e56381b9112'
+  version '1.16.1206.3'
+  sha256 '258ffd18fdd524bc441cc920b6266e52298f1d1837673ef925e01f2ebab5b4ec'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml',
-          checkpoint: '2e0c9131d6f6311a07966d30bb0ba3408727b4ff88255cfc3f2714e95391698d'
+          checkpoint: '99db96697412f8c1e6876192503e021bdf11c06a74b11840ac72ee9475a8c87d'
   name 'Vivaldi'
   homepage 'https://vivaldi.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.