### PR TITLE
Update slack-beta from 3.4.1 to 3.4.2-beta4

### DIFF
--- a/Casks/slack-beta.rb
+++ b/Casks/slack-beta.rb
@@ -1,6 +1,6 @@
 cask 'slack-beta' do
-  version '3.4.1'
-  sha256 'fb791c152975a49a40cd1efaf28b7b932ec3f59a2c26d4e5541aac264cc8a2a4'
+  version '3.4.2-beta4'
+  sha256 'eb72ec9ef91688b70f3c0cc191e989d8270db92dedefa724ca0f57e7f9f9ae62'
 
   # downloads.slack-edge.com was verified as official when first introduced to the cask
   url "https://downloads.slack-edge.com/mac_releases_beta/Slack-#{version}-macOS.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.