### PR TITLE
Update toggl-beta to 7.4.330

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,6 +1,6 @@
 cask 'toggl-beta' do
-  version '7.4.321'
-  sha256 'f8a0d404486cf95e61760a3d956df88a3599d12e194cb5de2ae3f0f87201b29a'
+  version '7.4.330'
+  sha256 '29c6df4dbdf575f2939b7c680ebeed9fb2abbe80a692022a56112f6127a47958'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.