### PR TITLE
Update firefox-nightly to use the "url do" block

### DIFF
--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -1,5 +1,5 @@
 cask 'firefox-nightly' do
-  version '63.0a1'
+  version :latest
   sha256 :no_check # required as upstream package is updated in-place
 
   language 'cs' do
@@ -23,7 +23,15 @@ cask 'firefox-nightly' do
   end
 
   # download-installer.cdn.mozilla.net/pub/firefox/nightly was verified as official when first introduced to the cask
-  url "https://download-installer.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-central#{language == 'en-US' ? '' : '-l10n'}/firefox-#{version}.#{language}.mac.dmg"
+  url do
+    require 'open-uri'
+    base_url = 'https://download-installer.cdn.mozilla.net/pub/firefox/nightly'
+    builds_url = "#{base_url}/latest-mozilla-central#{language == 'en-US' ? '' : '-l10n'}/"
+    latest_build_filename = URI(builds_url).open do |io|
+      io.read.scan(%r{<td><a href="/pub/firefox/nightly/([^\"]+\.mac\.dmg)">}).flatten.grep(%r{\.#{language}\.mac\.dmg})[0]
+    end
+    "#{base_url}/#{latest_build_filename}"
+  end
   name 'Mozilla Firefox'
   homepage 'https://www.mozilla.org/firefox/channel/desktop/#nightly'
 

--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -27,9 +27,7 @@ cask 'firefox-nightly' do
     require 'open-uri'
     base_url = 'https://download-installer.cdn.mozilla.net/pub/firefox/nightly'
     builds_url = "#{base_url}/latest-mozilla-central#{language == 'en-US' ? '' : '-l10n'}/"
-    latest_build_filename = URI(builds_url).open do |io|
-      io.read.scan(%r{<td><a href="/pub/firefox/nightly/([^\"]+\.mac\.dmg)">}).flatten.grep(%r{\.#{language}\.mac\.dmg})[0]
-    end
+    latest_build_filename = URI(builds_url).open.read.scan(%r{<td><a href="/pub/firefox/nightly/([^\"]+\.mac\.dmg)">}).flatten.grep(%r{\.#{language}\.mac\.dmg}).first
     "#{base_url}/#{latest_build_filename}"
   end
   name 'Mozilla Firefox'


### PR DESCRIPTION
This was meant for https://github.com/Homebrew/homebrew-cask-versions/issues/5953, which got addressed quickly, but hopefully it'll be useful for future cases.
 
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
    * includes the name but version is not applicable in this case 
