### PR TITLE
Update telegram-desktop-dev to 1.6.1

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.6.0'
-  sha256 'ba60fdd937c1255b205a42082ef230235670234719569ec6e46f589151fd97cd'
+  version '1.6.1'
+  sha256 '3d5a0283bfb41493c0f576d3b02f4d92358f452232ae4b9a52b4769648f3d85d'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.