### PR TITLE
Update telegram-alpha from 5.3-171636,2121 to 5.3-171649,2122

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.3-171636,2121'
-  sha256 '3564b1552626f113666b3d42d5c4a3940776ae6ea134e5589f1ac129efa2bf8f'
+  version '5.3-171649,2122'
+  sha256 'bd1428671012d454a226af7e667d59c07d92ecf45aba8bb2620c66c958b1af8d'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.