### PR TITLE
Update telegram-alpha from 5.1.1-167004,2048 to 5.1.1-167211,2052

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.1.1-167004,2048'
-  sha256 '59f09259e910d76fefa6e44a6d4b48050eed5215226d1221988451930f1742d7'
+  version '5.1.1-167211,2052'
+  sha256 '30f9bc66fb7b5968b495916e2e1ca64e1ebde00acd34df157735661daf48867d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.