### PR TITLE
Update signal-beta from 1.25.2-beta.1 to 1.25.2-beta.2

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.25.2-beta.1'
-  sha256 '738475b47eadb796d921ff88ac74fcbdfc4c854dc709c9cb5c283482e725de54'
+  version '1.25.2-beta.2'
+  sha256 '7824e16d4bbeaa520a313c663234ae43175f90ffe9ead7e64f4725b2584fcfef'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.