### PR TITLE
Update telegram-alpha to 4.3.1-138562,1240

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.3-138208,1213'
-  sha256 '74f0dcf01540835bb7e30bdbd83f8b8a057dd926aace4769d14693727926325a'
+  version '4.3.1-138562,1240'
+  sha256 'a030d7c99cfebfd97108d70bd96bc79b8d3fa387170d62d384c94b8ce314b8d1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.