### PR TITLE
Update smartgit-rc to 18.2-rc-3

### DIFF
--- a/Casks/smartgit-rc.rb
+++ b/Casks/smartgit-rc.rb
@@ -1,6 +1,6 @@
 cask 'smartgit-rc' do
-  version '18.1-rc-3'
-  sha256 'f992df0b378760ed516a7dbb481a1f6a9a014fe6933b0a232dbcef7df5ac9149'
+  version '18.2-rc-3'
+  sha256 '617b4d7fe949e8a5c1b56c1d8449417f6324be366c7fc9d7ceea3562dc2e8925'
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   appcast 'https://www.syntevo.com/smartgit/changelog-eap.txt'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.