### PR TITLE
Update slicer-nightly from 4.11.0.28129,999837 to 4.11.0.28138,1001140

### DIFF
--- a/Casks/slicer-nightly.rb
+++ b/Casks/slicer-nightly.rb
@@ -1,6 +1,6 @@
 cask 'slicer-nightly' do
-  version '4.11.0.28129,999837'
-  sha256 '11d000b24d904e95af8ec0cf154e41392443475a7153b3b184b7e0ed8b5a3d84'
+  version '4.11.0.28138,1001140'
+  sha256 '4b9a039ea65a4e904e07d675835054063c81d2d7dff8375bc1f54b69fb726bb1'
 
   # slicer.kitware.com/midas3 was verified as official when first introduced to the cask
   url "https://slicer.kitware.com/midas3/download?bitstream=#{version.after_comma}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.