### PR TITLE
Update openscad-snapshot to 2018.11.25

### DIFF
--- a/Casks/openscad-snapshot.rb
+++ b/Casks/openscad-snapshot.rb
@@ -2,7 +2,7 @@ cask 'openscad-snapshot' do
   version '2018.11.25'
   sha256 '128cd274dfc4b041f1ecf3d0bc911e8721713e3be2f353ee6b1f6994385cdd66'
 
-  url "http://files.openscad.org/snapshots/OpenSCAD-#{version}.dmg"
+  url "https://files.openscad.org/snapshots/OpenSCAD-#{version}.dmg"
   appcast 'https://www.openscad.org/inc/mac_snapshot_links.js'
   name 'OpenSCAD'
   homepage 'https://www.openscad.org/downloads.html#snapshots'

--- a/Casks/openscad-snapshot.rb
+++ b/Casks/openscad-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'openscad-snapshot' do
-  version '2018.03.17'
-  sha256 '58330d5118ec921b3ed930adfb35e90fdaa30afc25930f85cc102fdf255112aa'
+  version '2018.11.25'
+  sha256 '128cd274dfc4b041f1ecf3d0bc911e8721713e3be2f353ee6b1f6994385cdd66'
 
   url "http://files.openscad.org/snapshots/OpenSCAD-#{version}.dmg"
   appcast 'https://www.openscad.org/inc/mac_snapshot_links.js'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.