### PR TITLE
Update rstudio-preview to 1.2.1045

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1030'
-  sha256 '95b128cc2758b7bd0cd79878509419f98b488f2d108eb7d161703bc4aa80e355'
+  version '1.2.1045'
+  sha256 'fa26c367dcef800aa0595e6286e90b2ffb179efb2900d85dcf905c475e943837'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.