### PR TITLE
Update wine-staging to 4.3

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '4.2'
-  sha256 'a9c095f2b18b41b56b6f3ae108cee1091eeca348d3645a66cea304f7afc1e235'
+  version '4.3'
+  sha256 'c5eedcdc6c52ec2992acf836ed75739665d72fc917e936bd6cbe0d013ea4783e'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.