### PR TITLE
Update libreoffice-still to 6.0.6

### DIFF
--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice-still' do
-  version '5.4.7'
-  sha256 '541b43b958820048f919d50ee6b52515d9ba98608731392eb4a4ae4590ce3e82'
+  version '6.0.6'
+  sha256 '94d39d92160794fc1e8b4812d774ee3e203f7f2ec19064285b2309be5553453d'
 
   # documentfoundation.org was verified as official when first introduced to the cask
   url "http://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"

--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -13,7 +13,7 @@ cask 'libreoffice-still' do
                          'libreoffice',
                          'libreoffice-rc',
                        ]
-  depends_on macos: '>= :mountain_lion'
+  depends_on macos: '>= :mavericks'
 
   app 'LibreOffice.app'
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.