### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.4.1432,246

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.4.1426,245'
-  sha256 '0dd82eb00f48156baed0278afc3314429aec4c74786cce6214b627332b9d236a'
+  version '10.2.4.1432,246'
+  sha256 '764e37022f42eb4742dda850fb2a4be7477c1155b46440d8cdd5d9b8ea11aca4'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.