### PR TITLE
Update github-beta to 1.6.0-beta3-b59b51a1

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '1.6.0-beta2-8253e0f7'
-  sha256 '04f57de5e670e4dceaf2933fbdb70623f9ef4100ce0477403c1b475147afe71b'
+  version '1.6.0-beta3-b59b51a1'
+  sha256 '194e067e2a8601ddd589a7c1512e0c0b1cadce7efb9f70682857ded8a0e89c60'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.