### PR TITLE
Update telegram-alpha to 4.4.1-140622,1535

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.4.1-140602,1531'
-  sha256 'cda0b479609c71a5324855c77632f5a77e6ded1920e4e35b209d7be3414b9760'
+  version '4.4.1-140622,1535'
+  sha256 '91a399de0e5c1486ccd26a38b034cbcae668a46355f667279fe1d84010b63a0c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.