### PR TITLE
update clementine-latest: fix url

### DIFF
--- a/Casks/clementine-latest.rb
+++ b/Casks/clementine-latest.rb
@@ -4,14 +4,19 @@ cask 'clementine-latest' do
 
   url do
     require 'open-uri'
-    last_modified_query = '?C=M;O=D'
     base_url = 'https://builds.clementine-player.org/mac/'
-    file = URI("#{base_url}#{last_modified_query}")
-           .open
-           .read
-           .scan(%r{href="(clementine-[^"]+.dmg)"})
-           .flatten
-           .first
+    versions = URI(base_url.to_s)
+               .open
+               .read
+               .scan(%r{href="clementine\-((?:\d+\.?)+\-\d+\-\w+)\.dmg"})
+               .flatten
+
+    versions.sort_by { |version| Gem::Version.new(version) }
+
+    latest_version = versions.last
+
+    file = "clementine-#{latest_version}.dmg"
+
     "#{base_url}#{file}"
   end
   name 'Clementine'


### PR DESCRIPTION
closes #5895

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
