### PR TITLE
Update libreoffice-rc to 6.1.0.2

### DIFF
--- a/Casks/libreoffice-rc.rb
+++ b/Casks/libreoffice-rc.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice-rc' do
-  version '6.1.0.1'
-  sha256 '5ee38c3b00db2ba62efffd503a35f6664ad649623845af7b1265f126e54ed65b'
+  version '6.1.0.2'
+  sha256 '3ac3d22c4689bd04bbc33396e0e3bfcbd182c43669f72ee50d4490f27853876f'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.