### PR TITLE
Update tor-browser-alpha from 9.0a1 to 9.0a2

### DIFF
--- a/Casks/tor-browser-alpha.rb
+++ b/Casks/tor-browser-alpha.rb
@@ -1,6 +1,6 @@
 cask 'tor-browser-alpha' do
-  version '9.0a1'
-  sha256 'addab1d11f4ce2baa7483a1fab97fd77329ba31185a705339bd36495d8c247ca'
+  version '9.0a2'
+  sha256 '0858318b6db6f1f3b59ffdf795c12fc29762bebfdb9a1f22509842a6a5360a1c'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.