### PR TITLE
Update docker-edge from 2.0.4.1,34207 to 2.0.5.0,35318

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,12 +1,12 @@
 cask 'docker-edge' do
-  version '2.0.4.1,34207'
-  sha256 '98d1d02ddb929080b67345c2d0678e6dbc0d982fdaabc0eb4cf822dfdb990f94'
+  version '2.0.5.0,35318'
+  sha256 'f4321e5d3dc43b9fbf98c171f08ea5d529e2dc8c0e3c1c29dd4b078cd58cf850'
 
   url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast 'https://download.docker.com/mac/edge/appcast.xml'
   name 'Docker Community Edition for Mac (Edge)'
   name 'Docker CE for Mac (Edge)'
-  homepage 'https://www.docker.com/community-edition'
+  homepage 'https://www.docker.com/products/docker-desktop'
 
   auto_updates true
   depends_on macos: '>= :yosemite'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.