### PR TITLE
Update 1password-beta to 7.2.3.BETA-8

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.2.3.BETA-7'
-  sha256 '5bdc9c1f16b62551cc02a126e7ddc8ba69f57b4fe581562541c367b8c7175322'
+  version '7.2.3.BETA-8'
+  sha256 '484d1379a86e129b4b329666ec42a46b4fe3c61e284330bda183ab54739ceeef'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.