### PR TITLE
Update atom-beta from 1.38.0-beta0 to 1.39.0-beta0

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,6 +1,6 @@
 cask 'atom-beta' do
-  version '1.38.0-beta0'
-  sha256 '9980ca64cb542475b55ebc26ba5602f0b63eed18258a3a540d6bbd2fbb3dac67'
+  version '1.39.0-beta0'
+  sha256 'c347fcd0cc5563553399e7c69787b373c12a354bb3d70532b9cdd50bf514aa6d'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.