### PR TITLE
Update brave-browser-nightly latest

### DIFF
--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -6,7 +6,7 @@ cask 'brave-browser-nightly' do
   url do
     require 'open-uri'
     appcast = 'https://updates.bravesoftware.com/sparkle/Brave-Browser/nightly/appcast.xml'
-    URI(appcast).open.read.scan(%r{enclosure url="([^"]+.dmg)"}).flatten.first
+    URI(appcast).open.read.scan(%r{enclosure url="([^"]+.dmg)"}).flatten.last
   end
   name 'Brave Nightly'
   homepage 'https://brave.com/download-nightly/'


### PR DESCRIPTION
Changed the file to point to the latest version in the appcast, which is the bottom-most link.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
**REASON**: This is a Nightly version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].
- [x] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
