### PR TITLE
Update porting-kit-legacy to latest

### DIFF
--- a/Casks/porting-kit-legacy.rb
+++ b/Casks/porting-kit-legacy.rb
@@ -7,13 +7,16 @@ cask 'porting-kit-legacy' do
   homepage 'http://portingkit.com/'
 
   conflicts_with cask: 'porting-kit'
-  depends_on macos: '<= :mountain_lion'
+  depends_on macos: [
+                      :snow_leopard,
+                      :lion,
+                    ]
 
   app 'Porting Kit Legacy.app'
 
   zap trash: [
                '~/Library/Preferences/edu.ufrj.vitormm.Porting-Kit-Legacy.plist',
-               '~/Library/Application Support/Porting-Kit-Legacy',
+               '~/Library/Application Support/Porting-Kit',
                '~/Library/Saved Application State/edu.ufrj.vitormm.Porting-Kit-Legacy.savedState',
                '~/Library/Caches/edu.ufrj.vitormm.Porting-Kit-Legacy',
                '~/Library/Cookies/edu.ufrj.vitormm.Porting-Kit-Legacy.binarycookies',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/Homebrew/homebrew-cask-versions/issues/6079