### PR TITLE
Update termius-beta from 4.9.5 to 4.9.7

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,9 +1,9 @@
 cask 'termius-beta' do
-  version '4.9.5'
-  sha256 'dfa64837c028ca4435e84e1ae36d63155df3be94b117c21061a641598d99303b'
+  version '4.9.7'
+  sha256 '09ef6afe972c8c21e6211cba0281bd4efe36e1e5badb61d8b695510b5ba9dc2a'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
-  url 'https://s3.amazonaws.com/termius.desktop.autoupdate/mac-beta/Termius+Beta.dmg'
+  url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'
   name 'Termius Beta'
   homepage 'https://www.termius.com/beta-program'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.