### PR TITLE
Update telegram-alpha from 5.3-171628,2120 to 5.3-171636,2121

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.3-171628,2120'
-  sha256 '6997259ff0ea24b8032ff3a2a6c4608f3cf89f82d544cc4cbec5745b077886b8'
+  version '5.3-171636,2121'
+  sha256 '3564b1552626f113666b3d42d5c4a3940776ae6ea134e5589f1ac129efa2bf8f'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.