### PR TITLE
Update telegram-alpha to 4.9.5-159611,1863

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-159604,1862'
-  sha256 '63eacf42724f325935611d3fe597dbec446cebfbd0f7fc689d07e6b4906845f3'
+  version '4.9.5-159611,1863'
+  sha256 'b6267cf90336e0f51347147009ec7d9a606fec0bd1410ec00a281d6cc6a25deb'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.