### PR TITLE
Update toggl-dev to 7.4.189

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.186'
-  sha256 '679c256895fe676d74238d61c91a314e28e95771f866e6872632a241a6e37d5b'
+  version '7.4.189'
+  sha256 '388848bab8a25d8219c06042259825646c363c26c1f66555721cc6ef79b3a338'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.