### PR TITLE
Update iterm2-beta to 3.2.6beta3

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
   version '3.2.6beta3'
-  sha256 '0b76f0832685a97ca341c7a665c9b20e614bfeee208f031372ab5fbe16412b3d'
+  sha256 '2993719b4e9493e3291bf6357b9a44d9dd35d6004d24493dfcf0ee3b4d3dc626'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.