### PR TITLE
Update microsoft-remote-desktop-beta to 10.2.9.1575,274

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.8.1570,269'
-  sha256 '6bfe6aaf86994f87088710692b8e3aa95dcbd182bd8622b729437d62fedda723'
+  version '10.2.9.1575,274'
+  sha256 'd8ed61af9e1aee33c0b09586901b1de9d0cecbceca0d88ea7ea8c7388e192b13'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.