### PR TITLE
Update github-beta to 1.6.2-beta0-592cd2ec

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '1.6.0-beta3-b59b51a1'
-  sha256 '194e067e2a8601ddd589a7c1512e0c0b1cadce7efb9f70682857ded8a0e89c60'
+  version '1.6.2-beta0-592cd2ec'
+  sha256 'c9f412a03eeff7009338bd49cff2ab202ee9a760ad84436d0209f4fb595d023f'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.