### PR TITLE
Update iterm2-beta to 3.3.0beta1

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.2.8beta1'
-  sha256 '20abcf799810d2592c6052ca35b8b685e9aa5c06afef296ecdf6279624e79b25'
+  version '3.3.0beta1'
+  sha256 '000980a91dc7df8aa843cab1cc142beb48d8dd4be8b7b9d59ce884ce12239076'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.