### PR TITLE
Update atom-beta from 1.40.0-beta0 to 1.40.0-beta1

### DIFF
--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -1,6 +1,6 @@
 cask 'atom-beta' do
-  version '1.40.0-beta0'
-  sha256 'aa528910b84e222b5defa8b8bf25c37ec79f2a1495ace4fb519432829df40898'
+  version '1.40.0-beta1'
+  sha256 '1b2086dfd090315e0f5f4d95db568874edf2b86be03c3c2d8bc107e21b92938d'
 
   # github.com/atom/atom was verified as official when first introduced to the cask
   url "https://github.com/atom/atom/releases/download/v#{version}/atom-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.