### PR TITLE
Update rstudio-preview to 1.2.1268

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1256'
-  sha256 '2ba65173f599ae910e2f097906750a299899c502b0dc41b3fafc489b5107839f'
+  version '1.2.1268'
+  sha256 '573283341c12be6232c1d5cbae773eec166b4e456545e7359ce2a2ca83aaab11'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.