### PR TITLE
Update kicad-nightly to use the latest unified dmg.

### DIFF
--- a/Casks/kicad-nightly.rb
+++ b/Casks/kicad-nightly.rb
@@ -5,7 +5,7 @@ cask 'kicad-nightly' do
   url do
     require 'open-uri'
     base_url = 'http://downloads.kicad-pcb.org/osx/nightly/'
-    file = URI(base_url).open.read.scan(%r{href="([^"]+.dmg)"}).flatten.last
+    file = URI(base_url).open.read.scan(%r{href="(kicad-unified-[^"]+.dmg)"}).flatten.last
     "#{base_url}#{file}"
   end
   name 'KiCad'


### PR DESCRIPTION
Previously the file fetched was just the last .dmg file returned from
the nightly repository, http://downloads.kicad-pcb.org/osx/nightly/.
Recently a new file "test.dmg" was added to the repository, this file
is empty and not what the user would want to install.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. (nightly builds so no version number)