### PR TITLE
Update chromedriver-beta from 76.0.3809.25 to 76.0.3809.68

### DIFF
--- a/Casks/chromedriver-beta.rb
+++ b/Casks/chromedriver-beta.rb
@@ -1,6 +1,6 @@
 cask 'chromedriver-beta' do
-  version '76.0.3809.25'
-  sha256 '99445d3e42060f9cbd04753669df7828f48ec7546a9d32f206c1358215b9a5c9'
+  version '76.0.3809.68'
+  sha256 '093ce5480be24520c1b5c0d265cc20a3b28527877d0bb02fe24ab5ac503d1239'
 
   # chromedriver.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.