### PR TITLE
Update safari-technology-preview to 64

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '63'
+  version '64'
 
   if MacOS.version <= :high_sierra
-    url 'https://secure-appldnld.apple.com/STP/091-99998-20180815-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
-    sha256 'a3535919a5af214ce76bc46511a649edd1873a215d77fe5cdac5063302ecdf6b'
+    url 'https://secure-appldnld.apple.com/STP/041-03052-201808029-2EA97708-9B37-11E8-A4CA-EFFF75E91B15/SafariTechnologyPreview.dmg'
+    sha256 '5635870f1a2d989376a31ada3a8e35ac416dbccdddfb7935afce8e05f99f1ea9'
   else
-    url 'https://secure-appldnld.apple.com/STP/091-99601-20180815-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
-    sha256 '6fb5e485ade6e8fa6268bfada21c6ba3b950ce8439a5e12bba3e482f1e45e966'
+    url 'https://secure-appldnld.apple.com/STP/041-03050-201808029-2EA97708-9B37-11E8-A4CA-EFFF75E91B15/SafariTechnologyPreview.dmg'
+    sha256 'a8e8133eb9747b97f3aa9c190118cf1267a3decfb564ab2df9c4887ce03937a1'
   end
 
   name 'Safari Technology Preview'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.