### PR TITLE
Update iterm2-beta from 3.3.0beta7 to 3.3.0beta8

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.0beta7'
-  sha256 '6a8acffbc8f67e8063bdd0546edd83c57fef340bc858849dcd9a2b8db47a5bed'
+  version '3.3.0beta8'
+  sha256 'd9a650729d6c5a55b87a94ef287006b53afe1c35ba942d89400563b4489c8270'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.