### PR TITLE
Update rstudio-preview to 1.2.1015

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1013'
-  sha256 'f0f3de1d64c30df1d7f9b5326fd34302729c380efcf7f486955a96af03ff92b9'
+  version '1.2.1015'
+  sha256 '56ef6bd4124439146158a4832863c42163979bc39279d8e5393ab5cf7d1761f5'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.