### PR TITLE
Update 1password-beta to 7.2.3.BETA-2

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.2.3.BETA-1'
-  sha256 '132d6537fd434fdd445436d2ebce6635711ca23578b77e7fcf287d7f90f40de4'
+  version '7.2.3.BETA-2'
+  sha256 '0d76c1fbe69ab8fb1b472615a335b0947e6c6c28e96ddd1729d464039d17a630'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.