### PR TITLE
Update pext-nightly.rb

### DIFF
--- a/Casks/pext-nightly.rb
+++ b/Casks/pext-nightly.rb
@@ -1,15 +1,10 @@
 cask 'pext-nightly' do
-  version :latest
+  version :0.23.15.gac9a6bd
   sha256 :no_check
 
   # github.com/Pext/Pext was verified as official when first introduced to the cask
-  url do
-    require 'open-uri'
-    require 'json'
-
-    JSON.parse(open('https://api.github.com/repos/Pext/Pext/releases/tags/continuous').read)['assets']
-        .find { |r| r['browser_download_url'] =~ %r{/.*\.dmg} }['browser_download_url']
-  end
+  url "https://github.com/Pext/Pext/releases/download/continuous/Pext-#{version}.dmg"
+  appcast 'https://github.com/Pext/Pext/releases.atom'
   name 'Pext'
   homepage 'https://pext.io/'
 


### PR DESCRIPTION
Adherence to pass 'brew cask style pext-nightly.rb'. Not as efficient as parsing a page or directory but sufficient until a proper patch is applied if wanting to always retrieve the latest beta/dev version for Pext.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
