### PR TITLE
Add workflowy-beta 1.0.20-beta.314

### DIFF
--- a/Casks/workflowy-beta.rb
+++ b/Casks/workflowy-beta.rb
@@ -1,0 +1,12 @@
+cask 'workflowy-beta' do
+  version '1.0.20-beta.314'
+  sha256 'd24a1cb0b61dec155f3ad3eb73f91ec91db75c762c4827613d661cc447bdc0ef'
+
+  # github.com/workflowy/desktop-beta was verified as official when first introduced to the cask
+  url "https://github.com/workflowy/desktop-beta/releases/download/v#{version}/WorkFlowy-Beta.dmg"
+  appcast 'https://github.com/workflowy/desktop-beta/releases.atom'
+  name 'WorkFlowy-Beta'
+  homepage 'https://beta.workflowy.com/downloads/mac/'
+
+  app 'WorkFlowy Beta.app'
+end

--- a/Casks/workflowy-beta.rb
+++ b/Casks/workflowy-beta.rb
@@ -5,7 +5,7 @@ cask 'workflowy-beta' do
   # github.com/workflowy/desktop-beta was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop-beta/releases/download/v#{version}/WorkFlowy-Beta.dmg"
   appcast 'https://github.com/workflowy/desktop-beta/releases.atom'
-  name 'WorkFlowy-Beta'
+  name 'WorkFlowy'
   homepage 'https://beta.workflowy.com/downloads/mac/'
 
   app 'WorkFlowy Beta.app'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

See equivalent for the stable release: https://github.com/Homebrew/homebrew-cask/pull/39873

Motivated by https://blog.workflowy.com/2018/07/30/want-to-try-workflowys-new-design/

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version). _-> I added this in this repo because it's for a beta version, not the stable version_

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
