### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.8.1570,269

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.8.1566,268'
-  sha256 '66e56de4c54ac338215144a92c71a819ad53540ab3e32963db922f9eb8a5c2af'
+  version '10.2.8.1570,269'
+  sha256 '6bfe6aaf86994f87088710692b8e3aa95dcbd182bd8622b729437d62fedda723'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.