### PR TITLE
Update telegram-alpha from 5.2-170335,2088 to 5.2-170402,2089

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2-170335,2088'
-  sha256 '6a550b4b48f768d3c78690bc4b83a0e042a9b969a2f90b6d71e7efcf98f937ce'
+  version '5.2-170402,2089'
+  sha256 '34bc144bcd900fede36d8cda649938027685e32b31e7ee866f635a4975adc0ae'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.