### PR TITLE
Update visual-studio-code-insiders to 1.30.0,241923763dbeaf3b64443187e935d55b29f6125d

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.30.0,a152a5c7818a13666a5879b4450eb26a4d45fbde'
-  sha256 '8b7d2be5daef42bc07ef65141d86b8d5a7d4f81876a1d52a264b3fdc6a9657a1'
+  version '1.30.0,241923763dbeaf3b64443187e935d55b29f6125d'
+  sha256 '41184dba587dcf5288968f22fde7c458ebb017e3cfd68c024249b529544bfa44'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.