### PR TITLE
Update 1password-beta from 7.3.BETA-10 to 7.3.BETA-11

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.3.BETA-10'
-  sha256 '1ef424a24add6a7fdee7965df2205d643cd49f8163a3fff51eac743c37eea483'
+  version '7.3.BETA-11'
+  sha256 'da3f84cdf05236142345d04880b7dcd0c44c616a7c64347b77aea2e9e2ea983b'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.