### PR TITLE
Update iterm2-beta from 3.3.2beta1 to 3.3.2beta2

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.2beta1'
-  sha256 '4b90b5c1a494ab203aa1a22632bb989d66a3c9f9544e50dff2153b8e8b902c93'
+  version '3.3.2beta2'
+  sha256 'fd4754bc7428c7c2efd8dd1ecb34efdf897608254f2a2a1f72ca171f0b74b225'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.