### PR TITLE
Update telegram-alpha to 4.9.5-159852,1869

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-159829,1868'
-  sha256 '508155864a6fee836ec0a9091561e34f6a7f7fd0a27e19b74c8f6fda90f47b27'
+  version '4.9.5-159852,1869'
+  sha256 '05070b3bdf9a37a23b2c351c1e95fc367be8ca64f7846d22f233cce03f0d8b90'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.