### PR TITLE
Update wine-staging from 4.9 to 4.10

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '4.9'
-  sha256 'd51f6d2ef7fb9cb263b3f2384e7feca49e3f3d763e35881205ff957370092f22'
+  version '4.10'
+  sha256 '5fc7f5f08b1f6c437093de4da24cf37fcf5b1e4d445450504039b7b2fe01a8a0'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.