### PR TITLE
Update telegram-desktop-dev from 1.7.15.beta to 1.8.0

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.7.15.beta'
-  sha256 '6419ba33f42051d0d02fad378ff7c0564b9e81b4c10769cad7af1c6081c63e72'
+  version '1.8.0'
+  sha256 '78d3ed043357562f2bf5005c4f558a7acd8caa0fe0879fb930d4a6fbd20df804'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.