### PR TITLE
Update toggl-beta to 7.4.250

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,6 +1,6 @@
 cask 'toggl-beta' do
-  version '7.4.235'
-  sha256 'e571580b8d569baebfb7a5c0ef44304387b0b1bec308183f00939e8991b1df1c'
+  version '7.4.250'
+  sha256 'ab3e891e6173db326c1912a150daa662df31f7571a9d97ff5ff4a778456c51fb'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.