### PR TITLE
Update toggl-dev to 7.4.309

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.308'
-  sha256 '1bdd8867fffaadc9fa78ce2e36bd8aff0b0772f85ec17eafcee235ba5f2f7a7f'
+  version '7.4.309'
+  sha256 'fef8672380bd97ff9c78df6b3b4e2b744aebf6a7184ac0e9bc54fd7f8602dc9c'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.