### PR TITLE
Update telegram-alpha from 5.4-175291,2159 to 5.5-175803,2175

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.4-175291,2159'
-  sha256 '634d4074e6ed1fc4841c3c7abe70573f7a852cdb1522efea08f2c6befe97f3b2'
+  version '5.5-175803,2175'
+  sha256 '5233a692609a10665ed1eb2579f25c6597d0f70d94fe12eb954e48f762e62e02'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.