### PR TITLE
Added beyond-compare-beta version 4.3.0.24036

### DIFF
--- a/Casks/beyond-compare-beta.rb
+++ b/Casks/beyond-compare-beta.rb
@@ -3,7 +3,7 @@ cask 'beyond-compare-beta' do
   sha256 '4431e59d435e4a614fcdecff70467855b54e9a2f0619c86a0aedb29bfa243329'
 
   url "https://www.scootersoftware.com/BCompareOSX-#{version}.zip"
-  appcast 'https://www.scootersoftware.com/download.php?zz=v4changelog'
+  appcast 'https://www.scootersoftware.com/download.php?zz=v4betalog'
   name 'Beyond Compare'
   homepage 'https://www.scootersoftware.com/'
 

--- a/Casks/beyond-compare-beta.rb
+++ b/Casks/beyond-compare-beta.rb
@@ -1,0 +1,22 @@
+cask 'beyond-compare-beta' do
+  version '4.3.0.24036'
+  sha256 '4431e59d435e4a614fcdecff70467855b54e9a2f0619c86a0aedb29bfa243329'
+
+  url "https://www.scootersoftware.com/BCompareOSX-#{version}.zip"
+  appcast 'https://www.scootersoftware.com/download.php?zz=v4changelog'
+  name 'Beyond Compare'
+  homepage 'https://www.scootersoftware.com/'
+
+  auto_updates true
+  conflicts_with cask: 'beyond-compare'
+
+  app 'Beyond Compare.app'
+  binary "#{appdir}/Beyond Compare.app/Contents/MacOS/bcomp"
+
+  zap trash: [
+               '~/Library/Application Support/Beyond Compare',
+               '~/Library/Caches/com.apple.helpd/Generated/com.ScooterSoftware.BeyondCompare.help*',
+               '~/Library/Caches/com.ScooterSoftware.BeyondCompare',
+               '~/Library/Saved Application State/com.ScooterSoftware.BeyondCompare.savedState',
+             ]
+end


### PR DESCRIPTION
Provides 64-bit support for Beyond Compare for Mojave/Catalina.

Note that there used to be a `Casks/beyond-compare-4-beta.rb`, but that beta program closed and the cask was moved as a non-beta cask in Homebrew/homebrew-cask#6936. This is a new beta program and given that the production version is 32-bit only, valuable to developers wanting to test Catalina, in particular.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256