### PR TITLE
wine-devel rm conflict with wine-stable

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -8,10 +8,7 @@ cask 'wine-devel' do
   homepage 'https://wiki.winehq.org/MacOS'
 
   conflicts_with formula: 'wine',
-                 cask:    [
-                            'wine-stable',
-                            'wine-staging',
-                          ]
+                 cask:    'wine-staging'
   depends_on macos: '<= :mojave'
   depends_on x11: true
 


### PR DESCRIPTION
As per https://github.com/Homebrew/homebrew-cask/pull/65831

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download --appcast --token-conflicts {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).