### PR TITLE
Update telegram-alpha to 5.0-164558,1977

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.0-164543,1974'
-  sha256 '3eb2b8c0db92c64fa93f376c5e3c7cfdb427f721f4e7859abeca83add767bc32'
+  version '5.0-164558,1977'
+  sha256 '18aa1d4f0ddb1a26834f80cb5725f56c4f8accdbb8bb4365f78b8e241a96e83e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.