### PR TITLE
Update airmail-beta to 3.5.5.503,359

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.5.5.502,358'
-  sha256 '3ab46324b41b2359e51346c757a627c2731dd674bdb97659564d8ab02d8da57c'
+  version '3.5.5.503,359'
+  sha256 '903e42f1733c719661f4aae99ac9c0efeae57077c4bc7d53d6b1180e5528a27c'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.