### PR TITLE
Update dotnet-sdk-preview from 3.0.100-preview3-010431 to 3.0.100-preview5-011568

### DIFF
--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk-preview' do
-  version '3.0.100-preview3-010431'
-  sha256 '812827b5a7a38124a6f449ebe52ecbd17a485864849b637424d3660c7bc28e43'
+  version '3.0.100-preview5-011568'
+  sha256 '42b04e419ca1f4b9a95836d3663f94dd4113a755f808a30a93988fe8e6e4a16e'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/5f0daf69-7f98-4fa1-96a3-e76b4968b20d/58416a5d79bb578456beb80725c88bd7/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.visualstudio.microsoft.com/download/pr/afcef2c8-471f-48aa-8030-010fb6c8517b/75a05bc56f2849f80d5ca7b834bb8722/dotnet-sdk-#{version}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'
@@ -16,7 +16,10 @@ cask 'dotnet-sdk-preview' do
 
   pkg "dotnet-sdk-#{version}-osx-x64.pkg"
 
-  uninstall pkgutil: 'com.microsoft.dotnet.*',
+  uninstall pkgutil: [
+                       'com.microsoft.dotnet.*',
+                       'com.microsoft.netstandard.*',
+                     ],
             delete:  '/etc/paths.d/dotnet'
 
   zap trash: '~/.nuget'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.