### PR TITLE
Update toggl-beta from 7.4.484 to 7.4.1000

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,6 +1,6 @@
 cask 'toggl-beta' do
-  version '7.4.484'
-  sha256 'a65926853104485ee545595ada8ea5bbd518489e97d97f7bdae04bde87090bfc'
+  version '7.4.1000'
+  sha256 '1ae7d493f4bc2a50ea038a05029edcd8693f951e8aa2a042c61361438e4525fd'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.