### PR TITLE
Update openemu-experimental to 2.0.7

### DIFF
--- a/Casks/openemu-experimental.rb
+++ b/Casks/openemu-experimental.rb
@@ -1,6 +1,6 @@
 cask 'openemu-experimental' do
-  version '2.0.6.1'
-  sha256 'dd958890665323fb966dda7c4533e20613a78e6eca08aba28efb3df6f86db313'
+  version '2.0.7'
+  sha256 '2f8cd821fe35798a5c571da562ab7c4863605e53b5ce483f9ebb593c3338eb46'
 
   # github.com/OpenEmu/OpenEmu was verified as official when first introduced to the cask
   url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}-experimental.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.