### PR TITLE
Update telegram-alpha to 4.1.0-131896,1107

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.1.0-131513,1104'
-  sha256 'e1725cd1e76ef1f11d3d177ba1fed556e6d3dcf33503e1c760a525258928a840'
+  version '4.1.0-131896,1107'
+  sha256 'd0c4c1373c65d14bad9e6ecdc53381002dc407feeab37ccf11af37bed7cb345b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.