### PR TITLE
Update brave-browser-dev from 0.71.72 to 0.71.74

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '0.71.72'
-  sha256 'dd726d2d7fe6fecbffdf640653bc3bdc60ba1adee0f98f4bbf0f89e08c4356f3'
+  version '0.71.74'
+  sha256 'a51ac9d59fc38991c33136e1035c96416890e6ca3fead896d3d63cdc90330323'
 
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"
   appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.