### PR TITLE
update thunderbird-beta to latest

### DIFF
--- a/Casks/thunderbird-beta.rb
+++ b/Casks/thunderbird-beta.rb
@@ -1,31 +1,39 @@
 cask 'thunderbird-beta' do
-  version '60.0b10'
+  version :latest
+  sha256 :no_check
 
   language 'cs' do
-    sha256 '96c253d0301ab08ce06ae1814702c679b1c4bdd0f6c3d252fe6c17d884850d52'
     'cs'
   end
 
+  language 'en-GB' do
+    'en-GB'
+  end
+
   language 'en', default: true do
-    sha256 '0caa487ec3e1d143fe4d22b4f50ea78b042e21ec6b0eeaeb0e33ade834b90596'
     'en-US'
   end
 
   language 'ru' do
-    sha256 '72c4875c82705352dee2a60495349a21911378974cc6848f999aa0ed46944529'
     'ru'
   end
 
   language 'uk' do
-    sha256 '3d16cc3ce62d4e8e608f8ec46a9aab4366a1415f28de7be34abd64087d65ee14'
     'uk'
   end
 
-  url "https://ftp.mozilla.org/pub/thunderbird/releases/#{version}/mac/#{language}/Thunderbird%20#{version}.dmg"
+  language 'zh-TW' do
+    'zh-TW'
+  end
+
+  language 'zh' do
+    'zh-CN'
+  end
+
+  url "https://download.mozilla.org/?product=thunderbird-beta-latest-SSL&os=osx&lang=#{language}"
   name 'Mozilla Thunderbird'
   homepage 'https://www.mozilla.org/en-US/thunderbird/beta/all/'
 
-  auto_updates true
   conflicts_with cask: 'thunderbird'
 
   app 'Thunderbird.app'


### PR DESCRIPTION
Like [firefox-beta](https://github.com/Homebrew/homebrew-cask-versions/blob/ab0ae34f4284d1b1f96509340f66dec52fbea1d2/Casks/firefox-beta.rb), we should make sure that user downloads the latest version of `thunderbird-beta`.

---

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
  `thunderbird-beta` is beta version