### PR TITLE
Update telegram-alpha to 4.2-133352,1136

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2-133309,1135'
-  sha256 'd67f7db8a16f68391857f88d6e16228b0a3247c511bdba8f7f60038c3291fc0f'
+  version '4.2-133352,1136'
+  sha256 '9a7a58391c1f3d2c9da07b5cf56e0b0815928f455c7f391d3fc7c3c7ce0a3929'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.