### PR TITLE
Update airmail-beta to 3.5.5.507,363

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.5.5.505,361'
-  sha256 '2b6dd81560bbddd034b86861048aac973c646791703e69fc8e3934c60c8d5190'
+  version '3.5.5.507,363'
+  sha256 '294ceef6185a49c9440c7b8983f3475a561536aa06e044292b4ca8c889976a9b'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.