### PR TITLE
new formula: whoozle-android-file-transfer-nightly, continuous

### DIFF
--- a/Casks/whoozle-android-file-transfer-nightly.rb
+++ b/Casks/whoozle-android-file-transfer-nightly.rb
@@ -1,15 +1,16 @@
 cask 'whoozle-android-file-transfer-nightly' do
-  version 'continuous'
+  version :latest
   sha256 :no_check
 
   # github.com/whoozle/android-file-transfer-linux was verified as official when first introduced to the cask
-  url "https://github.com/whoozle/android-file-transfer-linux/releases/download/#{version}/AndroidFileTransferForLinux.dmg"
-  appcast 'https://github.com/whoozle/android-file-transfer-linux/releases.atom'
+  url 'https://github.com/whoozle/android-file-transfer-linux/releases/download/continuous/AndroidFileTransferForLinux.dmg'
   name 'Android File Transfer'
   homepage 'https://whoozle.github.io/android-file-transfer-linux/'
 
-  conflicts_with cask: ['android-file-transfer',
-                        'whoozle-android-file-transfer']
+  conflicts_with cask: [
+                         'android-file-transfer',
+                         'whoozle-android-file-transfer',
+                       ]
 
   app 'Android File Transfer for Linux.app'
 end

--- a/Casks/whoozle-android-file-transfer-nightly.rb
+++ b/Casks/whoozle-android-file-transfer-nightly.rb
@@ -1,0 +1,15 @@
+cask 'whoozle-android-file-transfer-nightly' do
+  version 'continuous'
+  sha256 :no_check
+
+  # github.com/whoozle/android-file-transfer-linux was verified as official when first introduced to the cask
+  url "https://github.com/whoozle/android-file-transfer-linux/releases/download/#{version}/AndroidFileTransferForLinux.dmg"
+  appcast 'https://github.com/whoozle/android-file-transfer-linux/releases.atom'
+  name 'Android File Transfer'
+  homepage 'https://whoozle.github.io/android-file-transfer-linux/'
+
+  conflicts_with cask: ['android-file-transfer',
+                        'whoozle-android-file-transfer']
+
+  app 'Android File Transfer for Linux.app'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

`brew audit` doesn't allow github release to be without appcast, in turn appcast forbids version :latest.