### PR TITLE
Update telegram-alpha to 4.2.2-136846,1182

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2.2-136796,1180'
-  sha256 '0b85742ee2fa89cc410425e614b0ec5177b6f08cef37e7a58772cd8851d0cdfc'
+  version '4.2.2-136846,1182'
+  sha256 'ffde84fd2861846ac7d9d9e7dcef55fc1dda0cb69db23dbf865ff24fe83c31f7'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.