### PR TITLE
Update brave-browser-dev from 0.69.98 to 0.69.99

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '0.69.98'
-  sha256 'dfe61a0721bcf812424c768c0f0161fc8cd60e359ab94fe1c988591407fb70f5'
+  version '0.69.99'
+  sha256 '9356da89d6c7729c4ac6bdb3775983d7a8d0b2c98dd8a6a96004f54ae4cdc921'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.