### PR TITLE
Update microsoft-edge-beta from 77.0.235.22 to 77.0.235.25

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '77.0.235.22'
-  sha256 '3fd5f3b7c10d45a475975146d3514e53cbc7add585a31345993ea1b1719d0125'
+  version '77.0.235.25'
+  sha256 '92dfbd56eb9ae005a7a2c6b35b40bc7e94add4bcc6c91d8d6eeda7ccfcece450'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.