### PR TITLE
Update toggl-dev from 7.4.527 to 7.4.1000

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.527'
-  sha256 '2c00f13febc08f71d676a00790751a7fb053adb835c8886216edf17ae4445762'
+  version '7.4.1000'
+  sha256 '1ae7d493f4bc2a50ea038a05029edcd8693f951e8aa2a042c61361438e4525fd'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.