### PR TITLE
Update telegram-alpha from 5.6-179051,2221 to 5.6-179184,2223

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.6-179051,2221'
-  sha256 'e0ba273fb88ba32964811f40953c2577f4ff8ad61bb0c249b33ba4adb3b98db1'
+  version '5.6-179184,2223'
+  sha256 '24687e6cd26fdb991faaaae77c6ef4d015dbc7f3e72d1a0b51022caab03a0ccd'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.