### PR TITLE
Update vivaldi-snapshot to 2.2.1388.29

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.2.1388.23'
-  sha256 'addd7f0357a1887ba062becd198be62d189db557a86c228bbfa4077fd133323e'
+  version '2.2.1388.29'
+  sha256 'a2b339c1f43b3e2ce7050d8b5b500439279372ee079d3d12f98bb237f98338e1'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.