### PR TITLE
Update telegram-alpha from 5.2.1-170738,2096 to 5.2.1-170741,2097

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2.1-170738,2096'
-  sha256 'f748b9f911a3a85ee977e5c3accc04579dedf82f1a2844ab3e9ed3d92053665c'
+  version '5.2.1-170741,2097'
+  sha256 '9f955145c6a1121bd46660bf53f112a99e61d19e6eea904e7c7f73cf6e19e56d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.