### PR TITLE
Update affinity-photo-beta to 1.7.0.99

### DIFF
--- a/Casks/affinity-photo-beta.rb
+++ b/Casks/affinity-photo-beta.rb
@@ -1,6 +1,6 @@
 cask 'affinity-photo-beta' do
-  version '1.7.0.98'
-  sha256 '171fe590ccbff74a7d856ae8f207ed50d45c65d44509d5503598a7bd3b1a7e5d'
+  version '1.7.0.99'
+  sha256 'd4575348e788e266ce8e3b44443de010f60dd1b9fe871acc5268bd527254dc9c'
 
   # affinity-beta.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://affinity-beta.s3.amazonaws.com/download/Affinity%20Photo%20Customer%20Beta%20%28#{version}%29.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.