### PR TITLE
Update dropbox-beta to 60.3.101

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '60.3.89'
-  sha256 'a6642a3780090cc2778c9486cf9d322053c7bf1bca455ebd11862ea46f857634'
+  version '60.3.101'
+  sha256 '10037ee299675cf9278e46c33afcbbe87856fb70610c135b10e244ea6ced8eaa'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.