### PR TITLE
Update firefox-esr from 60.6.2 to 60.6.3

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.6.2'
+  version '60.6.3'
 
   language 'cs' do
-    sha256 'c8b7d987ca2ab4b75427ed500e0577d2ac8e5569d52463cf1e5ca290c14f8424'
+    sha256 '237a80ab9bb52e40ea1e560582b2b2ba3cbd431d559ff62f607cc815fab457a1'
     'cs'
   end
 
   language 'de' do
-    sha256 'ca5540dfa97475f5628e487316029693e74f68f8983bdc7c5f750fce26c9ffe5'
+    sha256 '8a7d733a90e04e3bfff03f0d8d32b8333287d2182b83c28c396f6bf4363555da'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '1eae30a5545b66495132c08410fa7659713e627e20d62e54ce56ccc6978e6c05'
+    sha256 'd99604ea09524ca5fc71c99a1c1f3f05e4d9c661afffdcf884a83a4429d8075b'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'dbeb0403e9a35ceabf509bbcb8a4e1d049703e481133120b72d3ce3ff4b0d6d2'
+    sha256 'aed4bd947437173409ce8043441c03c48e746a52f1a4ff1f7a15949345a06fc6'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'bb679a2800c1cc78e54e325e21d49d9949cd7bf7a3341429ee35b44f54ba8978'
+    sha256 '3f803afd10ca5b76a44f08b0e688f55c8e7f6142356135eff033584481be0f70'
     'fr'
   end
 
   language 'gl' do
-    sha256 'e6709c1d5c4c27a173f5844265e3e09cb5f3e3ae3caadaa1658b65f79b134bae'
+    sha256 'e267ec4c678639ec48e5a99bcba0ed6c6f07446b44a419f68416994681c32959'
     'gl'
   end
 
   language 'it' do
-    sha256 '3a9df2a1ffd68574becd08bf377b3e45c37b8e6db16de2019713b4df74d57dc2'
+    sha256 '7277bb114461e10dc00d08da6da518633163110d208bffd178621e7f9302fdb8'
     'it'
   end
 
   language 'ja' do
-    sha256 'ca045ed88e3dc7456a62d81b75f1cae0db7bacde9ffb7cd1c26681e3cb45a4f3'
+    sha256 'caa49244b8994f951626a6451a774f19c3e68263d947b8f40d7b738c4564a98c'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '814643a9c94c401bf8933853b411704dc1dba6225cf2c2434cc5e70b8c6bc515'
+    sha256 'd071400f4cbd23c8625e36143bbd230489b181f3cf157d981600287b4192cef9'
     'nl'
   end
 
   language 'pl' do
-    sha256 '06bd13f3d89edcec76bbb125b18bff17da15b4994046d3390ee3e583853ffc1a'
+    sha256 'af56981aac1ce8a63fbac456f41d20a2a7879ca8d35cdf27a34a9b8fd1216a03'
     'pl'
   end
 
   language 'pt' do
-    sha256 'd36b94fb5214fcaf3fb5d1e0b64eb21fcf72095b9b03250c1c85acf27b4f40c5'
+    sha256 '0ad452028ec2828e4beab4fc79805e6be46efa684d1bb213ce8c5de775df537a'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'f73606c5555a9ce94aca93b9eee46ed0ee85b6dffb3929c88c97eb694d4db3d7'
+    sha256 '074ec32cc4905109b2fd466534206056404583652ac8129b1abd5c7ddfa689bd'
     'ru'
   end
 
   language 'uk' do
-    sha256 '5e7a9e5f067b6247f6c9fdb8e93f570efbba49cf6ca9a2cdb57f64facf1acd0d'
+    sha256 'eaecbaefc8bff7efc8d73303f82899bc5b06c541b9530ff8d1e1eea894871327'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '2b3fd625408fbf24e811edf9e281ee0b02fb4eeb5cfd058962fcdf9fcca130b8'
+    sha256 'ff70fce9c3ad8e29a5965e72dd56d19cfeacfa32bd9db63f7750b782ab48151a'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '564cc58bc0f832632261330afa28f92d21bc770d44de5d4942d894b796d94d22'
+    sha256 '129f0277c3fe24cd5a8ef1a8e1a64d90f649845c856e80094b9f84ec4573905e'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
