### PR TITLE
Update telegram-alpha to 4.9.5-157208,1813

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-157062,1805'
-  sha256 '97041f493ef2269fe0cd57a7afe6675f20523612b8b14587f361729f8189219b'
+  version '4.9.5-157208,1813'
+  sha256 'a2f009272d0c1417af48ba0d2e8cd7f57810999bb0ff0b9269b30c6ec944db6c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.