### PR TITLE
Update toggl-dev to 7.4.203

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.202'
-  sha256 '7b645cc6e2a2d7ae3bc18863b80d5e8521defe6ec956e170aacf72e81f819e07'
+  version '7.4.203'
+  sha256 'e943981c49a30958872c584bfc2dd2f865ebdca0da229158d7fc4da537d7e62a'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.