### PR TITLE
Update brave-browser-beta from 0.66.82 to 0.66.87

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '0.66.82'
-  sha256 '901de0d90d2b2ca98f0fc4affc0db808de004cfc5a6dd859c39c1fad859140c8'
+  version '0.66.87'
+  sha256 '70a97ceaee63fd308b35fa58a42565470b93040d6b71cbae2bb244b4c29a2b06'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Beta.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/beta/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.