### PR TITLE
Update firefox-esr from 60.7.1 to 60.7.2

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '60.7.1'
+  version '60.7.2'
 
   language 'cs' do
-    sha256 'd7444f10e4188bab777531c35874bea7a0858900a79e8420f88b66ba3344e89e'
+    sha256 'e904d27e035d3d0863341c1c28a29f3a09af667e0cac1c72e7c628f062eeb1be'
     'cs'
   end
 
   language 'de' do
-    sha256 '5b864ab8d924227bbc7aa3ac66f80aa531a1bf9f15b814b5044fc4b412a729b0'
+    sha256 '5d614be525b85018e12a833131e0cfd0c7848f4f3b754a034ea3171dbf546a70'
     'de'
   end
 
   language 'en-GB' do
-    sha256 'e997249b5bdac21ccd7a353d79167c9017e7c80d1f81f1b979e97042a7e84ae0'
+    sha256 'f27c90849d27309a6826b36e4906ae0a0531954872c73b4d74ccb4eb1caba3ad'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'cf507aaa0f5cb5c11b02fd228dfaafdb51afab61c4b7ea144458d73478386463'
+    sha256 'e5bd91e385b30aa521bae362b309a8f117f5a55b2b0b63699860e070c94b9f45'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'd1711c8e3c664e840d5e16d8d903bd3dd880b4c1a4224b01f4a2c55dd3fc1828'
+    sha256 'aabbf1f68f622b6310febdfe1aa58ed21c2c17a1d0eca3ce3e3d5921e98ba18f'
     'fr'
   end
 
   language 'gl' do
-    sha256 '2128dc75818afc112ce333f86529fcfa2d8cb93e3159396c209061171636bbc6'
+    sha256 'c8c65961a1cc1dad5764ae751599c9edb245d4d4c62dc0a081c408897083e600'
     'gl'
   end
 
   language 'it' do
-    sha256 '75edd74dac6887d7dd09787878dd3155c543261d37c70e961289df52fb7cb7bb'
+    sha256 'b280d83cb7a976d5f1d37fb79b04819d060234f2caf0282e295ddbeee229de97'
     'it'
   end
 
   language 'ja' do
-    sha256 '2b45bb3e68d0aa03bdaca1fe0da834db3bdb30c61acc999ee9e001fcdd8331bf'
+    sha256 '7c7de492193f11408521fc6bcb91d156286fa977e7a01a537a6b220916b2f673'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '5353a9be3d742f1c0b4467e9db92b4f5f58dd09598d698329e611f171ad30376'
+    sha256 '9d60f299003f68321346cfa8dbf7ea2a0ff079718e4524b0a1e08a93e7488086'
     'nl'
   end
 
   language 'pl' do
-    sha256 '6b2f2874efd17850e77327908d1fab91eebbb5428e04bc59459bd69fb35c56d8'
+    sha256 '13fcfd90803a8c1f9e2be1f37d0bc875c0e143a993cbbb622262a3c38ed6d4b3'
     'pl'
   end
 
   language 'pt' do
-    sha256 '47abd601f99aa93db0ba1e0764f3cabe2262bc34d275c5a5c240427cfe864e84'
+    sha256 '06aaa8b3498fac231b3d3ecaa7f2529d891b77687b8fbde9e4afc6cbe84978c1'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 '61159c12009247d96e4d4faec5e2f58c8be9bbe709ae21dceab04b7dac6ecdc1'
+    sha256 '099bea8c9569cd27628bb979dc79c603ef039f572e3dbe1dff7b8050fc202f34'
     'ru'
   end
 
   language 'uk' do
-    sha256 'cb1eb3054e95aeb627bd146cb46c43c76aba70a09ac4f16a74b6c24ab1c5ca9a'
+    sha256 '04bc58118a82412641b65f9976073702c3aacea4e32e007f6f2bbf34124ec3e9'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '3777e8fbb74b8cafec78e1f983e7831da6b11d7354021500b8cc3a4f9c0743f4'
+    sha256 'db436a0e94f0bcd7e6cac8cbeea44ce3f6b25f54d529e0439b74a45fbc5eff1e'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 'fa8dbab80ab6fae2e11556c661e78fdeec78f33e51a669887931bb246ddc5ee2'
+    sha256 '1cca42436a5e4d21daa9372442384ca5c0069016da3b819261f77ed527985eee'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
