### PR TITLE
Link dotnet binary in dotnet-preview cask

### DIFF
--- a/Casks/dotnet-preview.rb
+++ b/Casks/dotnet-preview.rb
@@ -15,6 +15,7 @@ cask 'dotnet-preview' do
   depends_on macos: '>= :sierra'
 
   pkg "dotnet-runtime-#{version}-osx-x64.pkg"
+  binary '/usr/local/share/dotnet/dotnet'
 
   uninstall pkgutil: 'com.microsoft.dotnet.*',
             delete:  '/etc/paths.d/dotnet'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

This PR improves the installation of the `dotnet-preview` cask so that the `dotnet` command works after the install completes.

See #7537 for a similar PR for the `dotnet-sdk-preview` cask.

`brew cask audit` build failure [is expected](https://github.com/Homebrew/homebrew-cask-versions/pull/7537#issuecomment-505021565).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.