### PR TITLE
Update opera-beta to 54.0.2952.23

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '54.0.2952.8'
-  sha256 'e56b960903880da13702de74de7d9bf87ff24f6fb376c3360332b2bca8d263ab'
+  version '54.0.2952.23'
+  sha256 '2dad300cae1d095ce75dad97da9ab8282503f17efddab21a62aae11cb2bdb3f4'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.