### PR TITLE
Update soulver2 from 2.6.9-6055 to 2.7.0-6068

### DIFF
--- a/Casks/soulver2.rb
+++ b/Casks/soulver2.rb
@@ -1,6 +1,6 @@
 cask 'soulver2' do
-  version '2.6.9-6055'
-  sha256 'e8f96895e43d28177f458404bfc082ebc940c66ce6f425cdceeedab9389272bf'
+  version '2.7.0-6068'
+  sha256 '798c9e76ed617a5c2522728e798aa7c8e271407137173de24b73cc111d674a76'
 
   url "https://www.acqualia.com/files/sparkle/soulver_#{version}.zip"
   appcast "https://www.acqualia.com/soulver/appcast/soulver#{version.major}.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.