### PR TITLE
Update telegram-alpha from 5.1.1-167211,2052 to 5.1.1-167328,2054

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.1.1-167211,2052'
-  sha256 '30f9bc66fb7b5968b495916e2e1ca64e1ebde00acd34df157735661daf48867d'
+  version '5.1.1-167328,2054'
+  sha256 'd6aff5845cc2ce22a3f1d0920eaeb3ecad75d1cca4e30e53bd58c7c32d68ab89'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.