### PR TITLE
update sourcetree-beta to :latest

### DIFF
--- a/Casks/sourcetree-beta.rb
+++ b/Casks/sourcetree-beta.rb
@@ -1,18 +1,16 @@
 cask 'sourcetree-beta' do
-  version '2.7.4b2'
-  sha256 'c0dddc756305b43be43e7a016422325323e195d6a1e4c7ed4cd02614839162cb'
+  version :latest
+  sha256 :no_check
 
-  # atlassian.com was verified as official when first introduced to the cask
-  url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip"
-  appcast 'https://www.sourcetreeapp.com/update/SparkleAppcastBeta.xml'
-  name 'Atlassian SourceTree'
+  # bitbucket.org/atlassianlabs/sourcetree was verified as official when first introduced to the cask
+  url 'https://bitbucket.org/atlassianlabs/sourcetree-betas/downloads/OSX_Beta_Latest.zip'
+  name 'Atlassian Sourctree'
   homepage 'https://www.sourcetreeapp.com/'
 
-  auto_updates true
   depends_on macos: '>= :yosemite'
 
-  app 'SourceTree-Beta.app'
-  binary "#{appdir}/SourceTree-Beta.app/Contents/Resources/stree"
+  app 'Sourcetree-Beta.app'
+  binary "#{appdir}/Sourcetree-Beta.app/Contents/Resources/stree"
 
   uninstall launchctl: 'com.atlassian.SourceTreePrivilegedHelper2',
             quit:      'com.torusknot.SourceTreeNotMAS'


### PR DESCRIPTION
It seems like official Sourcetree Beta download location is altered.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256