### PR TITLE
Update wine-staging from 4.7 to 4.8

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '4.7'
-  sha256 'd2e537af4c553a6727b109000617a83041f9cf4b0286a41dccf70911f6e7a7f7'
+  version '4.8'
+  sha256 'c361ca89d26895f6b8e47c7f2425e460d325a6dab89bc57f36dd9d56a10a74d0'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.