### PR TITLE
Update 1password-beta to 7.2.2.BETA-3

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.2.2.BETA-2'
-  sha256 'ad9980228ab1e2a908b331c9c1f0cf9900871fdbf08ee7eb7dedcca3767ff8a0'
+  version '7.2.2.BETA-3'
+  sha256 'cb05e2918a98056dad4a784715274ace6c57793e2fb662c9347f9b4fbc89a6de'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.