### PR TITLE
Update discord-canary from 0.0.232 to 0.0.233

### DIFF
--- a/Casks/discord-canary.rb
+++ b/Casks/discord-canary.rb
@@ -1,6 +1,6 @@
 cask 'discord-canary' do
-  version '0.0.232'
-  sha256 'c2ef37eafbf9528574e1857705defcb6c4356a126713e883432a01bed3ef4844'
+  version '0.0.233'
+  sha256 'f4f98b076ca89245b906c7d547befed49ce88258c310205709be4f09dbb33ccc'
 
   url "https://cdn-canary.discordapp.com/apps/osx/#{version}/DiscordCanary.dmg"
   appcast 'https://discordapp.com/api/canary/updates?platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.