### PR TITLE
Update opera-developer to 57.0.3065.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '57.0.3058.0'
-  sha256 'abf800d3296b3a6d432d7fc1383186ee02e2ccc36be73174f86536a2f62ead8c'
+  version '57.0.3065.0'
+  sha256 'a025d723cb3c7b9ab717005d86f9d94dd6d3198717a845e7cb5ce7b8a117367c'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.