### PR TITLE
Add Kitematic version 0.17.6

### DIFF
--- a/Casks/kitematic0176.rb
+++ b/Casks/kitematic0176.rb
@@ -1,0 +1,22 @@
+cask 'kitematic0176' do
+  version '0.17.6'
+  sha256 '827756c4b7de7b23b474aba12ed2b4a333d3a5f1b2fad5bc5819da405d72ed83'
+
+  # github.com/docker/kitematic was verified as official when first introduced to the cask
+  url "https://github.com/docker/kitematic/releases/download/v#{version}/Kitematic-#{version}-Mac.zip"
+  appcast 'https://github.com/docker/kitematic/releases.atom'
+  name 'Kitematic'
+  homepage 'https://kitematic.com/'
+
+  app 'Kitematic.app'
+
+  zap trash: [
+               '~/Kitematic',
+               '~/Library/Application Support/Kitematic',
+               '~/Library/Caches/Kitematic',
+               '~/Library/Logs/Kitematic',
+               '~/Library/Preferences/com.electron.kitematic.plist',
+               '~/Library/Preferences/com.electron.kitematic.helper.plist',
+               '~/Library/Saved Application State/com.electron.kitematic.savedState',
+             ]
+end


### PR DESCRIPTION
Install Kitematic version 0.17.6.  Kitematic version 0.17.7 has an
unfixed bug that prevents it from displaying any logs from a containter.
The recommended workaround is to uninstall that version and to install
an older version. Kitematic version 0.17.6 does not have that particular
issue.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
