### PR TITLE
Update wine-staging from 4.3 to 4.4

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '4.3'
-  sha256 'c5eedcdc6c52ec2992acf836ed75739665d72fc917e936bd6cbe0d013ea4783e'
+  version '4.4'
+  sha256 '42b6d35b8cc94f604a43ae3e4b54360680d06ff8dd30d3d75ed280422de56eb0'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.