### PR TITLE
Update telegram-alpha from 5.2-169847,2070 to 5.2-169883,2071

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2-169847,2070'
-  sha256 '32d996e9fa8cba64954a2d66834d483bc8d3a7d2b5e3f7ef931dfcc6c8080a75'
+  version '5.2-169883,2071'
+  sha256 'd7d40d0f087a900e43e08349440cc83f801addd729b773a8b7f4b8bd8ea75c09'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.