### PR TITLE
Update sketch-beta to 51.3,57541

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,6 +1,6 @@
 cask 'sketch-beta' do
-  version '51.2.0,57516'
-  sha256 '9f6315316be8f93ea4eb4fe2af0cab1d9be714959b4a29897b4befff3c36192d'
+  version '51.3,57541'
+  sha256 '01a82e65ab8b40fe955cdf179fdbc429127842171b4748f7aec166ef5e86e6f8'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.