### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.4.1420,244

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.4.1413,243'
-  sha256 '695ecda10f1e426f8d0f16130aa5b0ddc53b5ee018b883e94b33c90b6d87aabb'
+  version '10.2.4.1420,244'
+  sha256 'ae498c9a24e8ce1d44f845e1472fc919777b05503f38aba881757c042ad7141d'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.