### PR TITLE
Update vivaldi-snapshot to 2.2.1369.6

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.2.1360.4'
-  sha256 'aad7c869afe7738d2705d58f3ef391bdd22e98703d04eb1b8b60d872977f5911'
+  version '2.2.1369.6'
+  sha256 'e0b6fedda40e9d069e429afd89cf5f35bf0688e0f2e283a72b0f25e356599d7c'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.