### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.6.1546,261

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.6.1543,259'
-  sha256 '543e1088f4c749262258ed3af14687d7939904e0d81333e456b9bd2288fff1de'
+  version '10.2.6.1546,261'
+  sha256 '1ae4ac6eea1bc2f8ff04528330510a359b9af3a372fc115a553a5d6fc2c09ce5'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.