### PR TITLE
Update microsoft-edge-dev from 76.0.182.6 to 77.0.189.3

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '76.0.182.6'
-  sha256 '700bc062e9c4b0da7084cf6dae2d1d3f183a3d64a31901c33c763296c21cdee4'
+  version '77.0.189.3'
+  sha256 '01edcdc6b4e7cf4a7f7a0a2b07686e858fb1af26b906836f95276a810b57fff4'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.