### PR TITLE
Update telegram-alpha to 4.9.5-157480,1826

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-157208,1813'
-  sha256 'a2f009272d0c1417af48ba0d2e8cd7f57810999bb0ff0b9269b30c6ec944db6c'
+  version '4.9.5-157480,1826'
+  sha256 'fe59b12436a30726844c291d2bb0ab07b3f27342b21d17375a990a19e03aa1b4'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.