### PR TITLE
Update dotnet-sdk-preview from 3.0.100-preview5-011568 to 3.0.100-preview6-012264

### DIFF
--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk-preview' do
-  version '3.0.100-preview5-011568'
-  sha256 '42b04e419ca1f4b9a95836d3663f94dd4113a755f808a30a93988fe8e6e4a16e'
+  version '3.0.100-preview6-012264'
+  sha256 '109ba444cbce5c284a82292748b959ff59a19194d44dacdd69a316bf5626bb4e'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/afcef2c8-471f-48aa-8030-010fb6c8517b/75a05bc56f2849f80d5ca7b834bb8722/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.visualstudio.microsoft.com/download/pr/31af4401-55f7-487c-adf7-2b6bed7cb1c5/a6aafa2569a628a80a6ebd2a2fd5c6f3/dotnet-sdk-#{version}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.