### PR TITLE
Update telegram-alpha to 4.1-132343,1118

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.1.0-132280,1116'
-  sha256 '470cf8e64c2feb3630fe772b19960b00d9f4196a9ccb78ea55462376d7c47f99'
+  version '4.1-132343,1118'
+  sha256 '7effc514e8526a72ccd997a780f798ee7e9b1fc7b6b48424b51ccfdb72788f3e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.