### PR TITLE
Update vivaldi-snapshot to 2.2.1350.4

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.1.1337.35'
-  sha256 '85a21e3d8768c320edce91847b2c8ed8fe2a2c346fb9084486bbdf1a2f9f1b91'
+  version '2.2.1350.4'
+  sha256 '52f6cf58c0d27feb9756ae8d27988a8e063e9944093d906a112a26b02026db67'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.