### PR TITLE
Update telegram-alpha to 4.6.1-145150,1623

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.6.1-145065,1618'
-  sha256 '1eecc91d1389bb7e0d7e16dbfd2aa0635b139056a1f869cbc742d2d99bbe27d1'
+  version '4.6.1-145150,1623'
+  sha256 '237c51ee43a410d399bf2d88787e620d0f6e0e6ca17449bf67541482bca3db25'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.