### PR TITLE
Update telegram-alpha to 4.9.5-158327,1838

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-157926,1833'
-  sha256 'eed465413aa7bd6838a8fd058a6a4d5247a648e88acd25e7b04478d3d283c927'
+  version '4.9.5-158327,1838'
+  sha256 '15e4f30dbf7d561f18efbe513e2846c79892d301cc91dbe4d3196be52935c0b0'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.