### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.6.1529,257

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.6.1523,256'
-  sha256 '94feb54a3142650328ebc9a66ab74b995dab4b4a33e7f73c3b76d8d72a4423a9'
+  version '10.2.6.1529,257'
+  sha256 '8667b5d2e10ab48dde1af9c17bcbebb7d93684ced4b19a9ede06ec85a1bf325d'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.