### PR TITLE
Update telegram-desktop-dev from 1.7.10 to 1.7.11.beta

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.7.11.beta'
-  sha256 '4721bcbbc59ec15c0351363998eb6295505551246d4de3b9e6b9902b7b2a3ac9'
+  version '1.7.12.beta'
+  sha256 '5680e778e6c9f0b9df8902da869d45c1dd80ae38ed013fb1e491e41a58fe755f'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"

--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -4,7 +4,8 @@ cask 'telegram-desktop-dev' do
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"
-  appcast 'https://github.com/telegramdesktop/tdesktop/releases.atom'
+  appcast 'https://github.com/telegramdesktop/tdesktop/releases.atom',
+          configuration: version.major_minor_patch
   name 'Telegram Desktop'
   homepage 'https://desktop.telegram.org/'
 

--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,9 +1,9 @@
 cask 'telegram-desktop-dev' do
-  version '1.7.10'
-  sha256 '8382f3018b8746886c9a1eff76c560053448c051696e52d0efa25b881ab0db2d'
+  version '1.7.11.beta'
+  sha256 '4721bcbbc59ec15c0351363998eb6295505551246d4de3b9e6b9902b7b2a3ac9'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
-  url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.dmg"
+  url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"
   appcast 'https://github.com/telegramdesktop/tdesktop/releases.atom'
   name 'Telegram Desktop'
   homepage 'https://desktop.telegram.org/'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

@vitorgalvao, can't submit it with cask-repair due to
```
• audit for telegram-desktop-dev: warning
 - appcast at URL 'https://github.com/telegramdesktop/tdesktop/releases.atom' does not contain the version number: '1.7.11.beta'
```