### PR TITLE
Update sketch-beta to 52.0.0,66463

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,6 +1,6 @@
 cask 'sketch-beta' do
-  version '52.0.0,65972'
-  sha256 '7222abb36886eb4e0f6e0710282b90215b551f9c1bd0f0cdb828e1e4826c4960'
+  version '52.0.0,66463'
+  sha256 'a66546842144c620ba847e54c8bb9801900038c526bc3e9f25c83c3cc1b78867'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.