### PR TITLE
Update brave-browser-dev from 0.70.72 to 0.70.74

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '0.70.72'
-  sha256 '6760839bf135a8ae515b5e7d91953dea592e7e6f868d3be06dee6ee852469fe6'
+  version '0.70.74'
+  sha256 'f026ebaebb0be92cf8fa31bdc97511dbbec5243540013130cd19dd779b906024'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.