### PR TITLE
Update safari-technology-preview from 82,041-62874-20190514-dcb3b57a-1ea8-4753-81fe-673bc547318d to 83,041-67306-20190528-a2075346-5c3d-4fa2-89a3-06112c6c6eee

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '82,041-62874-20190514-dcb3b57a-1ea8-4753-81fe-673bc547318d'
+  version '83,041-67306-20190528-a2075346-5c3d-4fa2-89a3-06112c6c6eee'
 
   if MacOS.version <= :high_sierra
     url 'https://secure-appldnld.apple.com/STP/041-62843-20190514-272a49d7-cb29-4b4a-843d-b41160eb862c/SafariTechnologyPreview.dmg'
     sha256 'cf1ace8f8adc851652933cdb45c5378676a037acbcb5e1e93fd18b66e8f619b2'
   else
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 '7d68a57bc6f83aa5b4f071d33379b650c878d9e0896c2201483d51ad51c11f7c'
+    sha256 '06b0477fdd384cab04e98272a30923e9347212ac8fc0cd3d05c252cf2f708a04'
   end
 
   appcast 'https://developer.apple.com/safari/technology-preview/release-notes/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.