### PR TITLE
Update atom-beta to 1.29.0-beta2

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,6 +1,6 @@
 cask 'atom-beta' do
-  version '1.29.0-beta1'
-  sha256 'e20835378a0310021c8d0fab890d57966bba3fc7e92a290d21f374d303d1fbd2'
+  version '1.29.0-beta2'
+  sha256 '6230d884b873cdb2487156408be2d4a6f32f8449605cb9b93d7be02d6452a112'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.