### PR TITLE
Upgrade Lilypond.app to v2.19.83

### DIFF
--- a/Casks/lilypond-dev.rb
+++ b/Casks/lilypond-dev.rb
@@ -1,6 +1,6 @@
 cask 'lilypond-dev' do
-  version '2.19.82-1'
-  sha256 '558ffac7ba7543b39f2f87ed4a4141a29951d44772893c9af89a89ed33f16176'
+  version '2.19.83-1'
+  sha256 '15e763e908d1371fb3f8151f73ece23bdd8ea7bc757f427f067d8418659c15c3'
 
   url "http://lilypond.org/downloads/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
   name 'LilyPond'


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

