### PR TITLE
Update telegram-alpha from 5.2-170000,2078 to 5.2-170060,2080

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2-170000,2078'
-  sha256 '715448ffb8c4297a83efac3a1eea9ea7283fe503883a3aa97303856fcaabbc96'
+  version '5.2-170060,2080'
+  sha256 '4e164e7f0c911555fda6b8c3c4272ea6105c2a3789e176b45ae3bcea322d4c37'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.