### PR TITLE
Update visual-studio-code-insiders to 1.28.0,31bf4ccab388c082fcf4edafeaae5b703f211b5b

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.28.0,ee6a21fa49bd1906bd1378c2f2714cd656409e5c'
-  sha256 'c962bd696eb84d708e8906de4170757e32a4a1a8fa461c64d91789023c1099d6'
+  version '1.28.0,31bf4ccab388c082fcf4edafeaae5b703f211b5b'
+  sha256 'ba1c056a3c7bd8dfb916571cc7d933882555eb97bde11407335357f39b8e35a0'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.