### PR TITLE
Update audirvana-plus2 to version 2.6.9

### DIFF
--- a/Casks/audirvana-plus2.rb
+++ b/Casks/audirvana-plus2.rb
@@ -1,5 +1,5 @@
 cask 'audirvana-plus2' do
-  version '2.6.8'
+  version '2.6.9'
   sha256 '7db18cdd2754c2d366a840dea937e21a86fd73d1fbaf1214aaf517e85a81256a'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"


### PR DESCRIPTION
Because audirvana-plus2 failed to install I checked whats happening.  Version 2.6.8 is not available anymore and got replaced by version 2.6.9.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).