### PR TITLE
Update telegram-alpha from 5.3-171406,2109 to 5.3-171420,2111

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.3-171406,2109'
-  sha256 '04210b06d55320afd4b5c968e752c54ee227e7f573475a98033c8f5711ef17cf'
+  version '5.3-171420,2111'
+  sha256 '975b4ba8d6a90fa60ff335322f54d1ee00b8949ebc52050ac7f3af8f8815a58e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.