### PR TITLE
Update toggl-dev to 7.4.268

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.264'
-  sha256 'cad4e8950da111143223e6cf79e540b96852f795594b78bffb6a5e838b974acb'
+  version '7.4.268'
+  sha256 '02c02153804b919fac89dd97b51eb80c6af46dad1af9e807d93bb45ed0f52ef3'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.