### PR TITLE
Update telegram-alpha to 4.9-157053,1803

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9-157013,1800'
-  sha256 'bc2c4acb061723c2ed38a73b0052610467a1f58877ce67f0ebfd67eb40580e1e'
+  version '4.9-157053,1803'
+  sha256 '9393fd63c68af6c7974a22126b968774686549abab5a580b9042ff2542f47515'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.