### PR TITLE
Update opera-developer to 59.0.3167.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '59.0.3160.0'
-  sha256 '0b1c2b61809516867b65f48355e36dc0510bfe35a5c645d2d490d55a4b7788aa'
+  version '59.0.3167.0'
+  sha256 'e21ec2f8e36368f2611aaee6f0d6acf4d1fbca7b236c674aacb29899614fb3d9'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.