### PR TITLE
Update discord-ptb from 0.0.43 to 0.0.44

### DIFF
--- a/Casks/discord-ptb.rb
+++ b/Casks/discord-ptb.rb
@@ -1,6 +1,6 @@
 cask 'discord-ptb' do
-  version '0.0.43'
-  sha256 '4a154e0b84beaa40bf7aaffbcd042ecac29e2f469d237c8158614f16e8cf0f72'
+  version '0.0.44'
+  sha256 'ddbbc5834769c72bc48abf09c460cdd0b5291f2ba5f59de4ff60f7b589cc32a2'
 
   url "https://cdn-ptb.discordapp.com/apps/osx/#{version}/DiscordPTB.dmg"
   appcast 'https://discordapp.com/api/ptb/updates?platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.