### PR TITLE
Update wine-devel from 4.10 to 4.11

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '4.10'
-  sha256 'ca7b7cd2cebbe01a7034004dc6b6004420459477d7ca380058b796dd93b5897a'
+  version '4.11'
+  sha256 'bebc2355d299996e85a92c3be6cf5fec52fb4163d1f33270b78f91371a281853'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.