### PR TITLE
Update visual-studio-code-insiders to 1.30.0,456e8e64beb2dceac66743959f6802b66e18e300

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.30.0,f473dc4763467bbeee5d5ea76d4b583667f22e8a'
-  sha256 '69ff5c0d8ac9393fd612e315de2db4ff36b5c0c0258e0abc07fe33c67fe413ec'
+  version '1.30.0,456e8e64beb2dceac66743959f6802b66e18e300'
+  sha256 '16063f7652d6c65acb242e1d22aad64653a2a4949830c811d75452956011debd'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.