### PR TITLE
Add cask for PowerShell-Preview version 6.1.0-preview.3

### DIFF
--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -1,28 +1,28 @@
 cask 'powershell-preview' do
-    version '6.1.0-preview.3'
-    sha256 '95efa9d091de87746f877814aee56d2ab8f25fddf596aba2653b1782dd2ba362'
+  version '6.1.0-preview.3'
+  sha256 '95efa9d091de87746f877814aee56d2ab8f25fddf596aba2653b1782dd2ba362'
 
-    url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-x64.pkg"
-    appcast 'https://github.com/PowerShell/PowerShell/releases.atom'
-    name 'PowerShell'
-    homepage 'https://github.com/PowerShell/PowerShell'
+  url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-x64.pkg"
+  appcast 'https://github.com/PowerShell/PowerShell/releases.atom'
+  name 'PowerShell'
+  homepage 'https://github.com/PowerShell/PowerShell'
 
-    depends_on formula: 'openssl'
-    depends_on macos: '>= :sierra'
+  depends_on formula: 'openssl'
+  depends_on macos: '>= :sierra'
 
-    pkg "powershell-#{version}-osx-x64.pkg"
+  pkg "powershell-#{version}-osx-x64.pkg"
 
-    uninstall pkgutil: 'com.microsoft.powershell-preview'
+  uninstall pkgutil: 'com.microsoft.powershell-preview'
 
-    zap trash: [
-                 '~/.cache/powershell',
-                 '~/.config/PowerShell',
-                 '~/.local/share/powershell',
-               ],
-        rmdir: [
-                 '~/.cache',
-                 '~/.config',
-                 '~/.local/share',
-                 '~/.local',
-               ]
+  zap trash: [
+                '~/.cache/powershell',
+                '~/.config/PowerShell',
+                '~/.local/share/powershell',
+              ],
+      rmdir: [
+                '~/.cache',
+                '~/.config',
+                '~/.local/share',
+                '~/.local',
+              ]
 end

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -15,14 +15,14 @@ cask 'powershell-preview' do
   uninstall pkgutil: 'com.microsoft.powershell-preview'
 
   zap trash: [
-                '~/.cache/powershell',
-                '~/.config/PowerShell',
-                '~/.local/share/powershell',
-              ],
+               '~/.cache/powershell',
+               '~/.config/PowerShell',
+               '~/.local/share/powershell',
+             ],
       rmdir: [
-                '~/.cache',
-                '~/.config',
-                '~/.local/share',
-                '~/.local',
-              ]
+               '~/.cache',
+               '~/.config',
+               '~/.local/share',
+               '~/.local',
+             ]
 end

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -25,13 +25,4 @@ cask 'powershell-preview' do
                  '~/.local/share',
                  '~/.local',
                ]
-  
-    caveats <<~EOS
-      A OpenSSL-backed libcurl with GSSAPI is required for custom handling
-      of certificates and default credentials for web requests.
-      This is rarely needed, but you can install it with
-        brew install curl --with-openssl --with-gssapi
-      See https://github.com/PowerShell/PowerShell/issues/5638
-    EOS
-  end
-  
+end

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -12,7 +12,7 @@ cask 'powershell-preview' do
 
   pkg "powershell-#{version}-osx-x64.pkg"
 
-  uninstall pkgutil: 'com.microsoft.powershell-preview'
+  uninstall pkgutil: 'com.microsoft.powershell'
 
   zap trash: [
                '~/.cache/powershell',

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -1,19 +1,19 @@
 cask 'powershell-preview' do
     version '6.1.0-preview.3'
     sha256 '95efa9d091de87746f877814aee56d2ab8f25fddf596aba2653b1782dd2ba362'
-  
+
     url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-x64.pkg"
     appcast 'https://github.com/PowerShell/PowerShell/releases.atom'
     name 'PowerShell'
     homepage 'https://github.com/PowerShell/PowerShell'
-  
+
     depends_on formula: 'openssl'
     depends_on macos: '>= :sierra'
-  
+
     pkg "powershell-#{version}-osx-x64.pkg"
-  
+
     uninstall pkgutil: 'com.microsoft.powershell-preview'
-  
+
     zap trash: [
                  '~/.cache/powershell',
                  '~/.config/PowerShell',

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -1,0 +1,37 @@
+cask 'powershell-preview' do
+    version '6.1.0-preview.3'
+    sha256 '95efa9d091de87746f877814aee56d2ab8f25fddf596aba2653b1782dd2ba362'
+  
+    url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-x64.pkg"
+    appcast 'https://github.com/PowerShell/PowerShell/releases.atom'
+    name 'PowerShell'
+    homepage 'https://github.com/PowerShell/PowerShell'
+  
+    depends_on formula: 'openssl'
+    depends_on macos: '>= :sierra'
+  
+    pkg "powershell-#{version}-osx-x64.pkg"
+  
+    uninstall pkgutil: 'com.microsoft.powershell-preview'
+  
+    zap trash: [
+                 '~/.cache/powershell',
+                 '~/.config/PowerShell',
+                 '~/.local/share/powershell',
+               ],
+        rmdir: [
+                 '~/.cache',
+                 '~/.config',
+                 '~/.local/share',
+                 '~/.local',
+               ]
+  
+    caveats <<~EOS
+      A OpenSSL-backed libcurl with GSSAPI is required for custom handling
+      of certificates and default credentials for web requests.
+      This is rarely needed, but you can install it with
+        brew install curl --with-openssl --with-gssapi
+      See https://github.com/PowerShell/PowerShell/issues/5638
+    EOS
+  end
+  


### PR DESCRIPTION
Add a cask for powershell-preview
  - based on powershell from homebrew-cask

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
