### PR TITLE
Update telegram-alpha to 4.9.5-159721,1864

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-159611,1863'
-  sha256 'b6267cf90336e0f51347147009ec7d9a606fec0bd1410ec00a281d6cc6a25deb'
+  version '4.9.5-159721,1864'
+  sha256 '9f8cbb5f144e8d78b4a62f270fc2f02e83b78da363d40e24775db5d60272854f'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.