### PR TITLE
Update toggl-dev to 7.4.333

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.322'
-  sha256 'd110c68ed7650ee9f6f1237018effa78fdf2a4793ac0018706d9bd6d6e43a010'
+  version '7.4.333'
+  sha256 'dc117fae021cab8f247ed695d617657f65c9376697c6eb848313167c8a33c9d1'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.