### PR TITLE
Update visual-studio-code-insiders from 1.35.0,2737cde4facc8411982862742f5c6cd3dabef323 to 1.35.0,0284236851a94b116f468345f6e98688a737015d

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.35.0,2737cde4facc8411982862742f5c6cd3dabef323'
-  sha256 'fea072d1b6d855b87cbba49cb789ce165ae13fdd6e47f1f34a4c8e9a14b8eeae'
+  version '1.35.0,0284236851a94b116f468345f6e98688a737015d'
+  sha256 '805d856a643d456f35670b1b1e0584db5a8bc180d337c8a814a5486121f5cf06'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.