### PR TITLE
Update audirvana-plus2 from 2.6.8 to 2.6.9

### DIFF
--- a/Casks/audirvana-plus2.rb
+++ b/Casks/audirvana-plus2.rb
@@ -3,6 +3,7 @@ cask 'audirvana-plus2' do
   sha256 'bb3e4c39bcb98d8c59e42bc3cda488a02774eb504c3969b6c18a7e40c1bdd464'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"
+  appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_appcast.xml"
   name "Audirvana Plus #{version.major}"
   homepage 'https://audirvana.com/'
 

--- a/Casks/audirvana-plus2.rb
+++ b/Casks/audirvana-plus2.rb
@@ -1,9 +1,8 @@
 cask 'audirvana-plus2' do
-  version '2.6.8'
-  sha256 '7db18cdd2754c2d366a840dea937e21a86fd73d1fbaf1214aaf517e85a81256a'
+  version '2.6.9'
+  sha256 'bb3e4c39bcb98d8c59e42bc3cda488a02774eb504c3969b6c18a7e40c1bdd464'
 
   url "https://audirvana.com/delivery/AudirvanaPlus_#{version}.dmg"
-  appcast "https://audirvana.com/delivery/audirvanaplus#{version.major}_appcast.xml"
   name "Audirvana Plus #{version.major}"
   homepage 'https://audirvana.com/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.