### PR TITLE
Update microsoft-edge-beta from 77.0.235.9 to 77.0.235.15

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '77.0.235.9'
-  sha256 '3d262fa3ed1f4642f62edd8cb274709b739add1adf7eee932c666273fed0f084'
+  version '77.0.235.15'
+  sha256 '005b12a0938a036ce59f775b3fd4c451d8c8cfc781aa072db84ba0699b92810e'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.