### PR TITLE
Update visual-studio-code-insiders to 1.30.0,df8ea54c5397e67b3e47df15a355bd04345c6934

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.30.0,5fc60ec67950234cdf82ea455013617adf00e7b6'
-  sha256 '64e7e01c4b4b2f52376293977671d6afdc29caff79d77646138f27172b3dae10'
+  version '1.30.0,df8ea54c5397e67b3e47df15a355bd04345c6934'
+  sha256 '0c0e22f3170484fc8aef5ce46f3d804cb40fbc10450d483fba29cb728b67cd2c'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.