### PR TITLE
Update virtualbox-beta from 6.0.0_BETA3,127054 to 6.0.8,130520

### DIFF
--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'virtualbox-beta' do
-  version '6.0.0_BETA3,127054'
-  sha256 '7a5687b173c98fd5a0b286c5158f6aa4d4e038fe01e07a24a54574ec30100348'
+  version '6.0.8,130520'
+  sha256 '8e3ed48842821adba3cb48c37a2ffea8e1446ea7a99446df6a42c681720a90dd'
 
   url "https://download.virtualbox.org/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
   appcast 'https://download.virtualbox.org/virtualbox/LATEST-BETA.TXT'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.