### PR TITLE
Update vmware-fusion10 to 10.1.5-10950653

### DIFF
--- a/Casks/vmware-fusion10.rb
+++ b/Casks/vmware-fusion10.rb
@@ -1,6 +1,6 @@
 cask 'vmware-fusion10' do
-  version '10.1.3-9472307'
-  sha256 'ac08b91b7369bd88af62c21b2d2d9f5629eab59da514743acd21e76bcf8b7aac'
+  version '10.1.5-10950653'
+  sha256 '98e7f5877fe025fd08f121a7ac1d58b9aca81c8b0e03ac26c6023caf127f0719'
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
   appcast 'https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
