### PR TITLE
Update telegram-alpha from 5.2.2-170868,2099 to 5.2.2-170933,2101

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2.2-170868,2099'
-  sha256 '4985cf5a071cfd560e7c653a4404277aa25e8eb210fc8a776fad195eb374866a'
+  version '5.2.2-170933,2101'
+  sha256 '7014c84c29f6eccb922a2d281c86c3fc23d1f44b26dcb4c0af79188fcfa688dc'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.