### PR TITLE
Update signal-beta from 1.27.1-beta.5 to 1.27.1-beta.6

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.27.1-beta.5'
-  sha256 '045857afdd695865e295102eadab2c7544e9eac3a6a1ccd00f5abe8976152e22'
+  version '1.27.1-beta.6'
+  sha256 '4cd94d7879cccf68ed27e46e1af4f57e1c8ca44b8257abc338691382c8d8f81d'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.