### PR TITLE
Update brave-browser-dev from 0.70.66 to 0.70.68

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '0.70.66'
-  sha256 'dfa08aab1e7a26d97bf8863d58b3eb32a15c5de921636e0722a4540e5d78dd87'
+  version '0.70.68'
+  sha256 '9c6a9cabbbe2f609e1199021c9c1c1bb05028a224e6560e2ab931d6318f2475c'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.