### PR TITLE
Update sketch-beta to 52.4.0,67378

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,6 +1,6 @@
 cask 'sketch-beta' do
-  version '52.2.0,67145'
-  sha256 '87a5c1f16bd48435c28184143507f3e45f2d981d266abcf85b49a61caa7828c7'
+  version '52.4.0,67378'
+  sha256 'fdd14fd04169c6929201002bf1ddf0ebab178184843186d7d2e45bae5a14216f'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.