### PR TITLE
Update toggl-dev to 7.4.248

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.243'
-  sha256 'd7ea1c7b62f5b5a800bf3d11249154908a35d84cd78b28de89063ba0cbeef66f'
+  version '7.4.248'
+  sha256 '1d1917a6ffd007dd78e6c1a3683c14aff1637f3079efdaf0c25c683bf16e4cf1'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.