### PR TITLE
Update brave-browser-beta from 0.69.113 to 0.69.119

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '0.69.113'
-  sha256 '27a1b2af0dd5609c9a47cc0e0424d0e679853f49b44fcf056454544a11b51dd4'
+  version '0.69.119'
+  sha256 '035ee6135f73e267955e9207dd65abc33d9ef4956f7613efc9b68b1d7e22e47c'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Beta.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/beta/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.