### PR TITLE
android-studio-preview: rm java caveat, port zap from stable

### DIFF
--- a/Casks/android-studio-preview.rb
+++ b/Casks/android-studio-preview.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-preview' do
-  version '3.4.0.4,183.5141831'
-  sha256 'a277ab848578d0121c73ad0d5c100dbfc802b4a80c5d40e67ed1fe23a94720b1'
+  version '3.4.0.5,183.5146016'
+  sha256 '838548a4d21dd023d8ef68304efd49556fb0243e45139dbcfd443619c793422a'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
@@ -10,15 +10,17 @@ cask 'android-studio-preview' do
   app "Android Studio #{version.major_minor} Preview.app"
 
   zap trash: [
-               "~/Library/Application Support/AndroidStudioPreview#{version.major_minor}",
-               "~/Library/Caches/AndroidStudioPreview#{version.major_minor}",
-               "~/Library/Logs/AndroidStudioPreview#{version.major_minor}",
-               "~/Library/Preferences/AndroidStudioPreview#{version.major_minor}",
-               '~/Library/Preferences/com.google.android.studio.plist',
+               '~/Library/Android/sdk',
+               "~/Library/Application Support/AndroidStudio#{version.major_minor}",
+               "~/Library/Caches/AndroidStudio#{version.major_minor}",
+               "~/Library/Logs/AndroidStudio#{version.major_minor}",
+               "~/Library/Preferences/AndroidStudio#{version.major_minor}",
+               '~/Library/Preferences/com.android.Emulator.plist',
+               '~/Library/Saved Application State/com.google.android.studio.savedState',
+               '~/.android',
              ],
-      rmdir: '~/AndroidStudioProjects'
-
-  caveats do
-    depends_on_java
-  end
+      rmdir: [
+               '~/AndroidStudioProjects',
+               '~/Library/Android',
+             ]
 end


### PR DESCRIPTION
JDK is bundled in app.
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256