### PR TITLE
add neovim-nightly

### DIFF
--- a/Casks/neovim-nightly.rb
+++ b/Casks/neovim-nightly.rb
@@ -1,0 +1,11 @@
+cask 'neovim-nightly' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/neovim/neovim was verified as official when first introduced to the cask
+  url 'https://github.com/neovim/neovim/releases/download/nightly/nvim-macos.tar.gz'
+  name 'Neovim Nightly'
+  homepage 'https://neovim.io/'
+
+  binary 'nvim-osx64/bin/nvim'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This is a nightly version, I'm going to open a separate PR for a stable version of neovim in homebrew-cask next.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

Install, check version, uninstall:
```
% brew cask install neovim-nightly
==> Satisfying dependencies
==> Downloading https://github.com/neovim/neovim/releases/download/nightly/nvim-macos.tar.gz
Already downloaded: /Users/lazarus/Library/Caches/Homebrew/downloads/395aa28b1a0aed716e93d8c5237219fc0d75d9c104c79c59209eccba74c89973--nvim-macos.tar.gz
==> No SHA-256 checksum defined for Cask 'neovim-nightly', skipping verification.
==> Installing Cask neovim-nightly
==> Linking Binary 'nvim' to '/usr/local/bin/nvim'.
🍺  neovim-nightly was successfully installed!

% nvim --version
NVIM v0.4.0-1060-gc6ce40bf3
Build type: Release
LuaJIT 2.0.5
Compilation: /Applications/Xcode-10.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -O2 -DNDEBUG -DMIN_LOG_LEVEL=3 -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion -Wmissing-prototypes -Wimplicit-fallthrough -Wvla -fstack-protector-strong -fdiagnostics-color=auto -DINCLUDE_GENERATED_DECLARATIONS -D_GNU_SOURCE -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -I/Users/travis/build/neovim/bot-ci/build/neovim/build/config -I/Users/travis/build/neovim/bot-ci/build/neovim/src -I/Users/travis/build/neovim/bot-ci/build/neovim/.deps/usr/include -I/usr/local/opt/gettext/include -I/usr/include -I/Users/travis/build/neovim/bot-ci/build/neovim/build/src/nvim/auto -I/Users/travis/build/neovim/bot-ci/build/neovim/build/include
Compiled by travis@Traviss-Mac-6.local

Features: +acl +iconv +tui 
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/share/nvim"

Run :checkhealth for more info

% brew cask rm neovim-nightly
==> Uninstalling Cask neovim-nightly
==> Unlinking Binary '/usr/local/bin/nvim'.
==> Purging files for version latest of Cask neovim-nightly
```

cc https://github.com/neovim/neovim/issues/10181