### PR TITLE
Update atom-beta from 1.36.0-beta1 to 1.36.0-beta2

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,6 +1,6 @@
 cask 'atom-beta' do
-  version '1.36.0-beta1'
-  sha256 'e9f46c419ea42578980762002f8d9fed345d4fc48435d4ebc1ac72bb3fc106c0'
+  version '1.36.0-beta2'
+  sha256 'e0d7e00f8fc0415a0d43eca75edcc420caa33ff5b902f46157389044c4b55a6e'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.