### PR TITLE
Update opera-beta to 58.0.3135.26

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '58.0.3135.21'
-  sha256 '84343a97f10884553a8a46d8f004a8c614467b507d096345b1d3a9443720f11f'
+  version '58.0.3135.26'
+  sha256 'fa6d36564bd5b3510478b4ea8d3ed1c5b0f49a917086c6e16ea2b765aa4ef1b6'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.