### PR TITLE
Update brave-browser-beta from 0.67.99 to 0.67.101

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '0.67.99'
-  sha256 'c11e1d336a7edcc81378dc2140f6c3e483d156a0fa0e024a461572f498afd97a'
+  version '0.67.101'
+  sha256 '7916d5b52b09b06cde8c6a2cc9a907d5dbcd182f5307ef81559397c19578c38f'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Beta.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/beta/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.