### PR TITLE
Update dropbox-beta to 56.3.84

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '56.3.83'
-  sha256 'bced0bfba689ad9515baee1591e97d6b0e797893c26c844d03436e1e6d7af686'
+  version '56.3.84'
+  sha256 '05a6a062f69e7ff8b056cd659e146f366bafbdaf379a59749a3306ed5658bbc9'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.