### PR TITLE
Update rstudio-preview from 1.2.1502 to 1.2.1511

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1502'
-  sha256 '7518a7c4f71d50f18792150d83eff0d299d20023189fb746ac69f0fe97ebe868'
+  version '1.2.1511'
+  sha256 'ea52e682245f871361454b2fe6b2be4922b6391ef3d9b69165bebfd0403fa842'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.