### PR TITLE
Update visual-studio-code-insiders to 1.27.0,47d0584301d16d4efd6618f6f33ef14099c92561

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.27.0,43676d0cb7db94e2fa771f1d10bff10eaa01b453'
-  sha256 '167f56ef090eb18a63bb1c46425d1aba547588aaddb1ddfcaafe0754af2c2a96'
+  version '1.27.0,47d0584301d16d4efd6618f6f33ef14099c92561'
+  sha256 '707e1ab578048d57d78a2ae349f68432f6e0cadf72d90eeff52712a146d85b25'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.