### PR TITLE
Add sublime-merge-dev cask

### DIFF
--- a/Casks/sublime-merge-dev.rb
+++ b/Casks/sublime-merge-dev.rb
@@ -1,0 +1,26 @@
+cask 'sublime-merge-dev' do
+  version '1111'
+  sha256 '2d28a7dcc46d5c232d9d07b899fe366cfdfff353d2f36fedf98c38c333347212'
+
+  # download.sublimetext.com was verified as official when first introduced to the cask
+  url "https://download.sublimetext.com/sublime_merge_build_#{version}_mac.zip"
+  appcast 'https://www.sublimemerge.com/updates/dev_update_check'
+  name 'Sublime Merge'
+  homepage 'https://www.sublimemerge.com/dev'
+
+  auto_updates true
+  conflicts_with cask: 'sublime-merge'
+
+  app 'Sublime Merge.app'
+  binary "#{appdir}/Sublime Merge.app/Contents/SharedSupport/bin/smerge"
+
+  uninstall quit: 'com.sublimemerge'
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sublimemerge.sfl*',
+               '~/Library/Application Support/Sublime Merge',
+               '~/Library/Caches/com.sublimemerge/',
+               '~/Library/Preferences/com.sublimemerge.plist',
+               '~/Library/Saved Application State/com.sublimemerge.savedState',
+             ]
+end


### PR DESCRIPTION
Add `sublime-merge-dev` cask analogues to `sublime-text-dev`

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name ~~and version~~.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].