### PR TITLE
Update telegram-alpha to 4.3.2-138749,1301

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.3.1-138570,1242'
-  sha256 '43b8f1d5004e3dcdcd476ebfd7ba438d33fbadff748956ae833bbb7c4e6644fe'
+  version '4.3.2-138749,1301'
+  sha256 'c86febc272c6e271f321b39b8ed5d989b7293d70e66ee4777e072e23c83de78e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.