### PR TITLE
Update vivaldi-snapshot to 2.1.1328.4

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.1.1322.4'
-  sha256 '06ceb57dc9a6abf3da9c33193b19dd97bdee70a56248da59f9dd98a0fb6ec417'
+  version '2.1.1328.4'
+  sha256 '6634b3ec02b7016f968234d0d0641ed617441584fccc714a0f5df3a5893947ee'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.