### PR TITLE
Update java8.rb

### DIFF
--- a/Casks/java8.rb
+++ b/Casks/java8.rb
@@ -1,7 +1,6 @@
 cask 'java8' do
-  version '8u202,b08:1961070e4c9b4e26a04e7f5a083f551e'
-  sha256 'b41367948cf99ca0b8d1571f116b7e3e322dd1ebdfd4d390e959164d75b97c20'
-
+  version '8u212,b10:59066701cf1a433da9770636fbc4c9a'
+  sha256 'cdc6799eb1d98da541a91b70400f84f031cff04f30fb0865ad8f820771daade6'
   url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}-#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}-macosx-x64.dmg",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
@@ -11,7 +10,7 @@ cask 'java8' do
 
   depends_on macos: '>= :yosemite'
 
-  pkg 'JDK 8 Update 202.pkg'
+  pkg 'JDK 8 Update 212.pkg'
 
   uninstall pkgutil: "com.oracle.jdk#{version.before_comma}",
             delete:  [

--- a/Casks/java8.rb
+++ b/Casks/java8.rb
@@ -1,7 +1,7 @@
 cask 'java8' do
   version '8u212,b10:59066701cf1a433da9770636fbc4c9a'
   sha256 'cdc6799eb1d98da541a91b70400f84f031cff04f30fb0865ad8f820771daade6'
-  url "https://download.oracle.com/otn-pub/java/jdk/#{version.before_comma}-#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}-macosx-x64.dmg",
+  url "https://download.oracle.com/otn/java/jdk/#{version.before_comma}-#{version.after_comma.before_colon}/#{version.after_colon}/jdk-#{version.before_comma}-macosx-x64.dmg",
       cookies: {
                  'oraclelicense' => 'accept-securebackup-cookie',
                }


### PR DESCRIPTION
The download URL for the package has changed on Oracle's website. Specifically, the subdirectory "otn-pub" has changed to "otn".

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
