### PR TITLE
Update visual-studio-code-insiders to 1.29.0,1358e903716cf77711493770d63dde1ea178a73e

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.28.0,431ef9da3cf88a7e164f9d33bf62695e07c6c2a9'
-  sha256 '347c80313e7788bf9a2310e5cdf4b50299b5ab65dea5b17f9916f2a6810c2883'
+  version '1.29.0,1358e903716cf77711493770d63dde1ea178a73e'
+  sha256 '03861e7bd66c6bb196962c2b1ba0436d8884577b26d7086816bdffcb16b7f085'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.