### PR TITLE
Update vlc-nightly: add conflicts_with, shimscript and zap

### DIFF
--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -11,7 +11,29 @@ cask 'vlc-nightly' do
   name 'VLC media player'
   homepage 'https://www.videolan.org/vlc/'
 
+  auto_updates true
+  conflicts_with cask: 'vlc'
   depends_on macos: '>= :lion'
 
   app 'VLC.app'
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/vlc.wrapper.sh"
+  binary shimscript, target: 'vlc'
+
+  preflight do
+    IO.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/VLC.app/Contents/MacOS/VLC' "$@"
+    EOS
+  end
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.videolan.vlc.sfl*',
+               '~/Library/Application Support/org.videolan.vlc',
+               '~/Library/Application Support/VLC',
+               '~/Library/Preferences/org.videolan.vlc',
+               '~/Library/Preferences/org.videolan.vlc.plist',
+               '~/Library/Saved Application State/org.videolan.vlc.savedState',
+               '~/Library/Caches/org.videolan.vlc',
+             ]
 end

--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -11,7 +11,6 @@ cask 'vlc-nightly' do
   name 'VLC media player'
   homepage 'https://www.videolan.org/vlc/'
 
-  auto_updates true
   conflicts_with cask: 'vlc'
   depends_on macos: '>= :lion'
 

--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -31,9 +31,9 @@ cask 'vlc-nightly' do
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.videolan.vlc.sfl*',
                '~/Library/Application Support/org.videolan.vlc',
                '~/Library/Application Support/VLC',
+               '~/Library/Caches/org.videolan.vlc',
                '~/Library/Preferences/org.videolan.vlc',
                '~/Library/Preferences/org.videolan.vlc.plist',
                '~/Library/Saved Application State/org.videolan.vlc.savedState',
-               '~/Library/Caches/org.videolan.vlc',
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
