### PR TITLE
Update slicer-nightly to 4.11.0.28009,980094

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.11.0.27946,948152'
-  sha256 'b26a9406a74eeacb3ec480f55bd273a67f592e31f0376db6c53cb7526d8fdf26'
+  version '4.11.0.28009,980094'
+  sha256 '11e17df3b22cc82e92a4b48109c1d1606f26054a5710c01475163dfe026e5ec6'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.