### PR TITLE
Update java-beta from 13,32 to 14,14

### DIFF
--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,6 +1,6 @@
 cask 'java-beta' do
-  version '13,32'
-  sha256 '2fb4e71ec8148a3cbbbedec6b6ab886e6d161cda81217d71d8085683b057097f'
+  version '14,14'
+  sha256 'e099496d4dd8851f3df75ee96e0a26f206020f1cd8863bbce01a01566886b60f'
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_osx-x64_bin.tar.gz"
   name 'OpenJDK Early Access Java Development Kit'


### PR DESCRIPTION
As of today (see https://mail.openjdk.java.net/pipermail/jdk-dev/2019-September/003335.html) JDK 13 is the latest supported version and JDK 14 will be the next version.

I know that currently there is some discussion how to proceed with all these java casks (#57387) but I think for the time being updating to the latest beta version should be done nevertheless.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).