### PR TITLE
add vuescan-x32 version 9.6.36

### DIFF
--- a/Casks/vuescan-x32.rb
+++ b/Casks/vuescan-x32.rb
@@ -1,0 +1,11 @@
+cask 'vuescan-x32' do
+  version '9.6.36'
+  sha256 :no_check # required as upstream package is updated in-place
+
+  url "https://www.hamrick.com/files/vuex32#{version.major_minor.no_dots}.dmg"
+  appcast 'https://www.hamrick.com/alternate-versions.html'
+  name 'VueScan'
+  homepage 'https://www.hamrick.com/'
+
+  app 'VueScan.app'
+end


### PR DESCRIPTION
This is the 32bit of the latest version of VueScan. Some old scanners only work with this version.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256