### PR TITLE
Update telegram-alpha to 4.9.5-159421,1860

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-159191,1856'
-  sha256 '76f3e7f8c3fcbc328f6bf468596dbcecf78644de0d9ad5efabb1e60c61c04eb0'
+  version '4.9.5-159421,1860'
+  sha256 '8270b7ba12ceda1c7077ba4cc87612520e07dc184338430eaa1b28ae5026afdd'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.