### PR TITLE
Update telegram-alpha to 4.9.5-158974,1852

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-158789,1845'
-  sha256 'd57907ff29ec7698b6dc1dd3083eb6930072d4aee2de027d67cf36e51bdd79e5'
+  version '4.9.5-158974,1852'
+  sha256 '8796318b13e4a0a1a8f608f76fa18dd95b9ff6aef452c24cfd6c283c8e024440'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.