### PR TITLE
Update tunnelblick-beta to 3.7.9beta03,5210

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick-beta' do
-  version '3.7.9beta02,5200'
-  sha256 '46db6fe507199a379eb37d241dfea4e83509cfa578207385d5964863edac1bbd'
+  version '3.7.9beta03,5210'
+  sha256 'af798f603246d60f4e76e04e74d9535a49e56602ec855a473dc1d6ac1d8cb1fe'
 
   # github.com/Tunnelblick/Tunnelblick was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.