### PR TITLE
Update github-beta from 2.1.1-beta3-98957db8 to 2.1.1-beta4-c979f3d6

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '2.1.1-beta3-98957db8'
-  sha256 '63b03c52b2d9fa33e230ab9775a3927fce18b3137d460254f2a1d5cd177d0993'
+  version '2.1.2-beta1-b5568722'
+  sha256 '9785ff0ef3c25a90c104ce984ee92e75f07f49e244d1a0a7b46d7e1bfaa377c5'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.