### PR TITLE
Update telegram-alpha to 4.2.1-135121,1145

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2.1-134953,1143'
-  sha256 'dc1667acac0c4ae9f332ca716be1218440646587bcfa8ebacbda5c79f4b4b6bb'
+  version '4.2.1-135121,1145'
+  sha256 '15bf5d727bbe8ec3d95be3da7e853416b07999b76a76fb4e9e02b4a750ca4d71'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.