### PR TITLE
Add Synergy 2.0.12(beta)

### DIFF
--- a/Casks/synergy-beta.rb
+++ b/Casks/synergy-beta.rb
@@ -1,0 +1,10 @@
+cask 'synergy-beta' do
+  version '2.0.12,b1807-50472cde'
+  sha256 '41927a6a52a523797122a7d6a9c8817d09cce9966ad08118c693345f51aa41e9'
+
+  url "https://binaries.symless.com/v#{version.before_comma}/Synergy_v#{version.before_comma}-beta_#{version.after_comma}.dmg"
+  name 'Synergy'
+  homepage 'https://symless.com/synergy'
+
+  app 'Synergy.app'
+end


### PR DESCRIPTION
Because #50109 reverted back to Synergy v1.10 as the stable version,
I'm resurrecting the previous version of the formula and submitting it as
synergy-beta for those who want to continue using Synergy v2 while it's
in beta.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
