### PR TITLE
Update toggl-dev from 7.4.505 to 7.4.519

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.505'
-  sha256 '7f92fd750a090aad397e226b52072a3cca66b8467fb9ca99ea6fe6d3d9374d39'
+  version '7.4.519'
+  sha256 '202c83e299f44826f4ed6a85ac970a1288a71006dc0b1b52b6477abe2a70b99e'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.