### PR TITLE
Update affinity-designer-beta to 1.7.0.2

### DIFF
--- a/Casks/affinity-designer-beta.rb
+++ b/Casks/affinity-designer-beta.rb
@@ -1,9 +1,10 @@
 cask 'affinity-designer-beta' do
-  version :latest
-  sha256 :no_check
+  version '1.7.0.2'
+  sha256 '8bb7e45d80ca4bc58ff1820c084747e7bb776e13c213866143146ca91026936f'
 
   # amazonaws.com/affinity-beta was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/affinity-beta/download/Affinity+Designer+Customer+Beta.dmg'
+  url 'https://s3.amazonaws.com/affinity-beta/download/Affinity%20Designer%20Beta.dmg'
+  appcast 'https://forum.affinity.serif.com/index.php?/forum/15-designer-beta-on-mac/'
   name 'Serif Affinity Designer'
   homepage 'https://affinity.serif.com/en-us/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.