### PR TITLE
Update visual-studio-code-insiders to 1.29.0,bdfe4fd41f6a5fe538197b3cba937230249a563a

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.29.0,9b2a7f4a83ca6a2d495463276a21157f398b41e7'
-  sha256 '026077e417c66ebf4bc6f91961d450604355a052fb902d4eef5da9360253d53b'
+  version '1.29.0,bdfe4fd41f6a5fe538197b3cba937230249a563a'
+  sha256 '22c8203b1a060f2f81270841d6a6b768d4499ec85cc650a7120f4175e8c2ee19'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.