### PR TITLE
Update vivaldi-snapshot to 2.0.1296.4

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.0.1295.3'
-  sha256 '4f5ff5770220b729ed7e9d186a1b683941838dc9309d9f1e08e56d286024862e'
+  version '2.0.1296.4'
+  sha256 '1e37e69544bb6a99abcacc9768cd7c7f2798a0ed0f96592bd4adfb1598c17828'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.