### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.3.1335,231

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.3.1329,229'
-  sha256 '975880e2ef2aec66c59f92fea59a0cfdc4b89454ac8cce0216d735a3ba8db648'
+  version '10.2.3.1335,231'
+  sha256 '198eb0fdcd43e599d22c21a5513483d12b49adf88d588a78599fd3ebcb30a5d6'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.