### PR TITLE
Update microsoft-remote-desktop-beta from 10.2.9.1575,274 to 10.2.10.1582,278

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.9.1575,274'
-  sha256 'd8ed61af9e1aee33c0b09586901b1de9d0cecbceca0d88ea7ea8c7388e192b13'
+  version '10.2.10.1582,278'
+  sha256 '88e37bd805743ede806a1b3eb3f7b01c907f7fb9e1c8e86cdc1d01a45c22bf8c'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.