### PR TITLE
Update github-beta to 1.2.4-beta3-2617ffb9

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '1.2.4-beta2-f0767c31'
-  sha256 '5000616f6e6b5978374694b617964d91282f9b22a954bc6a6f36f9318d4a38f9'
+  version '1.2.4-beta3-2617ffb9'
+  sha256 'c1e480a6994165c68ca75e623d93311aabf35c8d38b9e0837a22a07d5dd6fc4d'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.