### PR TITLE
Update opera-beta to 57.0.3098.36

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '57.0.3098.14'
-  sha256 'd6bb200f9a655031ff045395b2616d7a4e2b33d1e5787e30c8fc50588b378038'
+  version '57.0.3098.36'
+  sha256 '57c3d39ba63b24c1bfb77db809365d4865539706ea7913ca22abf3859c8acd65'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.