### PR TITLE
Update telegram-alpha to 4.1-132829,1122

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.1-132498,1121'
-  sha256 '84524f6d625fdfcf2865bbfc4e6b17d50bf2fafefa8d24cb6bbad0e87a76a2c2'
+  version '4.1-132829,1122'
+  sha256 '5475aa1af4429b6aff2e3e7f8415a87efeb51c50a220af0e4e7919c779eace26'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.