### PR TITLE
Update telegram-alpha to 4.9.5-158886,1850

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-158789,1845'
-  sha256 'd57907ff29ec7698b6dc1dd3083eb6930072d4aee2de027d67cf36e51bdd79e5'
+  version '4.9.5-158886,1850'
+  sha256 '8fbaa789b0dc15e801a648b59590ff6eda5e78ea1046323c26e7d81288e2989b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.