### PR TITLE
Update telegram-alpha to 4.4.1-140701,1542

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.4.1-140682,1540'
-  sha256 '9e5db91c0a696f323c46d32e2274ade92365efc298134894ad09e19048198ca4'
+  version '4.4.1-140701,1542'
+  sha256 'ce9ce5cd546e5af21e9994ad6d2d033cc91c1ec1d6a96d22ff03f3a5047260d4'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.