### PR TITLE
Update toggl-dev to 7.4.270

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.268'
-  sha256 '02c02153804b919fac89dd97b51eb80c6af46dad1af9e807d93bb45ed0f52ef3'
+  version '7.4.270'
+  sha256 'e86d866cd77c93158ee0819e6b85bf3e0963272e8744e6b2e0842940d7af380c'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.