### PR TITLE
Update telegram-alpha from 5.2.2-170995,2103 to 5.2.2-171175,2105

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2.2-170995,2103'
-  sha256 '5612a33f6ddd1657a2cb06cb2bb3e5fa41b3f6fc23ba366ec0b51bf0f31d3de8'
+  version '5.2.2-171175,2105'
+  sha256 '0ff65203db71619e7c8ec1ed97e99e46372a9a15266675ca6f6871858c7a1184'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.