### PR TITLE
Update telegram-desktop-dev from 1.6.7 to 1.7.0

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.6.7'
-  sha256 'c7bd95f6c81efaf899437ce14148678d67cb31d73c1a25dae286f434931f6335'
+  version '1.7.0'
+  sha256 'f2c8dc057dbba2899af9abd42696cc62a4cdd60850ce1702b16aa16811ca9b34'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.