### PR TITLE
Update signal-beta to 1.20.0-beta.3

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.19.0-beta.4'
-  sha256 'd6168bb14b0fe1ea391be70e704ca7faa9217a3603a8db65f07dd8d7c571d47c'
+  version '1.20.0-beta.3'
+  sha256 'f221cfacee44e74c2d37b0caf29c3591ad45d918fc132d7fd5f7d03e6c5d0553'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.