### PR TITLE
Update telegram-alpha to 5.0-163175,1898

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.0-163094,1897'
-  sha256 '8196bb6491160ac34be7b35f03dc96732be44149a3b0fed6a669d3d98575a3f3'
+  version '5.0-163175,1898'
+  sha256 '20baf7c9963eec992ddf0a46b79573e6ef5e85317ee82afa0976122a8edeee79'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.