### PR TITLE
Update iterm2-beta from 3.3.0beta12 to 3.3.0beta13

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.0beta12'
-  sha256 'bf6a5a8df5d6f8492d53eaecfab201b45b659e63b456cbd7694f0b8f85ffd73b'
+  version '3.3.0beta13'
+  sha256 'f195980e4602b6842e3d112de45acfdac51c8230180ee93866ebc4938f69b41f'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.