### PR TITLE
Update telegram-alpha to 4.2.2-136750,1178

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2.2-136289,1165'
-  sha256 '9dfcd48fb7e53641397ca15c7b1b9c7d012d952a239093faf42e122c6e99d7f1'
+  version '4.2.2-136750,1178'
+  sha256 'f9569ac6102f2a837476fd4055525b0ba1593448b75e63e712fadc7e8181182f'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.