### PR TITLE
Update visual-studio-code-insiders from 1.34.0,b7c5e104a44b65e937408a10cbb8b49d6dfd19bf to 1.34.0,c1abf7978d59415dcfcf8cfcb15e0ee30c5e45a5

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.34.0,b7c5e104a44b65e937408a10cbb8b49d6dfd19bf'
-  sha256 'e8e55d7397437fa4b7105c2d2c635c8a278cbfa21b606c0d8655171bf047c991'
+  version '1.34.0,c1abf7978d59415dcfcf8cfcb15e0ee30c5e45a5'
+  sha256 'd677830481b96ef31b2be79bf04e2fca45832b32c6bef13313a211104a3c2a01'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.