### PR TITLE
Update ableton-live-suite9 to 9.7.7

### DIFF
--- a/Casks/ableton-live-suite9.rb
+++ b/Casks/ableton-live-suite9.rb
@@ -1,6 +1,6 @@
 cask 'ableton-live-suite9' do
-  version '9.7.6'
-  sha256 '60a0f9b035176a6a276b0d21315e0584a39adeea62d621ed074d9e4efe2f8cda'
+  version '9.7.7'
+  sha256 '582547c75197e0f88cb4b88d579ce982f03a32cd2b48739fe3c77a516b49191d'
 
   url "http://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.