### PR TITLE
Update microsoft-edge-beta from 77.0.235.18 to 77.0.235.20

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -13,7 +13,7 @@ cask 'microsoft-edge-beta' do
 
   pkg "MicrosoftEdgeBeta-#{version}.pkg"
 
-  uninstall pkgutil: 'com.microsoft.edgemac.Bet'
+  uninstall pkgutil: 'com.microsoft.Edge.Beta'
 
   zap launchctl: [
                    'com.microsoft.autoupdate.helper',
@@ -22,7 +22,7 @@ cask 'microsoft-edge-beta' do
       pkgutil:   'com.microsoft.package.Microsoft_AutoUpdate.app',
       trash:     [
                    '/Library/PrivilegedHelperTools/com.microsoft.autoupdate.helper',
-                   '~/Library/Preferences/com.microsoft.edgemac.Beta.plist',
+                   '~/Library/Preferences/com.microsoft.Edge.Beta.plist',
                    '/Library/Application Support/Microsoft',
                    '~/Library/Application Support/Microsoft Edge Beta',
                  ]

--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -13,7 +13,7 @@ cask 'microsoft-edge-beta' do
 
   pkg "MicrosoftEdgeBeta-#{version}.pkg"
 
-  uninstall pkgutil: 'com.microsoft.Edge.Beta'
+  uninstall pkgutil: 'com.microsoft.edgemac.Bet'
 
   zap launchctl: [
                    'com.microsoft.autoupdate.helper',
@@ -22,7 +22,7 @@ cask 'microsoft-edge-beta' do
       pkgutil:   'com.microsoft.package.Microsoft_AutoUpdate.app',
       trash:     [
                    '/Library/PrivilegedHelperTools/com.microsoft.autoupdate.helper',
-                   '~/Library/Preferences/com.microsoft.Edge.Beta.plist',
+                   '~/Library/Preferences/com.microsoft.edgemac.Beta.plist',
                    '/Library/Application Support/Microsoft',
                    '~/Library/Application Support/Microsoft Edge Beta',
                  ]

--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '77.0.235.18'
-  sha256 '2ff246da0c9c48ff4f2e1deb137f4fe2cc7144d98b4680aed7efc4f8a3f994a5'
+  version '77.0.235.20'
+  sha256 '3cba3b7c2457b1639382ac75cf32dd1f71822047a1ec8cfa2f9c073e6579e505'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.