### PR TITLE
Update github-beta to 1.4.0-beta3-45b4171c

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '1.4.0-beta2-61b1195e'
-  sha256 '9af028ede4c6bdc2b6a057cfd0524cec34c109a7ca3328f31c9eebe80c46c936'
+  version '1.4.0-beta3-45b4171c'
+  sha256 '6fe072177f93efb930ce04bf8395c2fbe1b4d5443036e828b960a6ebc6485758'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.