### PR TITLE
Update vivaldi-snapshot to 1.16.1226.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '1.16.1221.3'
-  sha256 '22a18c70f18721362dc3cf94eaa8ae71f14c276c7e2531fdb05a94075f7c9db7'
+  version '1.16.1226.3'
+  sha256 'ace0a8fa30c945f8fc828668fc309a9bcb0d909ed8ad9660eb1f1cf8bf4b6a90'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.