### PR TITLE
Update slicer-nightly to 4.9.0.27462,883249

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27401,870869'
-  sha256 '0ffbb97e5c468dae9f4caf2d528ceeb33ec9c78354226e757888debc88412be8'
+  version '4.9.0.27462,883249'
+  sha256 '5140e84b07639db50f626cca13b18424bd35ab18a62fb2615643f98bb17006b5'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.