### PR TITLE
Update adoptopenjdk8 from 8,212:b04 to 8,222:b10

### DIFF
--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -1,6 +1,6 @@
 cask 'adoptopenjdk8' do
-  version '8,212:b04'
-  sha256 '20c4d9d3c0b10c21f781ba3a723683c70805e61939f908522cbce76e6e1ed2af'
+  version '8,222:b10'
+  sha256 '21b4e428746cd7b930f4ffb5de53850a2a8e9a08bb53346b6e81567639473603'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk#{version.before_comma}u#{version.after_comma.before_colon}-#{version.after_colon}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}u#{version.after_comma.before_colon}#{version.after_comma.after_colon}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.