### PR TITLE
Update telegram-alpha to 4.2.2-136917,1183

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2.2-136846,1182'
-  sha256 'ffde84fd2861846ac7d9d9e7dcef55fc1dda0cb69db23dbf865ff24fe83c31f7'
+  version '4.2.2-136917,1183'
+  sha256 'fd94885382125355d12ef916ef245027c8aa6065a4efe3a3577f8e4465a9f26a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.