### PR TITLE
Update tor-browser-alpha to 8.5a9

### DIFF
--- a/Casks/tor-browser-alpha.rb
+++ b/Casks/tor-browser-alpha.rb
@@ -1,6 +1,6 @@
 cask 'tor-browser-alpha' do
-  version '8.5a8'
-  sha256 '8c42be56ab9a1141f29172e85a189dafa92d734fbd7eeb28515bf39d08e47ba9'
+  version '8.5a9'
+  sha256 'a5a042aad24ee2105246b4660caa9a4f49080ead61b275fedce5d2ad50a7fcac'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.