### PR TITLE
Update tunnelblick-beta to 3.7.7beta02,5090

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick-beta' do
-  version '3.7.7beta01,5070'
-  sha256 '66105ddcc1df3cda5cec8a90c14d1d16b75599abb48aedee2c537edb23565486'
+  version '3.7.7beta02,5090'
+  sha256 'fa4c89c80dbd3b593e97611bb646d0984d06bee0a07707685e66a509ddaa1e6c'
 
   # github.com/Tunnelblick/Tunnelblick/releases/download was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.