### PR TITLE
Update hex-fiend-beta to 2.10b6

### DIFF
--- a/Casks/hex-fiend-beta.rb
+++ b/Casks/hex-fiend-beta.rb
@@ -1,6 +1,6 @@
 cask 'hex-fiend-beta' do
-  version '2.10b5'
-  sha256 'd9defeeb11ffd6871b21361b066b5952a5f5353f982a97fe46f13f0a3a986000'
+  version '2.10b6'
+  sha256 'e07d242d2cf0733f0c548e776a226ab9c4eb943f16c41cc407a3e0a7b903fdb4'
 
   # github.com/ridiculousfish/HexFiend was verified as official when first introduced to the cask
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.