### PR TITLE
Update workflowy-beta to 1.1.11-beta.2177

### DIFF
--- a/Casks/workflowy-beta.rb
+++ b/Casks/workflowy-beta.rb
@@ -1,6 +1,6 @@
 cask 'workflowy-beta' do
-  version '1.1.11-beta.2138'
-  sha256 'f569b3087c204765b429b6371121035bc3ce2be89a7dcf77c00ad71a64e6d060'
+  version '1.1.11-beta.2177'
+  sha256 'faadd8a7fa55560dac1ba0267f2424bbcf85b05d51fda8cfcae35f8c69fb7a72'
 
   # github.com/workflowy/desktop-beta was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop-beta/releases/download/v#{version}/WorkFlowy-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.