### PR TITLE
Update 1password-beta from 7.3.BETA-8 to 7.3.BETA-10

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.3.BETA-8'
-  sha256 '3b5d0cfbf8e63feccf2b4756000dad3fdd2a692f61ebbdbb33c9dfdc195a39a0'
+  version '7.3.BETA-10'
+  sha256 '1ef424a24add6a7fdee7965df2205d643cd49f8163a3fff51eac743c37eea483'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.