### PR TITLE
Update discord-canary from 0.0.220 to 0.0.228

### DIFF
--- a/Casks/discord-canary.rb
+++ b/Casks/discord-canary.rb
@@ -1,6 +1,6 @@
 cask 'discord-canary' do
-  version '0.0.220'
-  sha256 'cc090bda2f87ab5159cd7c3c5c552e3cd24fb5de56394fd2bb2695064fd778fe'
+  version '0.0.228'
+  sha256 'a9197a7b4b0a4ece496f101ec9439c84bae2cb6598730fb9055e617afbe32d3c'
 
   url "https://cdn-canary.discordapp.com/apps/osx/#{version}/DiscordCanary.dmg"
   appcast 'https://discordapp.com/api/canary/updates?platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.