### PR TITLE
Update safari-technology-preview to 62

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '61'
+  version '62'
 
   if MacOS.version <= :high_sierra
-    url 'https://secure-appldnld.apple.com/STP/091-95261-201807018-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
-    sha256 '28cd2ea286a32beb12e36a4900584da0d60bb9b698f6e83ba536476150272622'
+    url 'https://secure-appldnld.apple.com/STP/091-95878-20180801-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
+    sha256 '01f8300d2fc6e7eb99206d25720ef275aa5c5317d1a02d9dbe636a526387bd80'
   else
-    url 'https://secure-appldnld.apple.com/STP/091-95465-201807018-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
-    sha256 'e2d2260dfd588870d609db8dd89598e15ea6b18375a7608950a2c72207fc508f'
+    url 'https://secure-appldnld.apple.com/STP/091-96008-20180801-01EC2FD2-85EB-11E8-AB5B-AEA972136C42/SafariTechnologyPreview.dmg'
+    sha256 '88d8e755795eddc5fc901ffc1d2e6ea9dec3663325340307b086bf138e169c57'
   end
 
   name 'Safari Technology Preview'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.