### PR TITLE
Update telegram-alpha from 5.0.1-165881,2015 to 4.0.1-166086,2020

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.0.1-165881,2015'
-  sha256 'a119ab0bd4095c5972a5063e2d28a0ff4cf1e45a8b02fcbf8bcd3cffee2d6426'
+  version '4.0.1-166086,2020'
+  sha256 'bfa00b0e6b2d3ae35e74268f47f80bbef600de891831fc23f41fabfa8c2e73bf'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.