### PR TITLE
Update github-beta to 1.3.0-beta1-57fe4f59

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '1.2.7-beta0-61d9aea2'
-  sha256 '2c9d721b107df39bfdcfbc6d3d0b6e8ba47afc61d51c5eb62c92791af6af519d'
+  version '1.3.0-beta1-57fe4f59'
+  sha256 'f151c27635667ce77773fb0dbf19de85e17cc68ec594809fdbbf59956aa80d09'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.