### PR TITLE
Update signal-beta from 1.25.3-beta.1 to 1.26.0-beta.3

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.25.3-beta.1'
-  sha256 '60149ba9a826abe20e0046a4edaeb7152f6e1eaf57fe5ec32cc65b4b46c569cd'
+  version '1.26.0-beta.3'
+  sha256 '18725d6c628b45fbcc6f5103a0ac4e241a2bfe31c4d06546c123a022634a0b31'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.