### PR TITLE
Update telegram-alpha to 4.2.1-134953,1143

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2-134760,1142'
-  sha256 '2cb250cf24be15014484c3bd1ca3ff21dd23db32c85c7b3a89605302a39b94b5'
+  version '4.2.1-134953,1143'
+  sha256 'dc1667acac0c4ae9f332ca716be1218440646587bcfa8ebacbda5c79f4b4b6bb'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.