### PR TITLE
Update workflowy-beta to 1.0.20-beta.403

### DIFF
--- a/Casks/workflowy-beta.rb
+++ b/Casks/workflowy-beta.rb
@@ -1,6 +1,6 @@
 cask 'workflowy-beta' do
-  version '1.0.20-beta.391'
-  sha256 'a9c280fe3fc71c2d9932c5aa502c7fa6a99e28f008f7571d0151ede436592def'
+  version '1.0.20-beta.403'
+  sha256 'd2913f8ac1c8d21dfc1a1b227c14bdd1b23aecdadf01a58af366ef6bb0abe7c9'
 
   # github.com/workflowy/desktop-beta was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop-beta/releases/download/v#{version}/WorkFlowy-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.