### PR TITLE
Update affinity-photo-beta to 1.7.0.101

### DIFF
--- a/Casks/affinity-photo-beta.rb
+++ b/Casks/affinity-photo-beta.rb
@@ -1,9 +1,9 @@
 cask 'affinity-photo-beta' do
-  version '1.7.0.99'
-  sha256 'd4575348e788e266ce8e3b44443de010f60dd1b9fe871acc5268bd527254dc9c'
+  version '1.7.0.101'
+  sha256 '79d888dda7054eac7c68ca7bda664fb0a3b840a96a87e164ca705b0ea511dac6'
 
   # affinity-beta.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://affinity-beta.s3.amazonaws.com/download/Affinity%20Photo%20Customer%20Beta%20%28#{version}%29.dmg"
+  url 'https://affinity-beta.s3.amazonaws.com/download/Affinity%20Photo%20Customer%20Beta.dmg'
   appcast 'https://forum.affinity.serif.com/index.php?/forum/19-photo-beta-on-mac/'
   name 'Serif Affinity Photo'
   homepage 'https://affinity.serif.com/en-us/photo/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.