### PR TITLE
Update wine-staging to 3.19

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '3.18'
-  sha256 'bd87cc2a60f294e5b2bd4b9c997c9da0f91b1685d8cf34212a3c3390d59612f4'
+  version '3.19'
+  sha256 'ca30a1b696cd55d336c52d45f431d3aa0e275b63b6338d0f2d045ce752967d9c'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.