### PR TITLE
Update telegram-alpha to 4.9.5-157926,1833

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-157905,1832'
-  sha256 '3ee8a9e124bb0d906d2ae8153758de995586a44a60d6c5a15e3d8e2208aa137b'
+  version '4.9.5-157926,1833'
+  sha256 'eed465413aa7bd6838a8fd058a6a4d5247a648e88acd25e7b04478d3d283c927'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.