### PR TITLE
Update iterm2-beta to 3.2.6beta2

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.6beta1'
-  sha256 '86e061c05b670b507e93997c5736224ddd6a3664083e9adf26465f3f7a965aa2'
+  version '3.2.6beta2'
+  sha256 'ff6b9d8d89f546d92df4a87d2e85a791a0d15206f3a1928f5613846ff220536c'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.