### PR TITLE
Update sublime-text-dev to 3190

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,6 +1,6 @@
 cask 'sublime-text-dev' do
-  version '3.189'
-  sha256 '163f46fbe47e369fa89b1dfafcfa1df577e87ebaa7aa502fbe77cebf1c7d2ced'
+  version '3190'
+  sha256 'de94231f6060a1ed01492d670347b40fb5bdc80471de6a79fbb958b818b07a00'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
   appcast "https://www.sublimetext.com/updates/#{version.major}/dev/appcast_osx.xml"

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,5 +1,5 @@
 cask 'sublime-text-dev' do
-  version '3190'
+  version '3.190'
   sha256 'de94231f6060a1ed01492d670347b40fb5bdc80471de6a79fbb958b818b07a00'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.