### PR TITLE
Update tunnelblick-beta from 3.7.9beta09,5290 to 3.7.9beta11,5310

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick-beta' do
-  version '3.7.9beta09,5290'
-  sha256 '1e37eef81f99333a31900419d897d6a4c282472c08f975d9a542ab316e453170'
+  version '3.7.9beta11,5310'
+  sha256 '52e0826b352d18d3a2329032d92d40c36da8175fb19102d0df5c87227ec638cc'
 
   # github.com/Tunnelblick/Tunnelblick was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.