### PR TITLE
Update visual-studio-code-insiders to 1.29.0,d7ac6e838f51a03f7d417b4758f5fb075878d615

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.29.0,9e83209ed59a22df3d593735d04cc963396bb89e'
-  sha256 '67d5140a193ad05bbc2c1f84d4c193809afa5f785d641d311748a87b776bc151'
+  version '1.29.0,d7ac6e838f51a03f7d417b4758f5fb075878d615'
+  sha256 '851702da0ce51a223ba4e75c7833e000a4a4a53b73aae9b7a964188a28caa674'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.