### PR TITLE
Adding a legacy Cask for OmniFocus version 2.

### DIFF
--- a/Casks/omnifocus2.rb
+++ b/Casks/omnifocus2.rb
@@ -1,0 +1,37 @@
+cask 'omnifocus2' do
+  if MacOS.version <= :mavericks
+    version '2.0.4'
+    sha256 '3282eb7e41ec2638f68a92a6509eddd96a96c39b65b954dcedcc4e62289f22a9'
+    url "https://downloads.omnigroup.com/software/MacOSX/10.9/OmniFocus-#{version}.dmg"
+  elsif MacOS.version <= :yosemite
+    version '2.7.4'
+    sha256 'a273e55c15f82540fe305344f9e49ad7d0d9c326ba2c37c312076ffd73780f80'
+    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
+  elsif MacOS.version <= :el_capitan
+    version '2.10'
+    sha256 'e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8'
+    url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
+  else
+    version '2.12.4'
+    sha256 '8a2dc53331dba804f6781773fef546a03c181fc4ff0eb7ee4f871c10342621f0'
+    url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
+  end
+
+  appcast "https://update.omnigroup.com/appcast/com.omnigroup.OmniFocus#{version.major}"
+  name 'OmniFocus'
+  homepage 'https://www.omnigroup.com/omnifocus/'
+
+  app 'OmniFocus.app'
+
+  uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
+
+  zap trash: [
+               "~/Library/Containers/com.omnigroup.OmniFocus#{version}",
+               "~/Library/Preferences/com.omnigroup.OmniFocus#{version}.LSSharedFileList.plist",
+               '~/Library/Preferences/com.omnigroup.OmniSoftwareUpdate.plist',
+               "~/Library/Caches/Metadata/com.omnigroup.OmniFocus#{version}",
+               "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.omnigroup.omnifocus#{version}.sfl*",
+               '~/Library/Group Containers/34YW5XSRB7.com.omnigroup.OmniFocus',
+               "~/Library/Saved Application State/com.omnigroup.OmniFocus#{version}.savedState",
+             ]
+end


### PR DESCRIPTION
OmniFocus 3 requires a new license. This legacy Cask will allow
users to continue to use their existing OmniFocus 2 license with brew
cask.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
