### PR TITLE
Update telegram-alpha to 4.6.1-145967,1640

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.6.1-145733,1634'
-  sha256 '850c5d46dca8076a8827111ccea61103dec96e28693d8dcf143b8d92d616324a'
+  version '4.6.1-145967,1640'
+  sha256 '225c51e6efb600498b79b43b6e4e0eeb2787b274a2dba1be886e75cd59596e83'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.