### PR TITLE
Update slack-beta from 3.4.0-beta1 to 3.4.0-beta2

### DIFF
--- a/Casks/slack-beta.rb
+++ b/Casks/slack-beta.rb
@@ -1,6 +1,6 @@
 cask 'slack-beta' do
-  version '3.4.0-beta1'
-  sha256 'ce70d82de826874eb4f2f317dc3ba4b32b7fd6904754c013fe1e1f10e1cf39d1'
+  version '3.4.0-beta2'
+  sha256 '31a864025a8f777e9598ffa334207523de121b8eab86cc953f64471853f76ffd'
 
   # downloads.slack-edge.com was verified as official when first introduced to the cask
   url "https://downloads.slack-edge.com/mac_releases_beta/Slack-#{version}-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.