### PR TITLE
new cask: inkscape-nightly, latest

### DIFF
--- a/Casks/inkscape-nightly.rb
+++ b/Casks/inkscape-nightly.rb
@@ -1,0 +1,20 @@
+cask 'inkscape-nightly' do
+  version :latest
+  sha256 :no_check
+
+  # gitlab.com/inkscape/inkscape was verified as official when first introduced to the cask
+  url 'https://gitlab.com/inkscape/inkscape/-/jobs/artifacts/master/download?job=inkscape:mac'
+  name 'Inkscape'
+  homepage 'https://inkscape.org/'
+
+  conflicts_with cask: 'inkscape'
+  container nested: 'artifacts/Inkscape.dmg'
+
+  app 'Inkscape.app'
+
+  zap trash: [
+               '~/Library/Application Support/Inkscape',
+               '~/Library/Saved Application State/org.inkscape.Inkscape.savedState',
+               '~/.cache/inkscape',
+             ]
+end


### PR DESCRIPTION
This cask maybe interesting for Catalina users, because latest stable version is 32-bit app.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256