### PR TITLE
Update wine-staging from 4.13 to 4.14

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '4.13'
-  sha256 'f7964942da49eb2d062a52cfd87aa5947adc20ba1b45e774607f0c431ba4ba05'
+  version '4.14'
+  sha256 '9e96b33cd17f06b2cbd3464d181f6a57ecc2591c37229021ccaf9fa827a5d431'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.