### PR TITLE
Update microsoft-edge-dev from 76.0.176.1 to 76.0.182.6

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '76.0.176.1'
-  sha256 'f7260b8640e9d159d6c1de9c8dfdd89bd70bd5999d3e4fffafca21ea258b7b8c'
+  version '76.0.182.6'
+  sha256 '700bc062e9c4b0da7084cf6dae2d1d3f183a3d64a31901c33c763296c21cdee4'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.