### PR TITLE
Update slicer-nightly to 4.11.0.27537,901576

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.11.0.27526,895038'
-  sha256 '59529897b5aa2e6bf30799720fbf7dca5775738db927632e29ce3f8f62150781'
+  version '4.11.0.27537,901576'
+  sha256 '1a14b68f120dad8fcea2cb918212de8582eed655ed9598fdc51f579ec0c463aa'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.