### PR TITLE
Added Cask tower2

### DIFF
--- a/Casks/tower2.rb
+++ b/Casks/tower2.rb
@@ -1,0 +1,19 @@
+cask 'tower2' do
+  version '2.6.6-359,b84d867f'
+  sha256 '3283e5b750336e5c14273b51376481bebc44bd03c5c028df52a5d0091ddf946a'
+
+  # fournova-app-updates.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://fournova-app-updates.s3.amazonaws.com/apps/tower#{version.major}-mac/#{version.split('-').last.tr(',', '-')}/Tower-#{version.major}-#{version.before_comma}.zip"
+  appcast "https://updates.fournova.com/updates/tower#{version.major}-mac/stable"
+  name 'Tower'
+  homepage 'https://www.git-tower.com/'
+
+  app 'Tower.app'
+  binary "#{appdir}/Tower.app/Contents/MacOS/gittower"
+
+  zap trash: [
+               "~/Library/Application Support/com.fournova.Tower#{version.major}",
+               "~/Library/Caches/com.fournova.Tower#{version.major}",
+               "~/Library/Preferences/com.fournova.Tower#{version.major}.plist",
+             ]
+end


### PR DESCRIPTION
In reference to issue https://github.com/Homebrew/homebrew-cask-versions/issues/5874 which says ok to add tower2.

Since Tower.app v3 has switched to subscriptions (booh!), adding this tower2 alternate version cask.

This is simply a copy of an older revision of the tower.rb cask from the homebrew-cask project, with cask name changed from ‘tower’ to ‘tower2’.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
`brew cask audit --download https://raw.githubusercontent.com/edrozenberg/homebrew-cask-versions/master/Casks/tower2.rb`
`audit for tower2: passed`
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
`brew cask style --fix tower2`
`1 file inspected, no offenses detected`
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
`tower2`
- [x] `brew cask install {{cask_file}}` worked successfully.
```
==> Satisfying dependencies
==> Downloading https://fournova-app-updates.s3.amazonaws.com/apps/tower2-mac/35
Already downloaded: /Users/eduardr/Library/Caches/Homebrew/Cask/tower2--2.6.6-359,b84d867f.zip
==> Verifying checksum for Cask tower2
==> Installing Cask tower2
==> Moving App 'Tower.app' to '/Applications/Tower.app'.
==> Linking Binary 'gittower' to '/usr/local/bin/gittower'.
tower2 was successfully installed!
```
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
```
==> Uninstalling Cask tower2
==> Backing App 'Tower.app' up to '/usr/local/Caskroom/tower2/2.6.6-359,b84d867f
==> Removing App '/Applications/Tower.app'.
==> Unlinking Binary '/usr/local/bin/gittower'.
==> Purging files for version 2.6.6-359,b84d867f of Cask tower2
```
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256