### PR TITLE
Update microsoft-edge-beta from 77.0.235.20 to 77.0.235.22

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '77.0.235.20'
-  sha256 '3cba3b7c2457b1639382ac75cf32dd1f71822047a1ec8cfa2f9c073e6579e505'
+  version '77.0.235.22'
+  sha256 '3fd5f3b7c10d45a475975146d3514e53cbc7add585a31345993ea1b1719d0125'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.