### PR TITLE
Update libreoffice-rc from 6.3.1.2 to 6.3.2.1

### DIFF
--- a/Casks/libreoffice-rc.rb
+++ b/Casks/libreoffice-rc.rb
@@ -1,6 +1,6 @@
 cask 'libreoffice-rc' do
-  version '6.3.1.2'
-  sha256 'f82bb333d6c744ff43c186b7e19037b84b182815c3db937617dad909eb158818'
+  version '6.3.2.1'
+  sha256 'e16a33e95be3bd1c8d64c1cab97f28346a3eff0eeb6485d5e321c7baaf5a68d4'
 
   # documentfoundation.org/libreoffice was verified as official when first introduced to the cask
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.