### PR TITLE
Update telegram-alpha to 4.3.4-139924,1494

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.3.4-139740,1492'
-  sha256 '4b98144acca32103bfe91a2fb5a215203cd02b298511377f3274c430467ada99'
+  version '4.3.4-139924,1494'
+  sha256 '4a50abe4839b6706a1d7d7cdd38512941804f556f4e1aa8aa6c42e2ada3496bb'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.