### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.6.1480,250

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.6.1473,249'
-  sha256 '3f32445c7362de354f9549c3b464ef75768d163a92da4e1861ef8e562e6e5d81'
+  version '10.2.6.1480,250'
+  sha256 '5a8b9dafa2954e842c6041ad2a839be585e08d943a64552955ede1b5f9c8dafb'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.