### PR TITLE
Update libreoffice-rc from 6.3.0.2 to 6.3.0.3

### DIFF
--- a/Casks/libreoffice-rc.rb
+++ b/Casks/libreoffice-rc.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice-rc' do
-  version '6.3.0.2'
-  sha256 '767597a5d723e269f0bfb5c6689140e11371936635b06f33b3fa4fe5d46d7bb5'
+  version '6.3.0.3'
+  sha256 '9f4623c7e654d50027fe2850e5d529f0362137bb08545fd701c4afacc8d60c85'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.