### PR TITLE
Link dotnet binary in postflight: dotnet-preview

### DIFF
--- a/Casks/dotnet-preview.rb
+++ b/Casks/dotnet-preview.rb
@@ -16,8 +16,15 @@ cask 'dotnet-preview' do
 
   pkg "dotnet-runtime-#{version}-osx-x64.pkg"
 
+  postflight do
+    FileUtils.ln_sf('/usr/local/share/dotnet/dotnet', "#{HOMEBREW_PREFIX}/bin/dotnet")
+  end
+
   uninstall pkgutil: 'com.microsoft.dotnet.*',
-            delete:  '/etc/paths.d/dotnet'
+            delete:  [
+                       '/etc/paths.d/dotnet',
+                       "#{HOMEBREW_PREFIX}/bin/dotnet",
+                     ]
 
   zap trash: '~/.nuget'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

This PR improves the installation of the `dotnet-preview` cask so that the `dotnet` command works after the install completes.

This mirrors [homebrew-cask PR #65203](https://github.com/Homebrew/homebrew-cask/pull/65203) to do the same in the `dotnet` and `dotnet-sdk` casks.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
