### PR TITLE
Update airmail-beta to 3.5.7.526,375

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.5.7.522,373'
-  sha256 'd2331430045b34c610743ef8157a801b1b4d5ea5f02a6a3b4e0ae049ddb35a61'
+  version '3.5.7.526,375'
+  sha256 '2f69c7922f278e8bad2896e226dfea4f026c61d5eb23d8c7677af5c6d3d3a532'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.