### PR TITLE
Update rstudio-preview from 1.2.1568 to 1.2.1578

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.1568'
-  sha256 'f9076b3a2d04809f1a1f66a8aff6ef827ebfe4b63398127eec564bf9239e41c1'
+  version '1.2.1578'
+  sha256 '9874c0c932e71ab106fa95476403573c3dd6046a3c64b9c0084adc6201bb51c0'
 
   # rstudio-ide-build.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://rstudio-ide-build.s3.amazonaws.com/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.