### PR TITLE
Update telegram-alpha to 4.9.5-160189,1877

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '4.9.5-160159,1875'
-  sha256 'fde564e7ce4897f5666e0d8f87f51433742b412a4745d80c92e394b106bffef4'
+  version '4.9.5-160189,1877'
+  sha256 '1bf8e209e190c62b55787480da39bfdd004450251919de581101acbd7504da6c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.