### PR TITLE
Update digikam-beta to 6.0.0-beta1-20181011T180655

### DIFF
--- a/Casks/digikam-beta.rb
+++ b/Casks/digikam-beta.rb
@@ -1,6 +1,6 @@
 cask 'digikam-beta' do
-  version '6.0.0-beta1-20180831T072944'
-  sha256 'd6a448833e2885f657ced3d3726b165c7454d86156c26e16bf3cb5def2dbdeb6'
+  version '6.0.0-beta1-20181011T180655'
+  sha256 'dd4b5409d751b344f766a89458720cf2964b6af669fb0af47bdd5acc018289b7'
 
   # kde.org/digikam was verified as official when first introduced to the cask
   url "https://files.kde.org/digikam/digiKam-#{version}-MacOS-x86-64.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.