### PR TITLE
Update dropbox-beta from 80.3.111 to 80.3.116

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '80.3.111'
-  sha256 'ddd8ede2bd92747df76a110949f43dd915c34496baf1b575e35cb6b637351a95'
+  version '80.3.116'
+  sha256 '5a2542d38bfcd06f63160c2d900ca647f20f5a0650be9b7229cdfb56666b6616'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.