### PR TITLE
Update and rename adoptopenjdk8.rb to openjdk8.rb

### DIFF
--- a/Casks/openjdk8.rb
+++ b/Casks/openjdk8.rb
@@ -1,4 +1,4 @@
-cask 'adoptopenjdk8' do
+cask 'openjdk8' do
   version '8,212:b03'
   sha256 'd0e4265b151d87235a74e354725fdc218d60abb06c253af0993fd2fcf4c3a355'
 


### PR DESCRIPTION
As discussed with several people the plan is move the adoptopenjdk casks over to cask-versions and rename them to be `openjdk<version>`. In turn we will deprecate the casks on our side with a message pointing to now download them from cask-versions.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
