### PR TITLE
Update telegram-alpha to 4.2.0-133144,1132

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2.0-133138,1131'
-  sha256 'b8d12431b819f5fa3d2fa9cdda8f0499cddbef06cc41816f098257e8f5ce014c'
+  version '4.2.0-133144,1132'
+  sha256 'f7bae11c6fedc84e906f008b98a598af67988b9b277ecd1678d477068ccd45da'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.