### PR TITLE
Update toggl-dev to 7.4.289

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.280'
-  sha256 '19fe398d9a27e54ccaff95fb3486345e0cbc5ea684159f561e352acd4bccf98d'
+  version '7.4.289'
+  sha256 'fe080463c0a295c39630b598aa931516884dd95adf5670af6d7a1765cade74a9'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.