### PR TITLE
Update telegram-alpha from 5.3-174814,2148 to 5.3-174878,2151

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.3-174814,2148'
-  sha256 'a55bddee748ea43dafc21fa3553f9dc1357468630f87f7a2b3f600030154f6ac'
+  version '5.3-174878,2151'
+  sha256 '0335de6a22f779055b05a44592ac6ee35cf790ed7b20cf52ba6d4e609d923bf0'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.