### PR TITLE
Update sketch-beta to 51.0.0,57336

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,6 +1,6 @@
 cask 'sketch-beta' do
-  version '51.0.0,57255'
-  sha256 'fa7f2d253f8123f69524e7fdf7af0dd4418a8e85d6d93b58d90944e0cd52690e'
+  version '51.0.0,57336'
+  sha256 'f677c99b6bd90f0105d94796a22377d048846c8d763c0c815971e09314968e20'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.