### PR TITLE
Update iterm2-beta to 3.2.7beta3

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.7beta2'
-  sha256 '82e24a9e0e11b0cc44f5717766c3735bf103e68d3011410a94e4af09a179a199'
+  version '3.2.7beta3'
+  sha256 '1d181c5d506ba1fdb7ea96364776ec0bfedbf8fc42dc14cde462857249976e9f'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.