### PR TITLE
Update airmail-beta to 3.7.0.533,382

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.7.0.532,381'
-  sha256 '57cff8546c59818165d1ca0b13ef4799a78d1709e4e5801d89db7df9a683eb35'
+  version '3.7.0.533,382'
+  sha256 '50c221aa7ee4761c0857f6033712b35322ffc44b5162a1d1688995e42a77ee68'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.