### PR TITLE
Update slicer-nightly to 4.11.0.27526,895038

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.9.0.27462,883249'
-  sha256 '5140e84b07639db50f626cca13b18424bd35ab18a62fb2615643f98bb17006b5'
+  version '4.11.0.27526,895038'
+  sha256 '59529897b5aa2e6bf30799720fbf7dca5775738db927632e29ce3f8f62150781'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.