### PR TITLE
Update chromedriver-beta from 77.0.3865.40 to 78.0.3904.11

### DIFF
--- a/Casks/chromedriver-beta.rb
+++ b/Casks/chromedriver-beta.rb
@@ -1,6 +1,6 @@
 cask 'chromedriver-beta' do
-  version '77.0.3865.40'
-  sha256 '6fd7ad8944f762933e2a62aa1908de26c94a81f5cb6673446700794ae0574313'
+  version '78.0.3904.11'
+  sha256 '8fc187209976e5752ce3053f30be5632e6be776331f20e0ea4b7f213e833b98e'
 
   # chromedriver.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.