### PR TITLE
Update vivaldi-snapshot to 2.2.1360.4

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.2.1350.4'
-  sha256 '52f6cf58c0d27feb9756ae8d27988a8e063e9944093d906a112a26b02026db67'
+  version '2.2.1360.4'
+  sha256 'aad7c869afe7738d2705d58f3ef391bdd22e98703d04eb1b8b60d872977f5911'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.