### PR TITLE
Update telegram-alpha to 4.6.1-145065,1618

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.6.1-144705,1611'
-  sha256 '86c4ed668dd041ef1a50a150e22d087672e71641925d2775aff9bcb040d4e26c'
+  version '4.6.1-145065,1618'
+  sha256 '1eecc91d1389bb7e0d7e16dbfd2aa0635b139056a1f869cbc742d2d99bbe27d1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.