### PR TITLE
Update little-snitch-nightly to 4.3,5231

### DIFF
--- a/Casks/little-snitch-nightly.rb
+++ b/Casks/little-snitch-nightly.rb
@@ -1,6 +1,6 @@
 cask 'little-snitch-nightly' do
-  version '4.3,5224'
-  sha256 'e2cb35e0f07efbc47fa90967ee3da09369082774cf90180d794aa7d9c40086f1'
+  version '4.3,5231'
+  sha256 '0d25bf33ed6ef1ddbbb1ccd7c9f0d9065d9fd20070627ef64c08105abd43e3a7'
 
   url "https://obdev.at/downloads/littlesnitch/nightly/LittleSnitch-#{version.before_comma}-nightly-(#{version.after_comma}).dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes-nightly.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.