### PR TITLE
Update brave-browser-dev from 0.69.103 to 0.70.65

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '0.69.103'
-  sha256 'e429c9da7e6733f59709aace2224d12ac2921fe01de1692e61a49dc498dec734'
+  version '0.70.65'
+  sha256 'be1b55820749a068ca7c5b42428d3126bd10181fe127df7366300cbb880bb741'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.