### PR TITLE
Update toggl-dev to 7.4.236

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.234'
-  sha256 '68c149264e0bfc3992bd7883237bc8ecb6c3f6d4e03cbb9925ad97c53390f9f1'
+  version '7.4.236'
+  sha256 '644422e7d72a2c7b473f8855d2cfb211cb5d9c2626be4799b68129ef0cb18c22'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.