### PR TITLE
Update slicer-nightly to 4.9.0.27267,830554

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27180,805346'
-  sha256 'a5317f79cf224cc2023c056ea3bdc3107bc68984470c7ff28f1a8f7c5aed99c6'
+  version '4.9.0.27267,830554'
+  sha256 'ba9fed6605d0d18ece5f151a192d38c04e4035551a64b554b6e76db90afac97b'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.