### PR TITLE
Update firefox-esr to 60.5.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.4.0'
+  version '60.5.0'
 
   language 'cs' do
-    sha256 '71cb8bb47f780e599278048c453d20ebf5d5d62baa0841482465018a217eed48'
+    sha256 'b135d8a9221f2c437cb19c79aa9060b6c669aabfb84e1b06d3fb7e2ee22a9d29'
     'cs'
   end
 
   language 'de' do
-    sha256 'ef59af50667c324b1fe92b2421f1b35b61c931bc894daeca11da0da0230a9dba'
+    sha256 '483c72502d08e16440447524a614260053dda7c9bb29696d1dcc3ddf5b6eb0b7'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '0e00e327664d70006aec72e05d62dd31cc3984b13a5cdfc06aee166649723e88'
+    sha256 'd11942990254ee15bfc787ae10f7435052854e9f8b3e8b3ff4a69f9e3f831f0b'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '9f482bf08db6e00652f72ea5b7e608250ed91626155a9314fe82e4e1826e61aa'
+    sha256 '773e2c003623645e26b6c6afb1c337967ca008f6e856eee4c89f8d637ae1461c'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '0b9d9498f4fe0e5800c87e2e56de513606eac1c5ce6c18c5d0cccb4ca5e792c4'
+    sha256 '17b0afbe5a24196e4c11ed6bc7b0690d6a5acdece49011096fd033021db9c9b2'
     'fr'
   end
 
   language 'gl' do
-    sha256 'ce6ed54a1528ca9452789b63ccf573bb203eecdb77b92eb8bca4198e303d1cb2'
+    sha256 '0b0c9bc5fb9fd49462e3cbedcd3a224a0aa6598bb9e59bff05b55f066447e26d'
     'gl'
   end
 
   language 'it' do
-    sha256 '7b7b8d248fdcc412abfcbb6db0b9c467302d845978832d07f434834a1d0ecf34'
+    sha256 '80d30f74b97fc517fc4d90aa25b689c0ba3645c7974fff6716a6e77b6f7e9d1f'
     'it'
   end
 
   language 'ja' do
-    sha256 'b564c3a0e04d2ee3605667567d8952a395c55cb20986b609c01bfff9fc1ffc02'
+    sha256 '0158a6e2bab16b0efe29555380891f96b103a50ff311870352a88c3ea6abe62d'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'c1108abda939af0436f7d13fd6f6c036206b22d0e4b1f2e1ec6b0263003b2adc'
+    sha256 '3a9e0e3e811a13dc4541dbe4676cd257493f0f288e7dd2e1e28b9e0b74ccf569'
     'nl'
   end
 
   language 'pl' do
-    sha256 'd25f0bc5fb4ca88bea886764a965fc5ff957ea0eadc40c5f0c3af134f42be3c1'
+    sha256 '5aeccadf24cb2f930ae10f4b39aac5a6012de908949a77fe0af2219b83dfb83b'
     'pl'
   end
 
   language 'pt' do
-    sha256 '0f3c371499925b027a9a514c3e3c9c8c62f04bd0e457c5d2eb4eb4af61c14338'
+    sha256 'ec238df899f8550824781cf35c248155b0446d5d9f2fedae2627802bf1e82853'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'c33ae643ccff3d71b546854f4e8c043db5399366af897e1fd24cee3e48bbd136'
+    sha256 '45e67e8e37e9504028a4ea0e418fe951224b4cb41b1ae529e1f944d9b1f1c5fa'
     'ru'
   end
 
   language 'uk' do
-    sha256 '740af3b04cc47e28365412ca831c7dd3d1bceea64672a1af48b3527bad5519d8'
+    sha256 'f0c376c664a3b60ac7a1f9227965d09ac47c3f1eebcc664699879ddfe2b844e7'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'f7f96571749814d8cb55ac5ecc4c179e87169360d88e48689a21ce1c2652d59d'
+    sha256 '7fd11e0292ed459a37ae7944f68ef02433ff3aa3bb47003b4424d62bb6d82a64'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '034668c4681da1457c2f2f0874e211b6793998ae079feeba321b85669f136749'
+    sha256 '8906365e052cf333fc8260128e6836e349f0ec835bc2f530caaa1fa52ea1aea9'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
