### PR TITLE
Update wine-devel from 4.13 to 4.14

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '4.13'
-  sha256 '96f87b2058016e0730511a8cb9eb861f06c3b6bf17746fd65e86110f4a97b620'
+  version '4.14'
+  sha256 'e55fe10488d54c1c88ba00cd0988c8c242426f3957660188775687e174e9d8b1'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.