### PR TITLE
Update airmail-beta to 3.7.0.531,380

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.7.0.530,379'
-  sha256 '2e2cce47e1d887f8e10a405cfa1a03b572b58d8f336d08a503f44e67c7743c8c'
+  version '3.7.0.531,380'
+  sha256 '3dc56afad6cc100b5d6482332d8799b80b1177a18583e958b4af44de566506e2'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.