### PR TITLE
Update workflowy-beta to 1.1.1-beta.605

### DIFF
--- a/Casks/workflowy-beta.rb
+++ b/Casks/workflowy-beta.rb
@@ -1,6 +1,6 @@
 cask 'workflowy-beta' do
-  version '1.1.1-beta.543'
-  sha256 'cec416ccf403c1f43f1aa08dd3eeef0d0f1dfd4d47259f730e96ef0c07f5616b'
+  version '1.1.1-beta.605'
+  sha256 '30036444412f0eadc7e3a880fe86298e0823bfe93bbfe5b76cb9268a807f5fd9'
 
   # github.com/workflowy/desktop-beta was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop-beta/releases/download/v#{version}/WorkFlowy-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.