### PR TITLE
Update telegram-alpha to 4.4.1-140602,1531

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.4.1-140456,1525'
-  sha256 '953301949879b0b374705059a0dcef80d4936234790c5c772d40219b7d90c9c5'
+  version '4.4.1-140602,1531'
+  sha256 'cda0b479609c71a5324855c77632f5a77e6ded1920e4e35b209d7be3414b9760'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.