### PR TITLE
Update toggl-dev to 7.4.230

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.227'
-  sha256 'e439209e9522c73b76da7847515b98be82c884a2d8fa3acf2c098556f83d3ec4'
+  version '7.4.230'
+  sha256 '2ae638e4d7afd8bcb521e56d8b7bc9673324324f5460e95b81038f120c46ef71'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.