### PR TITLE
Update telegram-alpha to 4.1-132995,1123

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.1-132829,1122'
-  sha256 '5475aa1af4429b6aff2e3e7f8415a87efeb51c50a220af0e4e7919c779eace26'
+  version '4.1-132995,1123'
+  sha256 '5975b4751fe09e538d37072d43f5337cb90340877f0432ad31696a0585aa0224'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.