### PR TITLE
Update mullvadvpn-beta from 2019.4-beta1 to 2019.5-beta1

### DIFF
--- a/Casks/mullvadvpn-beta.rb
+++ b/Casks/mullvadvpn-beta.rb
@@ -1,6 +1,6 @@
 cask 'mullvadvpn-beta' do
-  version '2019.4-beta1'
-  sha256 '78df24f098b9fc8e7f8dc63f18c959f0a5218079804786f465ab21d3be8adabe'
+  version '2019.5-beta1'
+  sha256 '65e320e1bd1ce351faa20f238e8c7bbe33517811ac7f5516a99223b0cd26de3f'
 
   # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.