### PR TITLE
Update discord-canary from 0.0.238 to 0.0.239

### DIFF
--- a/Casks/discord-canary.rb
+++ b/Casks/discord-canary.rb
@@ -1,6 +1,6 @@
 cask 'discord-canary' do
-  version '0.0.238'
-  sha256 '82c7e16cad255cba35926561f2d911a2d110151e12daba93d01a76ad4d85fa59'
+  version '0.0.239'
+  sha256 '92da447830a1ad40ce19eb7535cc6e3db23f99be1112ea3398187e4b35248472'
 
   url "https://cdn-canary.discordapp.com/apps/osx/#{version}/DiscordCanary.dmg"
   appcast 'https://discordapp.com/api/canary/updates?platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.