### PR TITLE
Update airmail-beta to 3.5.5.500,356

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.5.5.497,353'
-  sha256 '556e88f68cb8627a7ce71940fb9dd209b57db59ffad25acf28ec3e3ddc21b674'
+  version '3.5.5.500,356'
+  sha256 '81bef02a78cb836add7f9169efb920f45bf2bbfe3ff65067d25603e3709dc6b2'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.