### PR TITLE
Update 1password6 to 6.8.9

### DIFF
--- a/Casks/1password6.rb
+++ b/Casks/1password6.rb
@@ -2,7 +2,6 @@ cask '1password6' do
   version '6.8.9'
   sha256 'd7cc24dc354f27441929350b9e6e2e4a710d6ed0bdab06f0e9be07160fe04200'
 
-  # 1password.com was verified as official when first introduced to the cask
   url "https://c.1password.com/dist/1P/mac4/1Password-#{version}.zip"
   appcast 'https://app-updates.agilebits.com/product_history/OPM4'
   name '1Password'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Ref: https://github.com/Homebrew/homebrew-cask-versions/pull/6197#issuecomment-418545426