### PR TITLE
Update telegram-desktop-dev from 1.8.3 to 1.8.5.beta

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.8.3'
-  sha256 '58396bf10ec04b82bf2b3dc704a7918bd84d0ebe49bbf150c2a7dfc7910b80e0'
+  version '1.8.5.beta'
+  sha256 'a71442dc804391f2b9e64458f1807098282b2a8b126a76f1212e5dc218a9ca11'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.