### PR TITLE
Update kodi-development to Beta 2

### DIFF
--- a/Casks/kodi-development.rb
+++ b/Casks/kodi-development.rb
@@ -1,8 +1,8 @@
 cask 'kodi-development' do
-  version '18.0-Leia_alpha2'
-  sha256 '94bf58db6144e9037e6aba8ae1f513369c696fb87169f63ac4ec3d9068e05d08'
+  version '18.0-Leia_beta2'
+  sha256 '52756359e205411fa5496f91f5cc36efb4dcb8fe691823f1b5d103d216eb15eb'
 
-  url "http://mirrors.kodi.tv/snapshots/osx/x86_64/kodi-#{version}-x86_64.dmg"
+  url "http://mirrors.kodi.tv/releases/osx/x86_64/kodi-#{version}-x86_64.dmg"
   name 'Kodi-Development'
   homepage 'https://kodi.tv/'
 


### PR DESCRIPTION
Kodi Development release is now 18.0-Leia_beta2

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
