### PR TITLE
Update visual-studio-code-insiders to 1.27.0,07796186d388044595cd101c49378c7cd48b350b

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.27.0,6e559261f677793fea424c6eb5cb13d0301ffff1'
-  sha256 '46b92ab5b5b412c7ab4354f208db342819de6074e53e564f537c500e00079e9e'
+  version '1.27.0,07796186d388044595cd101c49378c7cd48b350b'
+  sha256 '5f21f2d85adb6301ee442c8f01495b5652d66b9f59c8ced2c6b5fd2612154e99'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.