### PR TITLE
Update telegram-alpha to 4.2-133309,1135

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2-133194,1134'
-  sha256 'efe5c38690e1ced071281e803b039282a5d4e6b1663527b1e79810e527f35f46'
+  version '4.2-133309,1135'
+  sha256 'd67f7db8a16f68391857f88d6e16228b0a3247c511bdba8f7f60038c3291fc0f'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.