### PR TITLE
Update safari-technology-preview from 81,041-59125-20190501-80842936-1ceb-4586-8a00-a4a2d2a54751 to 82

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '81,041-59125-20190501-80842936-1ceb-4586-8a00-a4a2d2a54751'
+  version '82'
 
   if MacOS.version <= :high_sierra
     url 'https://secure-appldnld.apple.com/STP/041-58764-20190501-d28417f0-1e4c-4abb-9cdf-b469cf8c1b48/SafariTechnologyPreview.dmg'
     sha256 'a54adcc8112eec0e31c0c7e8858b3f73e924ae1a97482d153b92201f2753f8ce'
   else
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 '3aa1008425146f4d17b7f4601c39ea895c542bf73f1cb919bfa7e9f6e525baf7'
+    sha256 'b3762454597c1bd7ece748880d4247a73f3c3b879b9023d6c2e444c2889e28f4'
   end
 
   appcast 'https://developer.apple.com/safari/technology-preview/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.