### PR TITLE
Update telegram-alpha from 5.3-174946,2152 to 5.4-175291,2159

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.3-174946,2152'
-  sha256 'e4f4b87d591539a8b14960d6175ab80c73769c7ea891647e825ba8965a4e44d9'
+  version '5.4-175291,2159'
+  sha256 '634d4074e6ed1fc4841c3c7abe70573f7a852cdb1522efea08f2c6befe97f3b2'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.