### PR TITLE
Update slicer-nightly to 4.11.0.28014,980673

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.11.0.28009,980094'
-  sha256 '11e17df3b22cc82e92a4b48109c1d1606f26054a5710c01475163dfe026e5ec6'
+  version '4.11.0.28014,980673'
+  sha256 '5142653662701741bc5e550e9fcc778128223c0f04d73d8c49891364e23350d7'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.