### PR TITLE
Update java8 to 8u202,b08:1961070e4c9b4e26a04e7f5a083f551e

### DIFF
--- a/Casks/java8.rb
+++ b/Casks/java8.rb
@@ -13,7 +13,17 @@ cask 'java8' do
 
   pkg 'JDK 8 Update 202.pkg'
 
-  uninstall pkgutil: "com.oracle.jdk#{version.before_comma}"
+  uninstall pkgutil: "com.oracle.jdk#{version.before_comma}",
+            delete:  [
+                       '/Library/Internet\ Plug-Ins/JavaAppletPlugin.plugin',
+                       '/Library/PreferencePanes/JavaControlPanel.prefPane',
+                     ]
+
+  zap trash: [
+               '~/Library/Application Support/Oracle/Java',
+               '~/Library/Application Support/com.oracle.java.JavaAppletPlugin.plist',
+               '~/Library/Application Support/com.oracle.javadeployment.plist',
+             ]
 
   caveats do
     license 'https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

added uninstall and zap files