### PR TITLE
Update telegram-alpha to 3.9.2-130203,1075

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '3.9.2-129932,1073'
-  sha256 '67be492e7b4a583fa0b43b1c573ce2c1c25e72edcf6fdae1c392d2b8d55aec37'
+  version '3.9.2-130203,1075'
+  sha256 '27537fe9251a663fee0e27e7beb299628ad8927b89058dec21a6e2e38ebf9f0e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.