### PR TITLE
Update telegram-alpha to 4.0-130219,1077

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.0-130206,1076'
-  sha256 'c09b90ee1e1585563d48f6c7cb8837e88681c559c9b21154179095361ff49c61'
+  version '4.0-130219,1077'
+  sha256 'a1eb7d966f5334e582056b83c1f34c5f34624edd21c49eb8e3848f0e07c397bd'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.