### PR TITLE
Add Freecad.app v0.18 prerelease

### DIFF
--- a/Casks/freecad-pre.rb
+++ b/Casks/freecad-pre.rb
@@ -1,0 +1,12 @@
+cask 'freecad-pre' do
+  version '0.18-15525.1a7d3d9'
+  sha256 '8c739a111482d640f7e9916429d767a084cacbb1db405c16e27688249e39627b'
+
+  # github.com/FreeCAD/FreeCAD was verified as official when first introduced to the cask
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.split('-')[0]}_pre/FreeCAD_#{version}-OSX-x86_64-Qt5-Py3.dmg"
+  appcast 'https://github.com/FreeCAD/FreeCAD/releases.atom'
+  name 'FreeCAD'
+  homepage 'https://www.freecadweb.org/'
+
+  app 'FreeCAD.app'
+end


### PR DESCRIPTION
This is currently the most recent release not marked as "latest".

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

I can't run `brew cask style` because of a problem with my ruby install. But the layout of the file is identical to the main Freecad cask.

The Py3, Qt5 version is the recommended default according to the download page.