### PR TITLE
Update slicer-nightly to 4.11.0.27666,927386

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.11.0.27630,923324'
-  sha256 '31a4fb49485e33b066d35220329d11cd18f8c446a9ac2c9f038d3df9c4f820ef'
+  version '4.11.0.27666,927386'
+  sha256 '8b6ffc8a5a3bb93065a848262270585f26bd3d484c16cc8f33a8f9d34a207474'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.