### PR TITLE
Add Atom Nightly.app

### DIFF
--- a/Casks/atom-nightly.rb
+++ b/Casks/atom-nightly.rb
@@ -1,0 +1,29 @@
+cask 'atom-nightly' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://atom.io/download/mac?channel=nightly'
+  name 'Github Atom Nightly'
+  homepage 'https://atom.io/nightly'
+
+  depends_on macos: '>= :mavericks'
+
+  app 'Atom Nightly.app'
+  binary "#{appdir}/Atom Nightly.app/Contents/Resources/app/apm/bin/apm", target: 'apm-nightly'
+  binary "#{appdir}/Atom Nightly.app/Contents/Resources/app/atom.sh", target: 'atom-nightly'
+
+  zap trash: [
+               '~/.atom',
+               '~/Library/Application Support/Atom',
+               '~/Library/Application Support/ShipIt_stderr.log',
+               '~/Library/Application Support/ShipIt_stdout.log',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.github.atom.sfl*',
+               '~/Library/Application Support/com.github.atom.ShipIt',
+               '~/Library/Caches/com.github.atom',
+               '~/Library/Caches/com.github.atom.ShipIt',
+               '~/Library/Logs/Atom',
+               '~/Library/Preferences/com.github.atom.helper.plist',
+               '~/Library/Preferences/com.github.atom.plist',
+               '~/Library/Saved Application State/com.github.atom.savedState',
+             ]
+end


### PR DESCRIPTION
This pull request adds `atom-nightly` cask for Atom's new [nightly builds](https://atom.io/nightly).

---

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256