### PR TITLE
Update vivaldi-snapshot to 1.16.1211.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '1.16.1206.3'
-  sha256 '258ffd18fdd524bc441cc920b6266e52298f1d1837673ef925e01f2ebab5b4ec'
+  version '1.16.1211.3'
+  sha256 'a73a65da12c4916d821e1fd56b77572af643d33d90477b79fa74c4e62624edce'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.