### PR TITLE
Update hex-fiend-beta to 2.12b1

### DIFF
--- a/Casks/hex-fiend-beta.rb
+++ b/Casks/hex-fiend-beta.rb
@@ -1,6 +1,6 @@
 cask 'hex-fiend-beta' do
-  version '2.11.0b6'
-  sha256 'a9bc7c22bcc03e02e2e79c3130148d6a08c760d04272fd0fa8baa04883929231'
+  version '2.12b1'
+  sha256 '009a931bfcb592509abcd2b217fcc449d1aab41fea982ac9f7a39ab64492e18b'
 
   # github.com/ridiculousfish/HexFiend was verified as official when first introduced to the cask
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.sub(%r{\w\d$}, '')}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.