### PR TITLE
Update microsoft-edge-dev from 78.0.249.1 to 78.0.262.0

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '78.0.249.1'
-  sha256 'b20091c6d9d907dbf02812d7637983ae746c5293504b2249536a6b1113c9715d'
+  version '78.0.262.0'
+  sha256 'f1a4b49fdadb4b76b8c6adb0925374ef2e337014a6a3bba7373268bcb2fac463'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"
@@ -13,7 +13,7 @@ cask 'microsoft-edge-dev' do
 
   pkg "MicrosoftEdgeDev-#{version}.pkg"
 
-  uninstall pkgutil: 'com.microsoft.Edge.Dev'
+  uninstall pkgutil: 'com.microsoft.edgemac.Dev'
 
   zap launchctl: [
                    'com.microsoft.autoupdate.helper',
@@ -22,7 +22,7 @@ cask 'microsoft-edge-dev' do
       pkgutil:   'com.microsoft.package.Microsoft_AutoUpdate.app',
       trash:     [
                    '/Library/PrivilegedHelperTools/com.microsoft.autoupdate.helper',
-                   '~/Library/Preferences/com.microsoft.Edge.Dev.plist',
+                   '~/Library/Preferences/com.microsoft.edgemac.Dev.plist',
                    '/Library/Application Support/Microsoft',
                    '~/Library/Application Support/Microsoft Edge Dev',
                  ]


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.