### PR TITLE
Update vivaldi-snapshot to 2.0.1300.5

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.0.1296.4'
-  sha256 '1e37e69544bb6a99abcacc9768cd7c7f2798a0ed0f96592bd4adfb1598c17828'
+  version '2.0.1300.5'
+  sha256 '0268519bf388d96629eea9b0b5eef6a10d8d1be6738026f2e6060dafcde2f886'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.