### PR TITLE
Update safari-technology-preview to 91

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,12 +1,12 @@
 cask 'safari-technology-preview' do
-  version '90,061-02262-20190820-07f36bc0-0154-437e-bbbb-fcd0ca56dfd7'
+  version '91,061-10706-20190903-6cbd1abb-4b46-4a3f-9229-5e3f89061692'
 
   if MacOS.version <= :mojave
-    url 'https://secure-appldnld.apple.com/STP/061-04045-20190821-10654810-39f2-4cbe-a92d-dedd7c4f85ef/SafariTechnologyPreview.dmg'
-    sha256 '0b921d4cd7a3e7ed52dc62835c3f62f9f4115295d5f68ab104a24ae1ddf61f4c'
+    url 'https://secure-appldnld.apple.com/STP/061-10708-20190903-4bf79804-9f40-4b31-97c9-c914330c30b1/SafariTechnologyPreview.dmg'
+    sha256 'ad39ec6525db9c95eaa9559ad446ab24bf179cdb599a8d5b47e01f4b395e1897'
   else
     url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-    sha256 '658e82c429784969ffbf01312cd785c5e8b8cacd25a4e265590c5f585df1cbbb'
+    sha256 'f9db8462b5dc2433e4af3deb1c354985c135bf8ce4173bda34f0602466fd7187'
   end
 
   appcast 'https://developer.apple.com/safari/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

----

Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 91, 14609.1.3)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=744&view=logs