### PR TITLE
Update telegram-alpha from 5.3-171757,2125 to 5.3-171759,2126

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.3-171757,2125'
-  sha256 '0da273ee0eb1db86096009d619c353adebc66e6a96ed21d46d638e5f61f1a0b2'
+  version '5.3-171759,2126'
+  sha256 'd42bc513a57778c06fa2aba319374f8662922acc867ebb9faac940de4216459a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.