### PR TITLE
Update telegram-alpha to 4.3.2-138861,1331

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.3.2-138835,1329'
-  sha256 'c2db4192fe245b0c9691bd467e0a7b444a967e90aa446fc456e4fe9689910719'
+  version '4.3.2-138861,1331'
+  sha256 '0bf31f5ace5e19d9d90ab93f0f1c3ad679d5f9f7628e2b2a5686021d2d1b0811'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.