### PR TITLE
Update safari-technology-preview to 78

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,11 +1,11 @@
 cask 'safari-technology-preview' do
-  version '78'
+  version '78,041-48448-20190319-3d1eddd6-14ef-4b4d-9a1d-e5462d07403c'
 
   if MacOS.version <= :high_sierra
     url 'https://secure-appldnld.apple.com/STP/041-48694-20190319-3be95cf1-f7e3-4673-b0ed-3da880f3f88b/SafariTechnologyPreview.dmg'
     sha256 '63deff4b7215be0816086d665d0f41d0e8c143dfb7c1ab5382dac8e2f5b6cb12'
   else
-    url 'https://secure-appldnld.apple.com/STP/041-48448-20190319-3d1eddd6-14ef-4b4d-9a1d-e5462d07403c/SafariTechnologyPreview.dmg'
+    url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
     sha256 '595b86d7d33d5cf1e233742472270bfe825c8de2f4b7c8789d9452ba30a32128'
   end
 

--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '77'
+  version '78'
 
   if MacOS.version <= :high_sierra
-    url 'https://secure-appldnld.apple.com/STP/041-45474-20190306-01614CC2-9292-493B-BD44-88C10420CC04/SafariTechnologyPreview.dmg'
-    sha256 '05620f8907ca55565f2e458628c359e906bec260309855c85b4695191e57283b'
+    url 'https://secure-appldnld.apple.com/STP/041-48694-20190319-3be95cf1-f7e3-4673-b0ed-3da880f3f88b/SafariTechnologyPreview.dmg'
+    sha256 '63deff4b7215be0816086d665d0f41d0e8c143dfb7c1ab5382dac8e2f5b6cb12'
   else
-    url 'https://secure-appldnld.apple.com/STP/041-43051-20190306-DAF02279-D00E-4F68-8D24-423551D294C8/SafariTechnologyPreview.dmg'
-    sha256 'f8e6574c46a57b107aa9b8d623311b35796c01371d3f2712fa9070c03c802cba'
+    url 'https://secure-appldnld.apple.com/STP/041-48448-20190319-3d1eddd6-14ef-4b4d-9a1d-e5462d07403c/SafariTechnologyPreview.dmg'
+    sha256 '595b86d7d33d5cf1e233742472270bfe825c8de2f4b7c8789d9452ba30a32128'
   end
 
   appcast 'https://developer.apple.com/safari/technology-preview/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.