### PR TITLE
Update telegram-alpha to 4.8-151090,1733

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.8-150943,1728'
-  sha256 'e760dfffb681550cbc48764b556b19b7787a30c75242c936d61c23b699c5880a'
+  version '4.8-151090,1733'
+  sha256 '5e90211833315dbd8eb4441e5284fded9d0c8f2193c088412ee04d72936cc057'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.