### PR TITLE
Update toggl-dev from 7.4.495 to 7.4.503

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.495'
-  sha256 'c4103d827e631e79d5755bff139d4fe6d9b7de09bff5007f488df7388a49e8a1'
+  version '7.4.503'
+  sha256 '51e58e1a196b5ba2eced56af9176be6a31693114f1f0db57ae895ecd3c09cb5e'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.