### PR TITLE
Update telegram-alpha to 4.8-155142,1775

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.8-155095,1772'
-  sha256 '154bbff3b71d521e075884c72126ddc547b7c7cc146363e40e7f0c7f4b8f5015'
+  version '4.8-155142,1775'
+  sha256 'f54b19911f218cdf12273c0e4584dbabd244ca412d082793e2fc4e2ae2e56fc8'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.