### PR TITLE
Update telegram-alpha to 4.9-156957,1796

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9-156258,1791'
-  sha256 '60b567305f8ae43005183c195bb2523d4807f8187b2892c44636a44415e4409e'
+  version '4.9-156957,1796'
+  sha256 '37ad1452d1933f7243710e0f337327c77802540bc4e5c851f1f73f42d68a033b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.