### PR TITLE
Update toggl-dev to 7.4.197

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.196'
-  sha256 '77eb12b1c403142d449ca8187e31a23aa30aacb263a1f20d1d063a82a802b4cf'
+  version '7.4.197'
+  sha256 'da7090b67b27f6b7957eb7631c4e755e2f65e8d10cd531dfd65101d68059969b'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.