### PR TITLE
Update qt-creator-dev to 4.8.0-beta1

### DIFF
--- a/Casks/qt-creator-dev.rb
+++ b/Casks/qt-creator-dev.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator-dev' do
-  version '4.4.0-rc1'
-  sha256 'c4194ff3b9109f71e7fbedac35b27883d65476610cee6a3e9adfe26a9dff2e39'
+  version '4.8.0-beta1'
+  sha256 'c90242f3314129cd2e1a145d4e4cc07d6d1b2488aafefbf7f16d90d7dff33c78'
 
   url "https://download.qt.io/development_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator Dev'


### PR DESCRIPTION
Version update: 4.4.0-rc1 -> 4.8.0-beta1

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for development version (development release)
