### PR TITLE
Update 1password-beta from 7.3.1.BETA-4 to 7.3.2.BETA-0

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,6 +1,6 @@
 cask '1password-beta' do
-  version '7.3.1.BETA-4'
-  sha256 '5261fcefa2ca453d79ca103541a4f0ec2455b079dc5603ea36f48d1b08790750'
+  version '7.3.2.BETA-0'
+  sha256 '82fbbf4a3dad278a883a12d6b01d820ac13a65c587f7f5dda4f23be39b5c91d8'
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   appcast "https://app-updates.agilebits.com/product_history/OPM#{version.major}"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.