### PR TITLE
Update firefox-esr to 60.5.1

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.5.0'
+  version '60.5.1'
 
   language 'cs' do
-    sha256 'b135d8a9221f2c437cb19c79aa9060b6c669aabfb84e1b06d3fb7e2ee22a9d29'
+    sha256 'c82c54252c2714e35fe197b3b105cdac78fcfbcad37f580e9111437cf5da4411'
     'cs'
   end
 
   language 'de' do
-    sha256 '483c72502d08e16440447524a614260053dda7c9bb29696d1dcc3ddf5b6eb0b7'
+    sha256 '176557ad2c4d8f13d72b0de559869a676d4330e06d205e15fd2ea10ae4c23485'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'd11942990254ee15bfc787ae10f7435052854e9f8b3e8b3ff4a69f9e3f831f0b'
+    sha256 'd19b1a8e432c9f5761047dfe88ecbf08dfc762fd01c5e9dbfea1040e64f1a82f'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '773e2c003623645e26b6c6afb1c337967ca008f6e856eee4c89f8d637ae1461c'
+    sha256 '0f697ef7423429fe70a3019e2d2cd2b3982106ef4103eef5aba73fbc6dafb0a6'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '17b0afbe5a24196e4c11ed6bc7b0690d6a5acdece49011096fd033021db9c9b2'
+    sha256 '057a8e7c77fd9a4117870f3575ea728319c22a14c9b88fb8e8a0586e6c434f67'
     'fr'
   end
 
   language 'gl' do
-    sha256 '0b0c9bc5fb9fd49462e3cbedcd3a224a0aa6598bb9e59bff05b55f066447e26d'
+    sha256 'c24b8bb321389f345a526d2c99cd2be3809410c157d9292646b6acbe9d279569'
     'gl'
   end
 
   language 'it' do
-    sha256 '80d30f74b97fc517fc4d90aa25b689c0ba3645c7974fff6716a6e77b6f7e9d1f'
+    sha256 '0f4d26fac3b3dacd4bc9cf49941b3bd32db0069c4dbd8532d7bc814f3c52148a'
     'it'
   end
 
   language 'ja' do
-    sha256 '0158a6e2bab16b0efe29555380891f96b103a50ff311870352a88c3ea6abe62d'
+    sha256 '5e4ab4fc7b51908ee5bda1cebf398706c4d5be77cebc6fbe0410511bf99a7bd5'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '3a9e0e3e811a13dc4541dbe4676cd257493f0f288e7dd2e1e28b9e0b74ccf569'
+    sha256 '9f72d3076371885246345c6d6313aa329bf9762d1df73c6571096a3662c085c1'
     'nl'
   end
 
   language 'pl' do
-    sha256 '5aeccadf24cb2f930ae10f4b39aac5a6012de908949a77fe0af2219b83dfb83b'
+    sha256 '97aa20a81f6042d500e9861d0a0117c984a8101eaf77bad979eac5507eb43efd'
     'pl'
   end
 
   language 'pt' do
-    sha256 'ec238df899f8550824781cf35c248155b0446d5d9f2fedae2627802bf1e82853'
+    sha256 '5aba6f10c7c3f0df28f839d17ea0518fc47360f2a7e8f2c66fe27d501508a486'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '45e67e8e37e9504028a4ea0e418fe951224b4cb41b1ae529e1f944d9b1f1c5fa'
+    sha256 '6fbeba43a572f9b71ddda96584573ad266bc0889fecea3dec606668de3d9b760'
     'ru'
   end
 
   language 'uk' do
-    sha256 'f0c376c664a3b60ac7a1f9227965d09ac47c3f1eebcc664699879ddfe2b844e7'
+    sha256 '7481e1d988ef07b393ac3ec08e8b84a2ff83dcfaeb9ada94f0668487e85bd6c7'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '7fd11e0292ed459a37ae7944f68ef02433ff3aa3bb47003b4424d62bb6d82a64'
+    sha256 '55d47ad4bd66ea7aa24fbf127b9fd8403edf60b529411653c1cac40503051326'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '8906365e052cf333fc8260128e6836e349f0ec835bc2f530caaa1fa52ea1aea9'
+    sha256 'e4d1fc414f82056b56bfd01d221601a41cf52f575cbc0007d5ef4f32efa263ea'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
