### PR TITLE
Update microsoft-remote-desktop-beta from 10.3.0.1617,298 to 10.3.0.1621,301

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.3.0.1617,298'
-  sha256 'af1a40624855b64314f63805ec9f7a93ed4987b90506d7e2ba963ea52c6258ca'
+  version '10.3.0.1621,301'
+  sha256 '96b6e308765054d5b576828a0a2cb3d820d013d862a204ff9d7121a03646d78b'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.