### PR TITLE
Update firefox-esr from 60.6.3 to 60.7.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.6.3'
+  version '60.7.0'
 
   language 'cs' do
-    sha256 '237a80ab9bb52e40ea1e560582b2b2ba3cbd431d559ff62f607cc815fab457a1'
+    sha256 '3627403ccf4d42175a58d87975e94ca8b86259dbc7b725ecb42ad39662851f31'
     'cs'
   end
 
   language 'de' do
-    sha256 '8a7d733a90e04e3bfff03f0d8d32b8333287d2182b83c28c396f6bf4363555da'
+    sha256 '62ce1817788862497663da64e86a8a193429bad7a4935a67df0d3816ea2a63f4'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'd99604ea09524ca5fc71c99a1c1f3f05e4d9c661afffdcf884a83a4429d8075b'
+    sha256 '8d36b66b74e99bf9923cc115125da8b23d66d1538b8996aa5065219f63e8ac86'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'aed4bd947437173409ce8043441c03c48e746a52f1a4ff1f7a15949345a06fc6'
+    sha256 '98cfec127db5dbcb352306851e6292af11efc0b0c0780ba076d3747521a6f015'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '3f803afd10ca5b76a44f08b0e688f55c8e7f6142356135eff033584481be0f70'
+    sha256 '129a28d70d04331a0e4ae5c2a698eca12e28396e60245156719e1c8500b9a35d'
     'fr'
   end
 
   language 'gl' do
-    sha256 'e267ec4c678639ec48e5a99bcba0ed6c6f07446b44a419f68416994681c32959'
+    sha256 'ca85001737ffa95bdd0a4b061635896c446f44be9f53570c127bf6fd4b88476a'
     'gl'
   end
 
   language 'it' do
-    sha256 '7277bb114461e10dc00d08da6da518633163110d208bffd178621e7f9302fdb8'
+    sha256 '3614dd17e41e6e939e76ebf1fd0906ebc165658c0a80e626717029898ce258bb'
     'it'
   end
 
   language 'ja' do
-    sha256 'caa49244b8994f951626a6451a774f19c3e68263d947b8f40d7b738c4564a98c'
+    sha256 'c643dfe84b1706abc519aa6879c298f79b18c2c6e05bb2c5b72694ebcb559eca'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 'd071400f4cbd23c8625e36143bbd230489b181f3cf157d981600287b4192cef9'
+    sha256 '8bdbf1385cac63b5057fe42ea71fc98ae5b36ad6550b5e1fb3fb8f11a0cdd356'
     'nl'
   end
 
   language 'pl' do
-    sha256 'af56981aac1ce8a63fbac456f41d20a2a7879ca8d35cdf27a34a9b8fd1216a03'
+    sha256 '09237db7636d653455497009b7ff0a0839c7cce77e5ff8f58cab2ed4c7cd69c1'
     'pl'
   end
 
   language 'pt' do
-    sha256 '0ad452028ec2828e4beab4fc79805e6be46efa684d1bb213ce8c5de775df537a'
+    sha256 'f5e83652465e3bb3b905bb88bcf59e4bcfc76c1e5675ab744cab5e5a072a2418'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '074ec32cc4905109b2fd466534206056404583652ac8129b1abd5c7ddfa689bd'
+    sha256 '101dc850019656ff851cebb7e98b130260d333f310e5aa06dee5f20d3bb1307c'
     'ru'
   end
 
   language 'uk' do
-    sha256 'eaecbaefc8bff7efc8d73303f82899bc5b06c541b9530ff8d1e1eea894871327'
+    sha256 'c5ad2006b00cc133febf022e2ba350bd50efbf80085bdd34a15ca5bf9b1bd0fa'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'ff70fce9c3ad8e29a5965e72dd56d19cfeacfa32bd9db63f7750b782ab48151a'
+    sha256 'ff1b083a804e965a9996178f2065dc64fd899b198dc4520b67d9c4e522d76076'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '129f0277c3fe24cd5a8ef1a8e1a64d90f649845c856e80094b9f84ec4573905e'
+    sha256 'c49aa3d03e084ee3dc3e34db3e6bd83a73a02dd8d9161ea2e8ae3751faec268c'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
