### PR TITLE
Update affinity-photo-beta to 1.7.0.98

### DIFF
--- a/Casks/affinity-photo-beta.rb
+++ b/Casks/affinity-photo-beta.rb
@@ -1,9 +1,10 @@
 cask 'affinity-photo-beta' do
-  version :latest
-  sha256 :no_check
+  version '1.7.0.98'
+  sha256 '171fe590ccbff74a7d856ae8f207ed50d45c65d44509d5503598a7bd3b1a7e5d'
 
-  # amazonaws.com/affinity-beta was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/affinity-beta/download/Affinity+Photo+Customer+Beta.dmg'
+  # affinity-beta.s3.amazonaws.com was verified as official when first introduced to the cask
+  url "https://affinity-beta.s3.amazonaws.com/download/Affinity%20Photo%20Customer%20Beta%20%28#{version}%29.dmg"
+  appcast 'https://forum.affinity.serif.com/index.php?/forum/19-photo-beta-on-mac/'
   name 'Serif Affinity Photo'
   homepage 'https://affinity.serif.com/en-us/photo/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.