### PR TITLE
Added Rider EAP 2018.3.1

### DIFF
--- a/Casks/rider-eap.rb
+++ b/Casks/rider-eap.rb
@@ -1,0 +1,25 @@
+cask 'rider-eap' do
+  version '2018.3-EAP1-183.3226.206'
+  sha256 'fe83b526f8ff6f40eaf80b1fb56c166d21ade8549dd02c4fe6351c23f7204d64'
+
+  url 'https://download.jetbrains.com/rider/JetBrains.Rider-2018.3-EAP1-183.3226.206.Checked.dmg'
+  name 'Jetbrains Rider EAP'
+  homepage 'https://www.jetbrains.com/rider/eap/'
+
+  auto_updates true
+
+  app 'Rider EAP.app'
+
+  uninstall_postflight do
+    ENV['PATH'].split(File::PATH_SEPARATOR).map { |path| File.join(path, 'rider') }.each { |path| File.delete(path) if File.exist?(path) && File.readlines(path).grep(%r{# see com.intellij.idea.SocketLock for the server side of this interface}).any? }
+  end
+
+  zap trash: [
+               "~/Library/Application Support/Rider#{version.major_minor}",
+               "~/Library/Caches/Rider#{version.major_minor}",
+               "~/Library/Logs/Rider#{version.major_minor}",
+               "~/Library/Preferences/Rider#{version.major_minor}",
+               '~/Library/Preferences/jetbrains.rider.71e559ef.plist',
+               '~/Library/Saved Application State/com.jetbrains.rider-EAP.savedState',
+             ]
+end

--- a/Casks/rider-eap.rb
+++ b/Casks/rider-eap.rb
@@ -2,7 +2,7 @@ cask 'rider-eap' do
   version '2018.3-EAP1-183.3226.206'
   sha256 'fe83b526f8ff6f40eaf80b1fb56c166d21ade8549dd02c4fe6351c23f7204d64'
 
-  url 'https://download.jetbrains.com/rider/JetBrains.Rider-2018.3-EAP1-183.3226.206.Checked.dmg'
+  url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version}.Checked.dmg"
   name 'Jetbrains Rider EAP'
   homepage 'https://www.jetbrains.com/rider/eap/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
  - No, but as this is the `cask-versions` repository, it's the correct place for beta versions

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
  - Kind off, stable package is called `rider` so followed that and called it `rider-eap`
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
