### PR TITLE
Update github-beta from 2.1.2-beta2-1d24dcd0 to 2.1.3-beta1-7f4b003f

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '2.1.2-beta2-1d24dcd0'
-  sha256 'c43d62fc5f9c3adcb591787a52ce83f50ce3e481ac1b363c6a9ba16f1ca387e1'
+  version '2.1.3-beta1-7f4b003f'
+  sha256 'd6ec74d946c3d02e31529ce415934d94cb41324b9d7afa5a03e2cc7bd6b8931b'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.