### PR TITLE
Update telegram-alpha from 5.6-177776,2213 to 5.6-178844,2216

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.6-177776,2213'
-  sha256 '1e098414af6e798669a871ee17bc0708b4259bc3f1b9c70f14950d924055f1fd'
+  version '5.6-178844,2216'
+  sha256 'c82b90e179d82a0c7a58a2f65cc2f5d3ba9a731252abcb5b2ea94705c545884e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.