### PR TITLE
Update dropbox-beta from 72.3.127 to 72.3.132

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '72.3.127'
-  sha256 '6537a15bc12ebdd4640d065149b20fd5c672831065f122629dac616ed6f4c29f'
+  version '72.3.132'
+  sha256 '632f029f220fd0e379dd3270eafe7b9170f6616c2983ceaa5b7b144f36be0481'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.