### PR TITLE
Update sublime-text-dev from 3.206 to 3208

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,6 +1,6 @@
 cask 'sublime-text-dev' do
-  version '3.206'
-  sha256 'eca30d5bcb4017c60dd89d4161e57715c04bd8b334ea6b06e6667953d8e3be42'
+  version '3.208'
+  sha256 '029121c0ff072a99a412ec53fc798c87d50fee71de09bbd7547006539f801a61'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
   appcast "https://www.sublimetext.com/updates/#{version.major}/dev/appcast_osx.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.