### PR TITLE
Update workflowy-beta to 1.1.2-beta.812

### DIFF
--- a/Casks/workflowy-beta.rb
+++ b/Casks/workflowy-beta.rb
@@ -1,6 +1,6 @@
 cask 'workflowy-beta' do
-  version '1.1.2-beta.751'
-  sha256 '3ca371cea2dac7b4461ec5f1da85f60f7f929b3a5026e906e56e589991af3cd4'
+  version '1.1.2-beta.812'
+  sha256 'd2aa065a73fdc77154fb6b2844e279f2a2fb7035dbb1da9b0bda929a60f299ce'
 
   # github.com/workflowy/desktop-beta was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop-beta/releases/download/v#{version}/WorkFlowy-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.