### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.4.1403,242

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.4.1391,241'
-  sha256 '52feddf608fc14aec8cbaa1303f7061165994f285f00b34b7aaff60728f46484'
+  version '10.2.4.1403,242'
+  sha256 '89edfb5ad9920c5b0321ca44f6c6955a9e79c5f36c116cc62a2795f3bb2a6716'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.