### PR TITLE
Update microsoft-remote-desktop-beta from 10.2.10.1582,278 to 10.2.12.1587,281

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.2.10.1582,278'
-  sha256 '88e37bd805743ede806a1b3eb3f7b01c907f7fb9e1c8e86cdc1d01a45c22bf8c'
+  version '10.2.12.1587,281'
+  sha256 '8133be48f6105ae82bc6d6089b1429b455aa8bc24dbe23d5b39cd3211756eb1b'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.