### PR TITLE
Update telegram-alpha to 4.4.1-140456,1525

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.4.1-140448,1524'
-  sha256 '1a0b8776d333b4208ca9c2e88fcda96d344c0248e6836a54158347bed98f3c83'
+  version '4.4.1-140456,1525'
+  sha256 '953301949879b0b374705059a0dcef80d4936234790c5c772d40219b7d90c9c5'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.