### PR TITLE
Update slicer-nightly to 4.11.0.28050,986247

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.11.0.28014,980673'
-  sha256 '5142653662701741bc5e550e9fcc778128223c0f04d73d8c49891364e23350d7'
+  version '4.11.0.28050,986247'
+  sha256 '6bcd221063346283fa84d6615f6703c957675a175a8e306bdba3b95dcba83844'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.