### PR TITLE
Update 1password-beta from 7.3.BETA-11 to 7.3.BETA-13

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.3.BETA-11'
-  sha256 'da3f84cdf05236142345d04880b7dcd0c44c616a7c64347b77aea2e9e2ea983b'
+  version '7.3.BETA-13'
+  sha256 'cc2d468d2a3257e24693d5ca0ee702e1cfb984743a4cc6d55f0248ec300a0d57'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.