### PR TITLE
Update affinity-photo-beta to 1.7.0.107

### DIFF
--- a/Casks/affinity-photo-beta.rb
+++ b/Casks/affinity-photo-beta.rb
@@ -1,6 +1,6 @@
 cask 'affinity-photo-beta' do
-  version '1.7.0.106'
-  sha256 '852277e4677c1d806e4b3e9c780c1495f8be1f896e583866a1a1f80429ec044b'
+  version '1.7.0.107'
+  sha256 'f17b3205b3477a114a695677962a92b554e2bd2559286929c962dc85be4912fc'
 
   # affinity-beta.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://affinity-beta.s3.amazonaws.com/download/Affinity%20Photo%20Customer%20Beta.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.