### PR TITLE
Update telegram-alpha from 5.1-166633,2039 to 5.1-166742,2041

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.1-166633,2039'
-  sha256 '7e2511de775e6f891a14c3385c8870fbe6fa36af3b65a61858e09e2d82b179f4'
+  version '5.1-166742,2041'
+  sha256 'a0af64b46405e72093155f1290cf1b75a5b4b3baa8dd30e359a07a8488afd5ad'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.