### PR TITLE
Update sketch-beta to 52.5.0,67469

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,6 +1,6 @@
 cask 'sketch-beta' do
-  version '52.5.0,67428'
-  sha256 '1aa022e369cb0975689f7df2dd50b3533c36b9871799660759d4943632315e46'
+  version '52.5.0,67469'
+  sha256 'd1729afec61c54c35ac3b1fc0720037f8d55ef6e7ac49dfaae0f61276239a4c0'
 
   # hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/0172d48cceec171249a8d850fb16276b/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.