### PR TITLE
Update rstudio-preview to 1.2.1091

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1070'
-  sha256 'f6c8ad5103eaeec072134e3ac4db9578a30da587d9a6a6817e2986f66239d031'
+  version '1.2.1091'
+  sha256 '9791812818f46ca767ed928eaac94d6ef497217836f7c42adf57b7957d00b3db'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.