### PR TITLE
Update opera-beta to 58.0.3135.45

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '58.0.3135.37'
-  sha256 '7b598102e4d93773b4d2f3deb64fad7d4e154ff1c2b8e8a158f7ae1f6c3cf545'
+  version '58.0.3135.45'
+  sha256 '4af28884e3a09eaea7cba070c65411e9390399f69a3fef677b1e79e450ab26c3'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.