### PR TITLE
Update toggl-dev to 7.4.262

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.259'
-  sha256 'efd6560489e03beb7243b7dc276ec6d06f1cb8c78d6c75502e0293091544f385'
+  version '7.4.262'
+  sha256 '60c1746661a780f330dffda2b0710181f2e994d1fb3b105c06fd3ef3e92c703a'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.