### PR TITLE
Update 1password-beta to 7.2.2.BETA-2

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.2.BETA-9'
-  sha256 '058e4baa14119e666e92b1610b3566cfa0d4e4ff5754fa77ebb43f01eb943f6f'
+  version '7.2.2.BETA-2'
+  sha256 'ad9980228ab1e2a908b331c9c1f0cf9900871fdbf08ee7eb7dedcca3767ff8a0'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.