### PR TITLE
Update toggl-dev to 7.4.206

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.205'
-  sha256 '7783b5b3355dbf72f28f9424a774ad913d8c5375c006528d720917e31fbde368'
+  version '7.4.206'
+  sha256 '9568f195d60bb1ee7f1d7ff3f61f2f7bd1ee202474e0a788e043ec4e67cba6d3'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.