### PR TITLE
Update telegram-alpha from 5.3-173153,2135 to 5.3-174172,2140

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.3-173153,2135'
-  sha256 'aa13da6e07b93b16224173215da90ea974bc786cc6ff78eb4fda61e99853678f'
+  version '5.3-174172,2140'
+  sha256 '96af9087b0b9679bd9f301e3a7c741aece0d83e101642542f99f2ed9c1edb011'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.