### PR TITLE
Update 1password-beta from 7.3.BETA-5 to 7.3.BETA-6

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.3.BETA-5'
-  sha256 'e5ca545a89a073476fe47ea635091e46b4c105175c1e01243617c16002b49f9e'
+  version '7.3.BETA-6'
+  sha256 '0db43dca51383854d572e12bde36a2539bc1380cda491bdf6539686b91d9333a'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.