### PR TITLE
Update slicer-nightly to 4.9.0.27356,861231

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27341,854367'
-  sha256 '29e2697f1d789a10841d2f20de22f7a4ea7426f6a14f0f61395bdf3044866ec7'
+  version '4.9.0.27356,861231'
+  sha256 '02a356784471fd00246f53f2d6dc7f75dfbe93d692d8096b571a984301aa6c58'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.