### PR TITLE
Update ableton-live-standard9 to 9.7.7

### DIFF
--- a/Casks/ableton-live-standard9.rb
+++ b/Casks/ableton-live-standard9.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-standard9' do
-  version '9.7.6'
-  sha256 'd6fda952da53bb2c0eb69a6c0653fd0396bcbe81f5ee239da8ee2e10904c07fa'
+  version '9.7.7'
+  sha256 'b78438cf84a25c9fd1a797103a86f94f563cae36170f3513ce8e0272b49fb3e8'
 
   url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.