### PR TITLE
Update iina-beta 1.0.0-beta3 depends on

### DIFF
--- a/Casks/iina-beta.rb
+++ b/Casks/iina-beta.rb
@@ -10,7 +10,7 @@ cask 'iina-beta' do
 
   auto_updates true
   conflicts_with cask: 'iina'
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :el_capitan'
 
   app 'IINA.app'
   binary "#{appdir}/IINA.app/Contents/MacOS/iina-cli", target: 'iina'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
---
This update is based on the release notes for this version:

> We have dropped macOS 10.10 Yosemite support starting from this version.

(https://github.com/lhc70000/iina/releases/tag/v1.0.0-beta3)