### PR TITLE
Update electron-beta to 3.0.0-beta.12

### DIFF
--- a/Casks/electron-beta.rb
+++ b/Casks/electron-beta.rb
@@ -1,6 +1,6 @@
 cask 'electron-beta' do
-  version '2.0.0-beta.8'
-  sha256 '5d40f579031b44db95b6d65478b6f783c0fe1d3838146d4a4a507a62a5d80930'
+  version '3.0.0-beta.12'
+  sha256 '4d443afca51efe474aadd00f24795707ab415e0a77bf11a5652eb1b2de8f375b'
 
   # github.com/electron/electron was verified as official when first introduced to the cask
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.