### PR TITLE
Update signal-beta to 1.16.0-beta.1

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.15.5-beta.1'
-  sha256 'd00eaa0a07cff91b9174ed278ed0cbfa8238f5c8832e8d93026264c1bb11859f'
+  version '1.16.0-beta.1'
+  sha256 'e07b598ad3dd626ed4e7155f5d9dfaab6222418b486342b8cef6a62f58e1ad9f'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.