### PR TITLE
Update anaconda2 from 5.1.0 to 2019.03

### DIFF
--- a/Casks/anaconda2.rb
+++ b/Casks/anaconda2.rb
@@ -1,6 +1,6 @@
 cask 'anaconda2' do
-  version '5.1.0'
-  sha256 'b686e01aeadb33526d9c154a0ac6f691dfad135080df96fb44d3ae1e4b128521'
+  version '2019.03'
+  sha256 '414917d00deaeefa38719992e6437470f54793718ef4bedcd66b0e5a30dbe4b6'
 
   # repo.continuum.io/archive was verified as official when first introduced to the cask
   url "https://repo.continuum.io/archive/Anaconda2-#{version}-MacOSX-x86_64.sh"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download anaconda2` is error-free.
- [x] `brew cask style --fix anaconda2` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
