### PR TITLE
Update dropbox-beta from 70.3.87 to 70.3.89

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '70.3.87'
-  sha256 '4ebc8b50ae6e67a79fdf0201ccc3d78b05912d75502025c01d3d5cfa6279640d'
+  version '70.3.89'
+  sha256 'f6a07550abc907cadef1e526ab9930f9fdb7c93d9111fc387c3b980b52797963'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.