### PR TITLE
update safari-technology-preview to 68

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '67'
+  version '68'
 
   if MacOS.version <= :high_sierra
-    url 'https://secure-appldnld.apple.com/STP/041-09757-20181009-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
-    sha256 '884ab490c4acedd64908b906fb3163010b6ad79ca08d300c06112d90c6cbe06b'
+    url 'https://secure-appldnld.apple.com/STP/041-16281-20181024-28C3C3FC-CCCE-11E8-A0FD-D2D18121E9C4/SafariTechnologyPreview.dmg'
+    sha256 'ed2dd3505a1ef0587fb67f3a9f3c270c231a2da5fe54340c5fdea462bb455d04'
   else
-    url 'https://secure-appldnld.apple.com/STP/041-11185-20181009-01EC2FD2-85EB-11E8-AB5B-AEA972136C40/SafariTechnologyPreview.dmg'
-    sha256 '4bda69a3599e861648f8f88eb88e2098a83fd50e7d811e282fab3ed320372a6a'
+    url 'https://secure-appldnld.apple.com/STP/041-16284-20181024-28C3C3FC-CCCE-11E8-A0FD-D2D18121E9C4/SafariTechnologyPreview.dmg'
+    sha256 'b4a5dfe1168a2c1ed1182283094661709365b7222ad8a203b3334620b811ded0'
   end
 
   name 'Safari Technology Preview'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
