### PR TITLE
Link dotnet binary in dotnet-sdk-preview cask

### DIFF
--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -15,6 +15,7 @@ cask 'dotnet-sdk-preview' do
   depends_on macos: '>= :sierra'
 
   pkg "dotnet-sdk-#{version}-osx-x64.pkg"
+  binary '/usr/local/share/dotnet/dotnet'
 
   uninstall pkgutil: [
                        'com.microsoft.dotnet.*',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

This PR improves the installation of the `dotnet-sdk-preview` cask so that the `dotnet` command works after the install completes.

See [homebrew-cask #65216](https://github.com/Homebrew/homebrew-cask/pull/65216) for a similar PR for the `dotnet-sdk` cask.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
