### PR TITLE
Update iterm2-beta to 3.2.0beta6

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.0beta5'
-  sha256 '59509b5ee0694fb4df55919cabbf260b28d9944b8d11ef9b6e7e690f7709c3ab'
+  version '3.2.0beta6'
+  sha256 'ada9905882fcfea29be9cd6465073f23ef57e546ac99de649366e0aa788357f9'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.