### PR TITLE
Update toggl-dev to 7.4.316

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.311'
-  sha256 '773eaefb5a4baae0f22a7dd5cb24b4a303e3fc37e2eac4225089b229335e4f0d'
+  version '7.4.316'
+  sha256 '1534cf5ae162b7ab239af375767a74a71012c1b70266f4a070cfe3aedbdf1dfa'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.