### PR TITLE
Update telegram-alpha from 5.2-169906,2074 to 5.2-170000,2078

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2-169906,2074'
-  sha256 '6266180a97a4ebf5ea71ab8c6171f1b48cf5c5325bea2b116efef3638c63e42b'
+  version '5.2-170000,2078'
+  sha256 '715448ffb8c4297a83efac3a1eea9ea7283fe503883a3aa97303856fcaabbc96'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.