### PR TITLE
Update brave-browser-dev from 0.71.70 to 0.71.72

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '0.71.70'
-  sha256 '443799a0da4165c191238192b75e8d84497484628adb13df47282828d96217a1'
+  version '0.71.72'
+  sha256 'dd726d2d7fe6fecbffdf640653bc3bdc60ba1adee0f98f4bbf0f89e08c4356f3'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.