### PR TITLE
Update telegram-alpha from 5.2.1-170463,2093 to 5.2.1-170738,2096

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2.1-170463,2093'
-  sha256 '29558875f60a93e8ea41832ac77265db85c939f1f776d6d1883455b12573cd64'
+  version '5.2.1-170738,2096'
+  sha256 'f748b9f911a3a85ee977e5c3accc04579dedf82f1a2844ab3e9ed3d92053665c'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.