### PR TITLE
Update github-beta from 2.1.1-beta2-f7fc18ca to 2.1.1-beta3-98957db8

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '2.1.1-beta2-f7fc18ca'
-  sha256 'dcbb4bd02f48da9d4ed8049c5b3f963840b78a79aa3883824cb4fe1469559936'
+  version '2.1.1-beta3-98957db8'
+  sha256 '63b03c52b2d9fa33e230ab9775a3927fce18b3137d460254f2a1d5cd177d0993'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.