### PR TITLE
Update microsoft-edge-dev from 77.0.235.5 to 78.0.244.0

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '77.0.235.5'
-  sha256 '642740d95fb5f281b76dafe8805cc6d2fd55573c16b9c629837cf7d12e14dc7f'
+  version '78.0.244.0'
+  sha256 'a37a7dad8491e757db6cec680cebdfbf6669845d0f2dca1040277d892c198627'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.