### PR TITLE
Update tor-browser-alpha to 8.5a1, update zap

### DIFF
--- a/Casks/tor-browser-alpha.rb
+++ b/Casks/tor-browser-alpha.rb
@@ -1,6 +1,6 @@
 cask 'tor-browser-alpha' do
-  version '8.0a10'
-  sha256 '61fec6301dde9d5c1ab05f52feb7175141cd5df16d8d4119334c98f1bf789634'
+  version '8.5a1'
+  sha256 '7a85938b3d1fb236354cab16afc4c4331700f3d2bbb89e596e1595aa8b3ae2fb'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/'

--- a/Casks/tor-browser-alpha.rb
+++ b/Casks/tor-browser-alpha.rb
@@ -17,5 +17,6 @@ cask 'tor-browser-alpha' do
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.tor browser.sfl*',
                '~/Library/Preferences/org.mozilla.tor browser.plist',
                '~/Library/Preferences/org.torproject.torbrowser.plist',
+               '~/Library/SavedApplicationState/org.torproject.torbrowser.savedState',
              ]
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.