### PR TITLE
Update toggl-dev to 7.4.186

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.184'
-  sha256 '15b9b4429dd72bcc0ea136ee856dc47b6b542643d24bf6663db76d7b661b247b'
+  version '7.4.186'
+  sha256 '679c256895fe676d74238d61c91a314e28e95771f866e6872632a241a6e37d5b'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.