### PR TITLE
Update vivaldi-snapshot to 2.1.1337.35

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.1.1337.17'
-  sha256 'c9bae8e7507dd252ff355acd1f2c72b4442f2f17aa9748e2fcc6329a5751e902'
+  version '2.1.1337.35'
+  sha256 '85a21e3d8768c320edce91847b2c8ed8fe2a2c346fb9084486bbdf1a2f9f1b91'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.