### PR TITLE
Update telegram-alpha to 4.9-153789,1753

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.8-152709,1751'
-  sha256 '42085438bab3fe318efd85ed883bc9b98c990695cbf76227f77d4682ccbe38af'
+  version '4.9-153789,1753'
+  sha256 '86ec3e87a02929ccec8dc0b7ee5c52bf3c9c56e7737a261e5df8c13775464c10'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.