### PR TITLE
Update telegram-alpha from 5.1-166765,2042 to 5.1.1-166795,2044

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.1-166765,2042'
-  sha256 '1783ba92d050726bf232cdebf98f975450589cc3054467b44813198002ae1d88'
+  version '5.1.1-166795,2044'
+  sha256 'e77da12106c9d0fe17928c9c7ab57f969a0eeba717973c543da7dfee9e91de14'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.