### PR TITLE
Update dotnet-sdk-preview to latest preview

### DIFF
--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk-preview' do
-  version '3.0.100-preview7-012821'
+  version '3.0.100-preview7-012821,64cb8405-ee15-4a9a-bf25-1201531f4519/b619596c137a08b204fc79a213bb9763'
   sha256 '44de66897f4f5a1991e46d6e4689682067a5bef1cd1b28827bc70fd095547f40'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/64cb8405-ee15-4a9a-bf25-1201531f4519/b619596c137a08b204fc79a213bb9763/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma}/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'
@@ -14,7 +14,7 @@ cask 'dotnet-sdk-preview' do
                        ]
   depends_on macos: '>= :sierra'
 
-  pkg "dotnet-sdk-#{version}-osx-x64.pkg"
+  pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
   binary '/usr/local/share/dotnet/dotnet'
 
   uninstall pkgutil: [

--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -3,7 +3,7 @@ cask 'dotnet-sdk-preview' do
   sha256 '44de66897f4f5a1991e46d6e4689682067a5bef1cd1b28827bc70fd095547f40'
 
   url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma}/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
-  appcast 'https://www.microsoft.com/net/download/macos'
+  appcast "https://dotnet.microsoft.com/download/dotnet-core/#{version.major_minor}"
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'
 

--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk-preview' do
-  version '3.0.100-preview6-012264'
-  sha256 '109ba444cbce5c284a82292748b959ff59a19194d44dacdd69a316bf5626bb4e'
+  version '3.0.100-preview7-012821'
+  sha256 '44de66897f4f5a1991e46d6e4689682067a5bef1cd1b28827bc70fd095547f40'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/31af4401-55f7-487c-adf7-2b6bed7cb1c5/a6aafa2569a628a80a6ebd2a2fd5c6f3/dotnet-sdk-#{version}-osx-x64.pkg"
+  url "https://download.visualstudio.microsoft.com/download/pr/64cb8405-ee15-4a9a-bf25-1201531f4519/b619596c137a08b204fc79a213bb9763/dotnet-sdk-#{version}-osx-x64.pkg"
   appcast 'https://www.microsoft.com/net/download/macos'
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'

--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -1,8 +1,8 @@
 cask 'dotnet-sdk-preview' do
-  version '3.0.100-preview7-012821,64cb8405-ee15-4a9a-bf25-1201531f4519/b619596c137a08b204fc79a213bb9763'
+  version '3.0.100-preview7-012821,64cb8405-ee15-4a9a-bf25-1201531f4519:b619596c137a08b204fc79a213bb9763'
   sha256 '44de66897f4f5a1991e46d6e4689682067a5bef1cd1b28827bc70fd095547f40'
 
-  url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma}/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
+  url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
   appcast "https://dotnet.microsoft.com/download/dotnet-core/#{version.major_minor}"
   name '.NET Core SDK'
   homepage 'https://www.microsoft.com/net/core#macos'


### PR DESCRIPTION
From version 3.0.100-preview6-012264 to version 3.0.100-preview7-012821

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
