### PR TITLE
Add brave-browser-nightly latest

### DIFF
--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -3,9 +3,13 @@ cask 'brave-browser-nightly' do
   sha256 :no_check
 
   # brave-browser-downloads.s3.brave.com was verified as official when first introduced to the cask
-  url 'https://brave-browser-downloads.s3.brave.com/latest/Brave-Browser-Nightly.dmg'
+  url do
+    require 'open-uri'
+    appcast = 'https://updates.bravesoftware.com/sparkle/Brave-Browser/nightly/appcast.xml'
+    URI(appcast).open.read.scan(%r{enclosure url="([^"]+.dmg)"}).flatten.first
+  end
   name 'Brave Nightly'
-  homepage 'https://github.com/brave/brave-browser'
+  homepage 'https://brave.com/download-nightly/'
 
   depends_on macos: '>= :mavericks'
 

--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -2,7 +2,7 @@ cask 'brave-browser-nightly' do
   version :latest
   sha256 :no_check
 
-  # updates-cdn.bravesoftware.com was verified as official when first introduced to the cask
+  # updates.bravesoftware.com was verified as official when first introduced to the cask
   url do
     require 'open-uri'
     appcast = 'https://updates.bravesoftware.com/sparkle/Brave-Browser/nightly/appcast.xml'

--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -1,0 +1,20 @@
+cask 'brave-browser-nightly' do
+  version '0.72.11'
+  sha256 'e3f305d035642bc0b8a0e505e7bd2c5590884effed8c127fb5eed7995e5fef9d'
+
+  url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Nightly.dmg"
+  appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/nightly/appcast.xml'
+  name 'Brave Nightly'
+  homepage 'https://github.com/brave/brave-browser'
+
+  auto_updates true
+  depends_on macos: '>= :mavericks'
+
+  app 'Brave Browser Nightly.app'
+
+  zap trash: [
+               '~/Library/Application Support/brave',
+               '~/Library/Preferences/com.electron.brave.plist',
+               '~/Library/Saved Application State/com.electron.brave.savedState',
+             ]
+end

--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -2,12 +2,11 @@ cask 'brave-browser-nightly' do
   version :latest
   sha256 :no_check
 
+  # URL_SECTION was verified as official when first introduced to the cask
   url "https://brave-browser-downloads.s3.brave.com/latest/Brave-Browser-Nightly.dmg"
-  appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/nightly/appcast.xml'
   name 'Brave Nightly'
   homepage 'https://github.com/brave/brave-browser'
 
-  auto_updates true
   depends_on macos: '>= :mavericks'
 
   app 'Brave Browser Nightly.app'

--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -1,8 +1,8 @@
 cask 'brave-browser-nightly' do
-  version '0.72.11'
-  sha256 'e3f305d035642bc0b8a0e505e7bd2c5590884effed8c127fb5eed7995e5fef9d'
+  version :latest
+  sha256 :no_check
 
-  url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Nightly.dmg"
+  url "https://brave-browser-downloads.s3.brave.com/latest/Brave-Browser-Nightly.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/nightly/appcast.xml'
   name 'Brave Nightly'
   homepage 'https://github.com/brave/brave-browser'

--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -2,8 +2,8 @@ cask 'brave-browser-nightly' do
   version :latest
   sha256 :no_check
 
-  # URL_SECTION was verified as official when first introduced to the cask
-  url "https://brave-browser-downloads.s3.brave.com/latest/Brave-Browser-Nightly.dmg"
+  # brave-browser-downloads.s3.brave.com was verified as official when first introduced to the cask
+  url 'https://brave-browser-downloads.s3.brave.com/latest/Brave-Browser-Nightly.dmg'
   name 'Brave Nightly'
   homepage 'https://github.com/brave/brave-browser'
 

--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -2,7 +2,7 @@ cask 'brave-browser-nightly' do
   version :latest
   sha256 :no_check
 
-  # brave-browser-downloads.s3.brave.com was verified as official when first introduced to the cask
+  # updates-cdn.bravesoftware.com was verified as official when first introduced to the cask
   url do
     require 'open-uri'
     appcast = 'https://updates.bravesoftware.com/sparkle/Brave-Browser/nightly/appcast.xml'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
**REASON:** This is not a stable version. It is a "Nightly" version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].
- [ ] Attempted to find an [appcast].
**REASON:** Casks with `version :latest` should not use an appcast.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
