### PR TITLE
Update waltr1 to 1.7.3,1480013435

### DIFF
--- a/Casks/waltr1.rb
+++ b/Casks/waltr1.rb
@@ -1,9 +1,10 @@
 cask 'waltr1' do
-  version :latest
-  sha256 :no_check
+  version '1.7.3,1480013435'
+  sha256 '729129129346228fc5d94af6993da2e32e98158f3978ac16b4d5f82b0e83db8b'
 
   # devmate.com/com.softorino.Waltr was verified as official when first introduced to the cask
-  url 'https://dl.devmate.com/com.softorino.Waltr/WALTR.zip'
+  url "https://dl.devmate.com/com.softorino.Waltr/#{version.before_comma}/#{version.after_comma}/WALTR-#{version.before_comma}.zip"
+  appcast 'https://updates.devmate.com/com.softorino.Waltr.xml'
   name 'WALTR'
   homepage 'https://softorino.com/waltr/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.