### PR TITLE
Update telegram-alpha from 5.1-166742,2041 to 5.1-166765,2042

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.1-166742,2041'
-  sha256 'a0af64b46405e72093155f1290cf1b75a5b4b3baa8dd30e359a07a8488afd5ad'
+  version '5.1-166765,2042'
+  sha256 '1783ba92d050726bf232cdebf98f975450589cc3054467b44813198002ae1d88'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.