### PR TITLE
Update airmail-beta to 3.7.0.542,387

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -6,7 +6,7 @@ cask 'airmail-beta' do
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
-  homepage 'http://airmailapp.com/beta/'
+  homepage 'https://airmailapp.com/beta/'
 
   app 'Airmail Beta.app'
 

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.7.0.541,386'
-  sha256 '5e5a0a4b947285b5ce1fb6f24e7c81813ba762388db5b8d8ddd5360764b61a81'
+  version '3.7.0.542,387'
+  sha256 '60628cbd54e76549809b1940826519b58637a303ae3b06db9969a2df0d1e7824'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.