### PR TITLE
Update dropbox-beta from 70.3.89 to 71.3.99

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '70.3.89'
-  sha256 'f6a07550abc907cadef1e526ab9930f9fdb7c93d9111fc387c3b980b52797963'
+  version '71.3.99'
+  sha256 '21e4d99318cf2efded5e416eb4f6ea98d3834062ae94a86ca39da1d1adf911d7'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.