### PR TITLE
Update toggl-dev to 7.4.264

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.263'
-  sha256 'e1ab5737c846b37a629e556524fff4ea6ec8d19cee152ace6da764d8254b72cf'
+  version '7.4.264'
+  sha256 'cad4e8950da111143223e6cf79e540b96852f795594b78bffb6a5e838b974acb'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.