### PR TITLE
Update qt-creator-dev from 4.10.0-beta1 to 4.10.0-rc1

### DIFF
--- a/Casks/qt-creator-dev.rb
+++ b/Casks/qt-creator-dev.rb
@@ -1,6 +1,6 @@
 cask 'qt-creator-dev' do
-  version '4.10.0-beta1'
-  sha256 '579d34fc6dc83df0d885415830d2c8890e70b0efaee7730db04814e8513f2b66'
+  version '4.10.0-rc1'
+  sha256 'f64c17e546eeb2e025fec4bb458909e7b7bdfa8e899090a06bf6af1b9d19ac19'
 
   url "https://download.qt.io/development_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name 'Qt Creator Dev'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.