### PR TITLE
Update digikam-beta url to pre-releases.

### DIFF
--- a/Casks/digikam-beta.rb
+++ b/Casks/digikam-beta.rb
@@ -2,9 +2,9 @@ cask 'digikam-beta' do
   version '6.0.0-beta3,20181228T124823'
   sha256 '4852602061b96368254431aaf0424e6cf5e8d5f00d8b77eca3953d18e18d3cd7'
 
-  # files.kde.org/digikam was verified as official when first introduced to the cask
-  url "https://files.kde.org/digikam/digiKam-#{version.before_comma}-#{version.after_comma}-MacOS-x86-64.pkg"
-  appcast 'https://files.kde.org/digikam/'
+  # download.kde.org/unstable/digikam was verified as official when first introduced to the cask
+  url "https://download.kde.org/unstable/digikam/digiKam-#{version.before_comma}-#{version.after_comma}-MacOS-x86-64.pkg"
+  appcast "https://download.kde.org/unstable/digikam/digiKam-#{version.before_comma}-#{version.after_comma}-MacOS-x86-64.pkg.mirrorlist"
   name 'digiKam'
   homepage 'https://www.digikam.org/'
 


### PR DESCRIPTION
The commit doesn't include cask version, because I only changed the url and appcast to fix broken url and pattern.
The original url seems used in Weekly Snapshots, not Pre-Releases (Beta).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
