### PR TITLE
Update rstudio-preview to 1.2.1163

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1153'
-  sha256 '3d98f0cda99877c55413a755313eae8cf24a0a051be1927ab5ae2e17b2aab9d6'
+  version '1.2.1163'
+  sha256 '717901c694e0d08a4b5007ce36f001afd9d88afb66fa10db4e9e1f9514bf5021'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.