### PR TITLE
Update sublime-text-dev to 3.180

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,6 +1,6 @@
 cask 'sublime-text-dev' do
-  version '3.179'
-  sha256 'e5af48dc4a8ab9508ed60883cc4aa1dcc0f752f187b3142bfb3ca4f564b43ff9'
+  version '3.180'
+  sha256 'a03204f1fcda6ab6a9a9d39924b37b41717e110dbc8b531400345c6814748736'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
   appcast "https://www.sublimetext.com/updates/#{version.major}/dev/appcast_osx.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.