### PR TITLE
Update airmail-beta to 3.7.0.538,385

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.7.0.536,384'
-  sha256 'd100c8db4f2ecfcad62e61972ae64dff55b707e921fc8681b3706d58fef8be1a'
+  version '3.7.0.538,385'
+  sha256 '46502d63500f74447e6d66401b66a8b07cd4beab74fb4af2d3db4e6b039c03b6'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.