### PR TITLE
Update telegram-alpha from 5.2-169893,2073 to 5.2-169906,2074

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2-169893,2073'
-  sha256 '0eb593306507e8ace154c760bf3911854ce9f6e77ae425502ec93aca81e71eaa'
+  version '5.2-169906,2074'
+  sha256 '6266180a97a4ebf5ea71ab8c6171f1b48cf5c5325bea2b116efef3638c63e42b'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.