### PR TITLE
Revert "Add google-chrome-canary login item uninstallation"

### DIFF
--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -10,11 +10,10 @@ cask 'google-chrome-canary' do
 
   app 'Google Chrome Canary.app'
 
-  uninstall launchctl:  [
-                          'com.google.keystone.agent',
-                          'com.google.keystone.daemon',
-                        ],
-            login_item: 'Google Chrome Canary'
+  uninstall launchctl: [
+                         'com.google.keystone.agent',
+                         'com.google.keystone.daemon',
+                       ]
 
   zap trash: [
                '/Library/Caches/com.google.SoftwareUpdate.*',


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask-versions#6526

@reitermarkus Reverting because as far as I can gather, Chrome does not add login items. If this existed, it was likely user-added.