### PR TITLE
Update affinity-photo-beta to 1.7.0.110

### DIFF
--- a/Casks/affinity-photo-beta.rb
+++ b/Casks/affinity-photo-beta.rb
@@ -1,6 +1,6 @@
 cask 'affinity-photo-beta' do
-  version '1.7.0.109'
-  sha256 '4a3a19cb3836b8b7a9803ded31af5ed9e8a0785a0534868479027901099be094'
+  version '1.7.0.110'
+  sha256 'c6304822a9b32b52bea895455453a3f7a909a3b391d12be3ab11919763ad1de5'
 
   # affinity-beta.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://affinity-beta.s3.amazonaws.com/download/Affinity%20Photo%20Customer%20Beta.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.