### PR TITLE
Update skype-preview to 8.28.76.19

### DIFF
--- a/Casks/skype-preview.rb
+++ b/Casks/skype-preview.rb
@@ -1,6 +1,6 @@
 cask 'skype-preview' do
-  version '8.27.76.16'
-  sha256 'b0cf3842542f80ed2072b96f75a0fed9a3a856558987519f7011a05a076f124a'
+  version '8.28.76.19'
+  sha256 '04536eae072b5124b108f732b2fca4ba985034266f179561f7c0a85ecaa672bc'
 
   # endpoint920510.azureedge.net/s4l/s4l/download/mac was verified as official when first introduced to the cask
   url "https://endpoint920510.azureedge.net/s4l/s4l/download/mac/Skype-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.