### PR TITLE
Update iterm2-beta to 3.2.1beta2

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.1beta1'
-  sha256 '0a204d5b936d7a3cfc4c2838e3424f0edfc53c267dc6225dcc98e5dd3e56d2d5'
+  version '3.2.1beta2'
+  sha256 'c8b6abc83aa817f4f66967070ba6cd39b90849d47bc8282c58c10099eaea72d5'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.