### PR TITLE
Update telegram-alpha to 4.7.1-148652,1704

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.7.1-146930,1669'
-  sha256 'bc39bad4fd8a24e8d20ea6bbb36559706060e6345b77280874a515b5f6892037'
+  version '4.7.1-148652,1704'
+  sha256 '594a566472ea39159fe480efcae7d448142f11cc1df273cf7050b39a9f3d854d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.