### PR TITLE
wine-staging <= :mojave

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -13,6 +13,7 @@ cask 'wine-staging' do
                             'wine-stable',
                             'wine-devel',
                           ]
+  depends_on macos: '<= :mojave'
   depends_on x11: true
 
   pkg "winehq-staging-#{version}.pkg",


### PR DESCRIPTION
Catalina lacks 32-bit libs needed by wine.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).