### PR TITLE
Update telegram-alpha to 4.7.2-148779,1707

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.7.1-148652,1704'
-  sha256 '594a566472ea39159fe480efcae7d448142f11cc1df273cf7050b39a9f3d854d'
+  version '4.7.2-148779,1707'
+  sha256 'f016cc25ab344314e82b22a7b5310967be2e759d889a826afb2de57adc5bb946'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.