### PR TITLE
Update rstudio-preview to 1.2.1226

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1206'
-  sha256 '2ecb5dd87ca38489f241a969636ee1dafabc0ea48a7cdf9410e3ebaf8fcce545'
+  version '1.2.1226'
+  sha256 'ba13047066b98c34d567851e04864d5eab9b8dd811db4393535fc84273152fb6'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.