### PR TITLE
Update safari-technology-preview to 61

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '60'
+  version '61'
 
   if MacOS.version <= :high_sierra
-    url 'https://secure-appldnld.apple.com/STP/091-93967-20180703-202A0C40-70FA-11E8-B6CB-0C6212F91F3C/SafariTechnologyPreview.dmg'
-    sha256 'e63ce6bd9863f93b3f618ba6aef4e1674700115b0a0bd67c06fa2e0d9e657aa0'
+    url 'https://secure-appldnld.apple.com/STP/091-95261-201807018-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
+    sha256 '28cd2ea286a32beb12e36a4900584da0d60bb9b698f6e83ba536476150272622'
   else
-    url 'https://secure-appldnld.apple.com/STP/091-93969-20180703-202A0C40-70FA-11E8-B6CB-0C6212F91F3C/SafariTechnologyPreview.dmg'
-    sha256 '2b403cf9d43ea5815b9cf677c0d21b2fbe7814522d9b21c6d35f75802d15c1bf'
+    url 'https://secure-appldnld.apple.com/STP/091-95465-201807018-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
+    sha256 'e2d2260dfd588870d609db8dd89598e15ea6b18375a7608950a2c72207fc508f'
   end
 
   name 'Safari Technology Preview'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.