### PR TITLE
Update telegram-alpha from 5.3-174235,2146 to 5.3-174666,2147

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.3-174235,2146'
-  sha256 'e582fad92262cb6e58bb6b1630dd82dc8d7bc1cd6ec1906adf772a649f9e9435'
+  version '5.3-174666,2147'
+  sha256 'd32da7b33864d57240a643325ebbf7beb57e2c5ffc3399e0c23b90535ac52f9a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.