### PR TITLE
Update telegram-alpha to 5.0-163094,1889

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,5 +1,5 @@
 cask 'telegram-alpha' do
-  version '5.0-162977,1889'
+  version '5.0-163094,1889'
   sha256 'ad59eda0365e12f369755110593bf80c83ffcdce954ee035f792d6113e85769a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.