### PR TITLE
Update airmail-beta to 3.7.0.543,388

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '3.7.0.542,387'
-  sha256 '60628cbd54e76549809b1940826519b58637a303ae3b06db9969a2df0d1e7824'
+  version '3.7.0.543,388'
+  sha256 '0d08a06011e0c34e31f25be007350c087011c6f26fc7b25e20e90346ec517167'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.