### PR TITLE
Update julia-nightly from 1.2 to 1.3

### DIFF
--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -1,5 +1,5 @@
 cask 'julia-nightly' do
-  version '1.2'
+  version '1.3'
   sha256 :no_check # required as upstream package is updated in-place
 
   url 'https://julialangnightlies-s3.julialang.org/bin/mac/x64/julia-latest-mac64.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.