### PR TITLE
Update ableton-live-lite9 to 9.7.7

### DIFF
--- a/Casks/ableton-live-lite9.rb
+++ b/Casks/ableton-live-lite9.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-lite9' do
-  version '9.7.6'
-  sha256 'f40ea7481318747ffcce9a7e79fdad38453664f53816c98390a94eb3e57b3ed2'
+  version '9.7.7'
+  sha256 '792e80d33d0c704b10b31c672b2e897644696232009cee1f4bf28b3cfb1281e3'
 
   url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.