### PR TITLE
Update telegram-alpha to 4.1.0-132280,1116

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.1.0-132106,1109'
-  sha256 'bb022ec0134c7aa2df918bcd038f6c45142d8f8dd866c6272a5959891592397e'
+  version '4.1.0-132280,1116'
+  sha256 '470cf8e64c2feb3630fe772b19960b00d9f4196a9ccb78ea55462376d7c47f99'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.