### PR TITLE
Update 1password-beta from 7.3.BETA-16 to 7.3.1.BETA-1

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.3.BETA-16'
-  sha256 '6e419193064b36ab2b0216d18bac28f8727bde260090bca65ed782f07b793b78'
+  version '7.3.1.BETA-1'
+  sha256 'a6c59e8b8cb94d048de2b4c42749c2471a9a943a2e00f0a18f60161e24470ca6'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.