### PR TITLE
Update iterm2-beta from 3.3.1beta1 to 3.3.2beta1

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.1beta1'
-  sha256 '5b0b03de5dc2ef2ce5e35f4e269b625ce72e6be66fb33857b594cb95af483889'
+  version '3.3.2beta1'
+  sha256 '4b90b5c1a494ab203aa1a22632bb989d66a3c9f9544e50dff2153b8e8b902c93'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.