### PR TITLE
Update tunnelblick-beta to 3.7.7beta06,5140

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick-beta' do
-  version '3.7.7beta05,5130'
-  sha256 'bc5364dd081c21ecd3f9a969548ccf09ec4a1f4d54036f5a1cb10dfd5dadfd56'
+  version '3.7.7beta06,5140'
+  sha256 'ae24d363ceedc45dff66fce458855425ab2167739e5ac663227694036b538122'
 
   # github.com/Tunnelblick/Tunnelblick was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.