### PR TITLE
Update brave-browser-dev from 0.68.96 to 0.68.99

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '0.68.96'
-  sha256 'a423e5760342ff3a4f116917d64f2f452a954e90d48599647083aa0c40984cb2'
+  version '0.68.99'
+  sha256 'f47a35e11b99546d7028d19709039518c0ced692ca0ca2f03737e018850eecc1'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.