### PR TITLE
Update vivaldi-snapshot to 1.16.1230.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '1.16.1226.3'
-  sha256 'ace0a8fa30c945f8fc828668fc309a9bcb0d909ed8ad9660eb1f1cf8bf4b6a90'
+  version '1.16.1230.3'
+  sha256 '4f599ace36ec01f725cb83b89e51901b1b2e6dbc230b67bd539acba45084a6ee'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.