### PR TITLE
Update libreoffice-rc to 6.1.1.2

### DIFF
--- a/Casks/libreoffice-rc.rb
+++ b/Casks/libreoffice-rc.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice-rc' do
-  version '6.1.1.1'
-  sha256 'c2a72ddcac1a3a888e8ec6bbe75a7b446a809da64b04599714c7e0c58d18301b'
+  version '6.1.1.2'
+  sha256 'a4c1c66ceabca45cba21163c56d321b2959b8185dbd2040aa362a794ac6078db'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.