### PR TITLE
Update telegram-alpha from 5.7-181147,2241 to 5.8-182623,2256

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.7-181147,2241'
-  sha256 '2f869fbd3914740f002d46135739465f1bcfd70640a92fbeba71ef633790b4f6'
+  version '5.8-182623,2256'
+  sha256 'e632c817c4a40a1802d2fe7d44b0167d9a3b476564d87c524df6c7332778de21'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.