### PR TITLE
Update microsoft-edge-dev from 78.0.244.0 to 78.0.249.1

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '78.0.244.0'
-  sha256 'a37a7dad8491e757db6cec680cebdfbf6669845d0f2dca1040277d892c198627'
+  version '78.0.249.1'
+  sha256 'b20091c6d9d907dbf02812d7637983ae746c5293504b2249536a6b1113c9715d'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.