### PR TITLE
Update iterm2-beta from 3.3.0beta8 to 3.3.0beta9

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.0beta8'
-  sha256 'd9a650729d6c5a55b87a94ef287006b53afe1c35ba942d89400563b4489c8270'
+  version '3.3.0beta9'
+  sha256 '341a10ea7130478a7f37bee8ab907d57662dbb0923115c0ea705393abf3b5a6c'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.