### PR TITLE
Update microsoft-edge-dev from 77.0.230.2 to 77.0.235.4

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '77.0.230.2'
-  sha256 '8975476bf3ce2c39b19a4ae737f878b639844f86121b25c47adba773a43f5635'
+  version '77.0.235.4'
+  sha256 '7e27e1d334e259b2b55fe3ccad995979a670e310fdf94957195dc53e9d9b6fa2'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.