### PR TITLE
Update firefox-esr from 60.7.0 to 60.7.1

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.7.0'
+  version '60.7.1'
 
   language 'cs' do
-    sha256 '3627403ccf4d42175a58d87975e94ca8b86259dbc7b725ecb42ad39662851f31'
+    sha256 'd7444f10e4188bab777531c35874bea7a0858900a79e8420f88b66ba3344e89e'
     'cs'
   end
 
   language 'de' do
-    sha256 '62ce1817788862497663da64e86a8a193429bad7a4935a67df0d3816ea2a63f4'
+    sha256 '5b864ab8d924227bbc7aa3ac66f80aa531a1bf9f15b814b5044fc4b412a729b0'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '8d36b66b74e99bf9923cc115125da8b23d66d1538b8996aa5065219f63e8ac86'
+    sha256 'e997249b5bdac21ccd7a353d79167c9017e7c80d1f81f1b979e97042a7e84ae0'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '98cfec127db5dbcb352306851e6292af11efc0b0c0780ba076d3747521a6f015'
+    sha256 'cf507aaa0f5cb5c11b02fd228dfaafdb51afab61c4b7ea144458d73478386463'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '129a28d70d04331a0e4ae5c2a698eca12e28396e60245156719e1c8500b9a35d'
+    sha256 'd1711c8e3c664e840d5e16d8d903bd3dd880b4c1a4224b01f4a2c55dd3fc1828'
     'fr'
   end
 
   language 'gl' do
-    sha256 'ca85001737ffa95bdd0a4b061635896c446f44be9f53570c127bf6fd4b88476a'
+    sha256 '2128dc75818afc112ce333f86529fcfa2d8cb93e3159396c209061171636bbc6'
     'gl'
   end
 
   language 'it' do
-    sha256 '3614dd17e41e6e939e76ebf1fd0906ebc165658c0a80e626717029898ce258bb'
+    sha256 '75edd74dac6887d7dd09787878dd3155c543261d37c70e961289df52fb7cb7bb'
     'it'
   end
 
   language 'ja' do
-    sha256 'c643dfe84b1706abc519aa6879c298f79b18c2c6e05bb2c5b72694ebcb559eca'
+    sha256 '2b45bb3e68d0aa03bdaca1fe0da834db3bdb30c61acc999ee9e001fcdd8331bf'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '8bdbf1385cac63b5057fe42ea71fc98ae5b36ad6550b5e1fb3fb8f11a0cdd356'
+    sha256 '5353a9be3d742f1c0b4467e9db92b4f5f58dd09598d698329e611f171ad30376'
     'nl'
   end
 
   language 'pl' do
-    sha256 '09237db7636d653455497009b7ff0a0839c7cce77e5ff8f58cab2ed4c7cd69c1'
+    sha256 '6b2f2874efd17850e77327908d1fab91eebbb5428e04bc59459bd69fb35c56d8'
     'pl'
   end
 
   language 'pt' do
-    sha256 'f5e83652465e3bb3b905bb88bcf59e4bcfc76c1e5675ab744cab5e5a072a2418'
+    sha256 '47abd601f99aa93db0ba1e0764f3cabe2262bc34d275c5a5c240427cfe864e84'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '101dc850019656ff851cebb7e98b130260d333f310e5aa06dee5f20d3bb1307c'
+    sha256 '61159c12009247d96e4d4faec5e2f58c8be9bbe709ae21dceab04b7dac6ecdc1'
     'ru'
   end
 
   language 'uk' do
-    sha256 'c5ad2006b00cc133febf022e2ba350bd50efbf80085bdd34a15ca5bf9b1bd0fa'
+    sha256 'cb1eb3054e95aeb627bd146cb46c43c76aba70a09ac4f16a74b6c24ab1c5ca9a'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 'ff1b083a804e965a9996178f2065dc64fd899b198dc4520b67d9c4e522d76076'
+    sha256 '3777e8fbb74b8cafec78e1f983e7831da6b11d7354021500b8cc3a4f9c0743f4'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'c49aa3d03e084ee3dc3e34db3e6bd83a73a02dd8d9161ea2e8ae3751faec268c'
+    sha256 'fa8dbab80ab6fae2e11556c661e78fdeec78f33e51a669887931bb246ddc5ee2'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
