### PR TITLE
Update telegram-alpha to 4.1-133015,1125

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.1-133000,1124'
-  sha256 '95159c44079fdfc8c93102ccf40aaaa59269084a0ec477913c3eaa15f05a9b50'
+  version '4.1-133015,1125'
+  sha256 'e9e9b7862928db67a464fae2b1d70429fb0f55823dcab2983c156ce8e9f5c17a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.