### PR TITLE
Update telegram-alpha from 5.0.1-166295,2022 to 5.0.1-166399,2028

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.0.1-166295,2022'
-  sha256 'deffd0d9091e2cf2106aa64532616bef8990c39cadfd8a68cfa80b4e534a3ee3'
+  version '5.0.1-166399,2028'
+  sha256 'bc8cf3f3be3af415ccf74bbb334c0b740020039179dd2528087e26f0408a33d1'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.