### PR TITLE
Update telegram-alpha to 4.8-154263,1759

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.8-153943,1757'
-  sha256 'a30fdabc29466def2ca6eb8c5d5328a54958daf0eafcd56f9da6fa32e518dc03'
+  version '4.8-154263,1759'
+  sha256 'a254b927bd43aa510ba7e9507cdd60c234872a93123aabd1162143518d0488bc'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.