### PR TITLE
Update telegram-alpha to 4.6.1-143378,1607

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.5.1-142788,1590'
-  sha256 'f75227b6dfd6cd554c91959fa74cbc5fa9541491916dd3eddd0d5f68be49d7ad'
+  version '4.6.1-143378,1607'
+  sha256 'ea3de3ff7d41d72eef7674f79517cadb50f221428023a93d6c5c205f6c7ac38e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.