### PR TITLE
Update microsoft-remote-desktop-beta from 10.3.0.1622,302 to 10.3.0.1623,303

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.3.0.1622,302'
-  sha256 '399a1aba7ebe6bdc82440ac2f35bb9d971cf184b7346378ab44f207907c9e311'
+  version '10.3.0.1623,303'
+  sha256 'f40df95d061d418c3a0a6a62b5bc9d90b1b0f4a4a458737616f5220f542da021'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.