### PR TITLE
Create brave-dev @ 0.55.4 cask

### DIFF
--- a/Casks/brave-dev.rb
+++ b/Casks/brave-dev.rb
@@ -3,14 +3,14 @@ cask 'brave-dev' do
   sha256 '28b11716604546f96dca92018415995c3e1af6dc5767ef4efa6e62b24e1c8b93'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
-  appcast 'https://github.com/brave/browser-browser/releases.atom'
+  appcast 'https://github.com/brave/brave-browser/releases.atom'
   name 'Brave Dev'
-  homepage 'https://brave.com/'
+  homepage 'https://github.com/brave/brave-browser'
 
   auto_updates true
   depends_on macos: '>= :mavericks'
 
-  app 'Brave-Browser-Dev.app'
+  app 'Brave Browser Dev.app'
 
   zap trash: [
                '~/Library/Application Support/brave',

--- a/Casks/brave-dev.rb
+++ b/Casks/brave-dev.rb
@@ -1,0 +1,20 @@
+cask 'brave-dev' do
+  version '0.55.4'
+  sha256 '28b11716604546f96dca92018415995c3e1af6dc5767ef4efa6e62b24e1c8b93'
+
+  url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
+  appcast 'https://github.com/brave/browser-browser/releases.atom'
+  name 'Brave Dev'
+  homepage 'https://brave.com/'
+
+  auto_updates true
+  depends_on macos: '>= :mavericks'
+
+  app 'Brave-Browser-Dev.app'
+
+  zap trash: [
+               '~/Library/Application Support/brave',
+               '~/Library/Preferences/com.electron.brave.plist',
+               '~/Library/Saved Application State/com.electron.brave.savedState',
+             ]
+end

--- a/Casks/brave-dev.rb
+++ b/Casks/brave-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-dev' do
-  version '0.55.4'
-  sha256 '28b11716604546f96dca92018415995c3e1af6dc5767ef4efa6e62b24e1c8b93'
+  version '0.55.5'
+  sha256 'fb3788fe620f08c367993e1ab1c1d0d2eab58f1f78d7e6bb1243c66bc671881b'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
   appcast 'https://github.com/brave/brave-browser/releases.atom'


### PR DESCRIPTION
New Cask for the Brave Browser Dev channel.

Refiling from https://github.com/Homebrew/homebrew-cask/pull/52036 on correct repo according to contribution guidelines.

cc: @RyanJarv @bbondy

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

```bash
❯ brew cask install brave-dev
==> Satisfying dependencies
==> Downloading https://github.com/brave/brave-browser/releases/download/v0.55.4/Brave-Browser-Dev.dmg
==> Verifying SHA-256 checksum for Cask 'brave-dev'.
==> Installing Cask brave-dev
==> Moving App 'Brave Browser Dev.app' to '/Applications/Brave Browser Dev.app'.
🍺  brave-dev was successfully installed!
```

```bash
❯ brew cask uninstall brave-dev
==> Uninstalling Cask brave-dev
==> Backing App 'Brave Browser Dev.app' up to '/usr/local/Caskroom/brave-dev/0.55.4/Brave Browser Dev.app'.
==> Removing App '/Applications/Brave Browser Dev.app'.
==> Purging files for version 0.55.4 of Cask brave-dev
```

```bash
❯ brew cask audit brave-dev --download
==> Downloading https://github.com/brave/brave-browser/releases/download/v0.55.4/Brave-Browser-Dev.dmg
Already downloaded: /Users/kevinschaich/Library/Caches/Homebrew/downloads/dc42303f848959db5316583dc6943a59df3e975dab30bea83c5f6968bc03bb1e--Brave-Browser-Dev.dmg
==> Verifying SHA-256 checksum for Cask 'brave-dev'.
audit for brave-dev: passed
```

```bash
❯ brew cask style brave-dev
1 file inspected, no offenses detected
```