### PR TITLE
Update telegram-alpha to 5.0-164279,1957

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.0-164218,1891'
-  sha256 'd66b363a274cb2e5eea26074010c955a81201aacacdf4babfccb8757af28237b'
+  version '5.0-164279,1957'
+  sha256 'f21f2bc9c47790bcf23e6d771f602a092d0aa24670d7493c7b24d71af287e700'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.