### PR TITLE
Update mullvad-vpn-beta to 2018.4-beta2

### DIFF
--- a/Casks/mullvad-vpn-beta.rb
+++ b/Casks/mullvad-vpn-beta.rb
@@ -1,6 +1,6 @@
 cask 'mullvad-vpn-beta' do
-  version '2018.4-beta1'
-  sha256 '07fb440f26eb6ba768cceb4d72d4bdbefbbc9bf5be0666ac37d2f30ed2e3b8b9'
+  version '2018.4-beta2'
+  sha256 '908932f4aff95e6820994a81fe62330cee52d8b98d775ac7ed827fba4bbfecb6'
 
   # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.