### PR TITLE
Update iina-beta: homepage and zap 

### DIFF
--- a/Casks/iina-beta.rb
+++ b/Casks/iina-beta.rb
@@ -2,11 +2,10 @@ cask 'iina-beta' do
   version '1.0.0-rc'
   sha256 '40fb3442705e8ca1ab27c16e6dbdab9d41f926e4eeecb65c8f7829196b9cb863'
 
-  # dl-portal.iina.io was verified as official when first introduced to the cask
   url "https://dl-portal.iina.io/IINA.v#{version}.dmg"
   appcast 'https://www.iina.io/appcast-beta.xml'
   name 'IINA'
-  homepage 'https://lhc70000.github.io/iina/'
+  homepage 'https://iina.io/'
 
   auto_updates true
   conflicts_with cask: 'iina'
@@ -16,10 +15,14 @@ cask 'iina-beta' do
   binary "#{appdir}/IINA.app/Contents/MacOS/iina-cli", target: 'iina'
 
   zap trash: [
+               '~/Library/Application Scripts/com.colliderli.iina.OpenInIINA',
                '~/Library/Application Support/com.colliderli.iina',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.colliderli.iina.sfl*',
+               '~/Library/Application Support/CrashReporter/IINA*.plist',
                '~/Library/Caches/com.colliderli.iina',
+               '~/Library/Containers/com.colliderli.iina.OpenInIINA',
                '~/Library/Cookies/com.colliderli.iina.binarycookies',
+               '~/Library/Logs/com.colliderli.iina',
                '~/Library/Logs/DiagnosticReports/IINA*.crash',
                '~/Library/Preferences/com.colliderli.iina.plist',
                '~/Library/Safari/Extensions/Open in IINA*.safariextz',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.