### PR TITLE
Update signal-beta from 1.26.0-beta.3 to 1.26.0-beta.4

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.26.0-beta.3'
-  sha256 '18725d6c628b45fbcc6f5103a0ac4e241a2bfe31c4d06546c123a022634a0b31'
+  version '1.26.0-beta.4'
+  sha256 '88a749725ae5d1fe23f0407b5fcbb16a1cb1a144162190b050d673bf1ea2fbc2'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.