### PR TITLE
Update telegram-alpha from 5.5-175803,2175 to 5.5-175876,2176

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.5-175803,2175'
-  sha256 '5233a692609a10665ed1eb2579f25c6597d0f70d94fe12eb954e48f762e62e02'
+  version '5.5-175876,2176'
+  sha256 'a069cc699aee08d02660f0de9049295b8b3bee92fa7a1c00016895ea88fdbfce'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.