### PR TITLE
Update 1password-beta to 7.3.BETA-1

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.3.BETA-0'
-  sha256 'bd90604409cf969e637b71f248f6461cedd3eb20e247c6b81ecd4d91b6239315'
+  version '7.3.BETA-1'
+  sha256 '1f3a5e3b8c6f8a4281fad7809e5c0f1163c05fbbcf6b8c155c33a26085b13e30'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.