### PR TITLE
Update slicer-nightly to 4.11.0.27589,916796

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.11.0.27565,908135'
-  sha256 'ceb0f4f6a0ff5709d19ce0545676aa4f773a6ecf495da4e2536a50d15b889d33'
+  version '4.11.0.27589,916796'
+  sha256 '9a3061259f88549bea479ac065a32ed867c5609861054ffe97cd3494434893e7'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.