### PR TITLE
Update telegram-alpha to 4.0-130948,1093

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.0-130791,1091'
-  sha256 '91465e940748c3a52cffce84f39c558f445e2b8ded6eb3941976ca22e1caf67e'
+  version '4.0-130948,1093'
+  sha256 '365294b44fde017c07ea247d0d24e4a10d22bb8a216963f9c1afa21167a407f1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.