### PR TITLE
Update telegram-alpha to 4.2-133153,1133

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2.0-133138,1131'
-  sha256 'b8d12431b819f5fa3d2fa9cdda8f0499cddbef06cc41816f098257e8f5ce014c'
+  version '4.2-133153,1133'
+  sha256 '93c3cc3350787c361bd99678b56e5ad163f880e02f0974ea748874c7505478e0'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.