### PR TITLE
Update little-snitch-nightly from 4.3.2,5280 to 4.4,5403

### DIFF
--- a/Casks/little-snitch-nightly.rb
+++ b/Casks/little-snitch-nightly.rb
@@ -1,6 +1,6 @@
 cask 'little-snitch-nightly' do
-  version '4.3.2,5280'
-  sha256 'ad7d7cba79f989a796250014282ca56d637e2089fb5d9d15a8075a8148726f7e'
+  version '4.4,5403'
+  sha256 'b1eb84ff9369229f662b1fde6797b26146007a3cca3256d261a974761e280ed9'
 
   url "https://obdev.at/downloads/littlesnitch/nightly/LittleSnitch-#{version.before_comma}-nightly-(#{version.after_comma}).dmg"
   appcast 'https://www.obdev.at/products/littlesnitch/releasenotes-nightly.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.