### PR TITLE
Update wine-devel from 4.8 to 4.9

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '4.8'
-  sha256 'b018eea2c52a67dd8fcfadefdba4bc0782da1c3c2cfb10e8602c4f99f2dd37e1'
+  version '4.9'
+  sha256 'a2a419d15cd2e5f627f68a765c2824585a28b1e3a798b2dc2572f7e4dd21a100'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.