### PR TITLE
Update firefox-esr to 60.6.1

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.6.0'
+  version '60.6.1'
 
   language 'cs' do
-    sha256 '5e61776181169aa2baec72bc95be4682f0e02ab9f05a01a0cea99a4ec65a5913'
+    sha256 '51395a3bfde73fbd3593a0a626a2782d72bb7a0b550222eb45f16f15e5e3cfe7'
     'cs'
   end
 
   language 'de' do
-    sha256 'a64d1ff9a97cbcce8b96d6d2831660b60bc1ef587619e47e64a8d75aeee3f67d'
+    sha256 '2cf1d8e80dc5f648f37b1f3e217404f812b9f73d7803b7ca94929b3ccf8c1b0d'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '7b522275a69be8cb9bba32c9e3e5beba3b9a2015dacc4caabc2b1ef45dfe2546'
+    sha256 'c94e514970ef61f2393415bac185b6a605245abd79eb4134f91467d6caa0cb15'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '9d95386a6ec0d4f1ecf408bb913dc49d40df7e92debd28a7f42ad1351661e82a'
+    sha256 '15e9aea68428bb3941a0330c05ac3b39b59cc3a0a75e1f67c2921c8d881fa92e'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '127bcd53edc9593e4a61a7bebf1aa5a0d551bb63079004b02338739657ef712d'
+    sha256 '5f8be88e683257095d44904891e8b769f8f08b448f0522e4b45e4e9b5c9aed39'
     'fr'
   end
 
   language 'gl' do
-    sha256 'c2e5a2906227469858a64c246a6939054cb6a09bff2d7f36b4bf71f96e1262c4'
+    sha256 'a09a08fdc2697e1a07d469d1ff54b50b1249ab0c1c2928e1b449cb93add2f7e8'
     'gl'
   end
 
   language 'it' do
-    sha256 '974dbb1aa45d8f1b76c6e32d09fd6ba4cefc7f5f5635f984c1c5879a66426bf2'
+    sha256 '36902eecc40fbe92013ba8f3b295a4b1b0dcfce13565335a63173a57414fb982'
     'it'
   end
 
   language 'ja' do
-    sha256 'd5eae331d50ba1d2f417b483638317454b5cace5990c9189879cdf9007c28cbe'
+    sha256 '95a074310a2c595da88aca0cc229171f624e876d6ca5e391dc35a7acaed140f0'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '182ca861b7379ce812810f0b26970896544c8ce9d7bddb889504505eaebc017e'
+    sha256 '6b717793fe7e1c7a7435f21f86d8c323f2834c3408eb869c7c9cc39e0dd6f6ef'
     'nl'
   end
 
   language 'pl' do
-    sha256 '2456181fe1a28dd9cbbfb42bff48ddf766d8f2f209bd6ccb31a6d406f5837f09'
+    sha256 '92599949e24561206df72e62eb13fe8e471db58ca99ea213b7297fbbb3656e6f'
     'pl'
   end
 
   language 'pt' do
-    sha256 '54415605cdd6a8cf2c34a886630b0e1aa130966900db2129b0d7548fc3f50b1d'
+    sha256 '62a5844f38a2f6f040ce7104854f33c069ea28e40d698b53db13c52e09bb71c3'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '44e89fd92a28f3bd59b97ef48db20d53a142c87c6704d87d24e362f635bfba34'
+    sha256 '10548e6e59f4bb4a86fa026bb6a380b72fa9b256e95890c676522dc01f1fadee'
     'ru'
   end
 
   language 'uk' do
-    sha256 '793c1c0e7a0bb2aaffe1714ba5ebd249e026d3af29915e3b22208940f73d9535'
+    sha256 '4f27f1a9a63644a9c9cd07ef9de5d45aae681c8996e0a63969423e9c43f6b45e'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '5603f1a3bba65aa9c4a4e772e9edf53289f7b0904d6a24266e7e183f4812cd82'
+    sha256 'dbbe8bd5314dfe9d92520c0e20bd4aa620bf70f7ce58ffde1c7b1e03286f5431'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'd4dd815ec128e312974ba1eb1e74102dbdd312068e1def20e607c48df18ecb89'
+    sha256 '7385130dac7d7b1575e101a060c8ec1be2fc71e2c22c73ca6285b3adc8b6f44b'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
