### PR TITLE
Update telegram-alpha to 5.0.1-165362,2002

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.0.1-164802,1995'
-  sha256 '71db95f9f4c478669886f8af3655e22ac1b14a7a44048b9a324df06d69e8e388'
+  version '5.0.1-165362,2002'
+  sha256 'fa87b7940d5538b4bc82ba62c342c0d98db86c305048f9163f8fb41d487c88ef'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.