### PR TITLE
Update telegram-alpha to 4.3.3.1-139629,1483

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.3.3-139549,1344'
-  sha256 'bec0c16c6b38a1bfa7604d1e0182bafad53af86671be235f07518df9784750ae'
+  version '4.3.3.1-139629,1483'
+  sha256 '25a4153adb7a5783c8d87ce8361d42922125028a3979ae8bcc20f411eef4fb96'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.