### PR TITLE
Update telegram-alpha to 4.3-138074,1209

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.2.2-137885,1201'
-  sha256 '7c563bd8e5b119f6a85dbfa53b8c4bac0a2981f010dced0f6caf777c5fe4f93c'
+  version '4.3-138074,1209'
+  sha256 '461f32404250d7829c8a73ca0f0fa86f69572555b9daeca936d74957000602d3'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.