### PR TITLE
Update telegram-alpha from 5.2-170176,2082 to 5.2-170188,2083

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2-170176,2082'
-  sha256 '6a35445ded67155665eed407a9920000580a3274a8d43ad5c3726a88ca7ea9d0'
+  version '5.2-170188,2083'
+  sha256 '80d0bbcf5b4358ad3ae1159c4bef4846bb81a968ddb221c820b1e60cde240939'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.