### PR TITLE
Update telegram-alpha to 4.2.0-133138,1131

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.1-133065,1127'
-  sha256 'e2ab7f5c0ced43cd243675b795166c84cda624866806d7293565b22efac99ae8'
+  version '4.2.0-133138,1131'
+  sha256 'b8d12431b819f5fa3d2fa9cdda8f0499cddbef06cc41816f098257e8f5ce014c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.