### PR TITLE
Update telegram-alpha from 5.2.2-171179,2107 to 5.3-171385,2108

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.2.2-171179,2107'
-  sha256 'b9da02bc4761ccbc6319477afd0b1127b4974e163569282994c844a6775fd0b0'
+  version '5.3-171385,2108'
+  sha256 '383ad324a410f21947b72cba97cc2cdb2f4887e67d6615469000577e172c9728'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.