### PR TITLE
Update sketch-beta to 51.0.0,57462

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,6 +1,6 @@
 cask 'sketch-beta' do
-  version '51.0.0,57336'
-  sha256 'f677c99b6bd90f0105d94796a22377d048846c8d763c0c815971e09314968e20'
+  version '51.0.0,57462'
+  sha256 '3969656cebd8700c6e2022da52a14a0a1b923a708d79887b75a484ac5264af2b'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.