### PR TITLE
Add Postgres.app v2.3beta2

### DIFF
--- a/Casks/postgres-beta.rb
+++ b/Casks/postgres-beta.rb
@@ -1,5 +1,5 @@
 cask 'postgres-beta' do
-  version '2.3beta3,2.2.4'
+  version '2.3beta3,2.2.5'
   sha256 'c63b8bff1e24cdfc8a755ae29a1ff3e17f014cfd2800364df6455357a70c0ea1'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask

--- a/Casks/postgres-beta.rb
+++ b/Casks/postgres-beta.rb
@@ -1,0 +1,28 @@
+cask 'postgres-beta' do
+  version '2.3beta2'
+  sha256 'aefd40af43a29e0c304dad4d723001fa0d30962941ad4344c798bb3872c13111'
+
+  # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
+  url "https://github.com/PostgresApp/PostgresApp/releases/download/v2.2.4/Postgres-#{version}.dmg"
+  appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom'
+  name 'Postgres'
+  homepage 'https://postgresapp.com/'
+
+  auto_updates true
+  depends_on macos: '>= :sierra'
+
+  app 'Postgres.app'
+
+  uninstall launchctl: "com.postgresapp.Postgres#{version.major}LoginHelper",
+            quit:      [
+                         "com.postgresapp.Postgres#{version.major}",
+                         "com.postgresapp.Postgres#{version.major}MenuHelper",
+                       ]
+
+  zap trash: [
+               '~/Library/Application Support/Postgres',
+               "~/Library/Caches/com.postgresapp.Postgres#{version.major}",
+               "~/Library/Cookies/com.postgresapp.Postgres#{version.major}.binarycookies",
+               "~/Library/Preferences/com.postgresapp.Postgres#{version.major}.plist",
+             ]
+end

--- a/Casks/postgres-beta.rb
+++ b/Casks/postgres-beta.rb
@@ -1,6 +1,6 @@
 cask 'postgres-beta' do
   version '2.3beta3,2.2.4'
-  sha256 'aefd40af43a29e0c304dad4d723001fa0d30962941ad4344c798bb3872c13111'
+  sha256 'c63b8bff1e24cdfc8a755ae29a1ff3e17f014cfd2800364df6455357a70c0ea1'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{vesion.after_comma}/Postgres-#{version.before_comma}.dmg"

--- a/Casks/postgres-beta.rb
+++ b/Casks/postgres-beta.rb
@@ -3,7 +3,7 @@ cask 'postgres-beta' do
   sha256 'c63b8bff1e24cdfc8a755ae29a1ff3e17f014cfd2800364df6455357a70c0ea1'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
-  url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{vesion.after_comma}/Postgres-#{version.before_comma}.dmg"
+  url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version.after_comma}/Postgres-#{version.before_comma}.dmg"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom'
   name 'Postgres'
   homepage 'https://postgresapp.com/'

--- a/Casks/postgres-beta.rb
+++ b/Casks/postgres-beta.rb
@@ -1,9 +1,9 @@
 cask 'postgres-beta' do
-  version '2.3beta2'
+  version '2.3beta3,2.2.4'
   sha256 'aefd40af43a29e0c304dad4d723001fa0d30962941ad4344c798bb3872c13111'
 
   # github.com/PostgresApp/PostgresApp was verified as official when first introduced to the cask
-  url "https://github.com/PostgresApp/PostgresApp/releases/download/v2.2.4/Postgres-#{version}.dmg"
+  url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{vesion.after_comma}/Postgres-#{version.before_comma}.dmg"
   appcast 'https://github.com/PostgresApp/PostgresApp/releases.atom'
   name 'Postgres'
   homepage 'https://postgresapp.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

Hey everyone, I'm adding the latest beta for Postgres.app, including PostgreSQL 12beta2 / PostGIS 3.0.0alpha2 / plv8 n/a, per their [Downloads page](https://postgresapp.com/downloads.html).

Please let me know if anything's wrong, I mostly copied the current [Postgres.app](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/postgres.rb) formula, and tested it, everything seems to be working correctly.

Concerning the token reference, should I rename the app to Postgres-beta.app or similar to differentiate it from the stable release? Or keep the Postgres.app name and rename the cask? What's the convention in this kind of situation?

Kind regards