### PR TITLE
Update rstudio-preview to 1.2.1303

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1280'
-  sha256 'a90bb137338b4183437001212983bfbda0ecdf45b4ca37fde125399f55be3e53'
+  version '1.2.1303'
+  sha256 '20ffc81ed0f84819306cd7dce26d31a22e350053faa81472159bdea28b261c51'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.