### PR TITLE
Update signal-beta from 1.27.1-beta.8 to 1.27.1-beta.9

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.27.1-beta.8'
-  sha256 'd3ac7347a5a52d9aba52492afd9d77caf5f7ed32f7376adf2c7d775a92cb3620'
+  version '1.27.1-beta.9'
+  sha256 'c8c1603b5b5b6eb37d8f6f03db6dac7325cb448f8ced380d4a894581ed5c4faf'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.