### PR TITLE
Update rstudio-preview to 1.2.1139

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1114'
-  sha256 '45591a10b212a251ae83043576ff8198ed750361935c9be66503cfacab6ea2bc'
+  version '1.2.1139'
+  sha256 'f52aeb7fac8f14dde6e6eded0cee69a4209bcb6ddd881efdfe85bcfd35b79c55'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.