### PR TITLE
Update telegram-alpha from 5.0.1-166284,2021 to 5.0.1-166295,2022

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.0.1-166284,2021'
-  sha256 '73ea9867fbb9094ad86286bd2833cb4e000ce391d3f4b648459e66dc66a47611'
+  version '5.0.1-166295,2022'
+  sha256 'deffd0d9091e2cf2106aa64532616bef8990c39cadfd8a68cfa80b4e534a3ee3'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.