### PR TITLE
Update telegram-alpha to 4.1.0-132106,1109

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.1.0-131896,1107'
-  sha256 'd0c4c1373c65d14bad9e6ecdc53381002dc407feeab37ccf11af37bed7cb345b'
+  version '4.1.0-132106,1109'
+  sha256 'bb022ec0134c7aa2df918bcd038f6c45142d8f8dd866c6272a5959891592397e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.