### PR TITLE
Update java-beta to OpenJDK 12,20

### DIFF
--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,70 +1,26 @@
 cask 'java-beta' do
-  version '11,28'
-  sha256 'addd853fc5447df7067a9eb3bec7c3e9115abec74e4f42e11ad47fbb181d5fc0'
+  version '12,20'
+  sha256 '50c20a603364d3f0ef9378f7ac2bfd0f7ea8de376789e5ab834b57a946384fb3'
 
-  url "https://download.java.net/java/early_access/jdk#{version.before_comma}/#{version.after_comma}/BCL/jdk-#{version.before_comma}+#{version.after_comma}_osx-x64_bin.dmg"
-  name 'Java Standard Edition Development Kit - Early Access'
-  homepage "http://jdk.java.net/#{version.before_comma}/"
-
-  # auto_updates true: JDK does not auto-update
-
-  pkg "JDK #{version.before_comma}.pkg"
+  url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_osx-x64_bin.tar.gz"
+  name 'OpenJDK - Early Access'
+  homepage 'https://jdk.java.net/'
 
   postflight do
-    system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string BundledApp', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+    system_command '/bin/mv',
+                   args: ['-f', '--', "#{staged_path}/jdk-#{version.before_comma}.jdk",
+                          "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk"],
                    sudo: true
-    system_command '/usr/libexec/PlistBuddy',
-                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Info.plist"],
-                   sudo: true
-    system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home", '/Library/Java/Home'],
-                   sudo: true
+
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
+                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
                    sudo: true
+
     system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib",
+                          "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
                    sudo: true
   end
 
-  uninstall pkgutil:   [
-                         "com.oracle.jdk-#{version.before_comma}",
-                       ],
-            launchctl: [
-                         'com.oracle.java.Helper-Tool',
-                         'com.oracle.java.Java-Updater',
-                       ],
-            quit:      [
-                         'com.oracle.java.Java-Updater',
-                         'net.java.openjdk.cmd', # Java Control Panel
-                       ],
-            delete:    [
-                         "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk/Contents",
-                         '/Library/Java/Home',
-                       ],
-            rmdir:     "/Library/Java/JavaVirtualMachines/jdk-#{version.before_comma}.jdk"
-
-  zap trash: [
-               '~/Library/Application Support/Java/',
-               '~/Library/Application Support/Oracle/Java',
-               '~/Library/Caches/com.oracle.java.Java-Updater',
-               '~/Library/Caches/Oracle.MacJREInstaller',
-               '~/Library/Caches/net.java.openjdk.cmd',
-               '~/Library/Preferences/com.oracle.java.Java-Updater.plist',
-               '~/Library/Preferences/com.oracle.javadeployment.plist',
-             ]
-
-  caveats do
-    license 'https://www.oracle.com/technetwork/java/javase/terms/license/index.html'
-    <<~EOS
-      This Cask makes minor modifications to the JRE to prevent issues with
-      packaged applications, as discussed here:
-
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=411361
-
-      If your Java application still asks for JRE installation, you might need
-      to reboot or logout/login.
-    EOS
-  end
+  uninstall delete: "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk"
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
   My system (macOS 10.12.6) is broken, it fails installing rubocop.
- [x] The commit message includes the cask’s name and version.
