### PR TITLE
Update opera-developer to 56.0.3051.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '56.0.3045.0'
-  sha256 'f1278d2b960adb00cd2856cce0e62354f6cf33be0ad63728f8fc2b48cbdedb40'
+  version '56.0.3051.0'
+  sha256 '7bf0107dcf22bad2bfc601daecdff73d05ba4c4d75209fa59239c8929481d4b2'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.