### PR TITLE
Update firefox-esr to 60.2.1

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.1.0'
+  version '60.2.1'
 
   language 'cs' do
-    sha256 '8fd11e84e2a13b905709b48551348ddaaa65d39c0f1e0fbc925ef9600225bf78'
+    sha256 'c1a65d472596677d8031e0a47414db59c87fe605272708c6fa27b8989ea32fba'
     'cs'
   end
 
   language 'de' do
-    sha256 '769db2010a2a92b3f9d2e64925768e7dd400ecdf7d99c4d788ab7ac016ea1a54'
+    sha256 '5a90aa1143463cad8d537d9c8ae337e7eb92b632a6e93e072b1c172b6e2eec89'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '893dda71ed99782a30bee944ba57720ff7a4edff63d4ceab1fdc352cbfbd6671'
+    sha256 '73688776deacd345b69a5e1beb7c624ea70ec52b583d092ef270aac5300a5572'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '26e4e7443b22bdce63d7d135ea7df569d38386d0869154a026e96f19d1f8b63a'
+    sha256 '6622d9358f683ac9db5122fe786f44651970de17e608912dcd82a20e05bddcfb'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '16070e8f3b36a04376ff2c1ef0382b6519b24d5f83843a44d8a263f10642892f'
+    sha256 'a9ea2b70352303ba8ae36e48217044c21aabd197c45944b48cf43855fe886c8b'
     'fr'
   end
 
   language 'gl' do
-    sha256 '2e04720319d67f594c06c8c97d5dde51a5d3b0ff285d067514faa3cc99a65f26'
+    sha256 '3fcecbfa12c79fc698658e3bd66574444142829a960c58368b2fa83773209a90'
     'gl'
   end
 
   language 'it' do
-    sha256 '9cc07e009364ae90cdda51a184ae7abc111f9d510ff73c2367ab6fc7a0c41c47'
+    sha256 '99c891d9233ebf92ccafe517b5251244f827111da3c084ab2e453be25c92ed05'
     'it'
   end
 
   language 'ja' do
-    sha256 '4fe1d14529b04e7c406981129ebcd9b0b3bb7e159ede8c361b62d089e59fcf80'
+    sha256 'a78bcb310805a7b4a529757bffb1e48d153ece7ea4d1b1510ab17e19b5163630'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '0ea15badef338c912fadb720802dd7bdcad576094dbbd05c4a4e1c8f9dd02dca'
+    sha256 '45860a163d050ea1cd066182761daf17813332382033cd5a0bec354ae9e4fd02'
     'nl'
   end
 
   language 'pl' do
-    sha256 'f00a492166de13254f475dcdf4b5c7310a0afa1f7a744ca387ca90c53a5e350e'
+    sha256 'f2756fd78402b6e85894118c546b18248c344c9e251415415654d1f9cf7e3f3d'
     'pl'
   end
 
   language 'pt' do
-    sha256 'a2b40213b65c6f8d295407bb28fe9fdaf65564fc83ec47ed0a48e00eb8102112'
+    sha256 '338d90a76701cb36b434f759eabcd2e4831302f69926687b5369fd690d5143b9'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '9dec76aaaa4cbd0599cbb28f6a529c8e182a78fcc2f7fc251c26e25d4c25eaf3'
+    sha256 '26373f8915f0ef0b6d55058068fa1df07ade0386d3da87480042b3cda5295a9a'
     'ru'
   end
 
   language 'uk' do
-    sha256 'c5fa57d5ebf5e5fcfff451ed62474e210c86eb70449ffb04a01c2183ff952e8b'
+    sha256 '0b5479b3581b24167e9edf7ebac26f407791fc14d6c9f5453ce5d3fed985e89f'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'c0b3daef788308e2bc683f3f5df522018c26226aa2ffc356ecd3796ea40f7232'
+    sha256 'ce5a658c0eac699dba5ff17fb3eb0b8b23cf65ab0ecc6164a3a275d67c525987'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '463e5227268ede163e4dde98de7e9105710c3ac93e03ac88fc93680d1091b99f'
+    sha256 'e9a32eff7547cf7fdd178aef3160ced23d4b214c4a4b69efb57474c30d40f227'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
