### PR TITLE
Update java8 to 1.8.0_181-b13,96a7b8442fe848ef90c96a2fad6ed6d1

### DIFF
--- a/Casks/java8.rb
+++ b/Casks/java8.rb
@@ -1,6 +1,6 @@
 cask 'java8' do
-  version '1.8.0_172-b11,a58eab1ec242421181065cdc37240b08'
-  sha256 'b0de04d3ec7fbf2e54e33e29c78ababa0a4df398ba490d4abb125b31ea8d663e'
+  version '1.8.0_181-b13,96a7b8442fe848ef90c96a2fad6ed6d1'
+  sha256 '3ea78e0107f855b47a55414fadaabd04b94e406050d615663d54200ec85efc9b'
 
   java_update = version.sub(%r{.*_(\d+)-.*}, '\1')
   url "http://download.oracle.com/otn-pub/java/jdk/#{version.minor}u#{version.before_comma.split('_').last}/#{version.after_comma}/jdk-#{version.minor}u#{java_update}-macosx-x64.dmg",


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.