### PR TITLE
Update dropbox-beta from 81.3.190 to 82.3.133

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '81.3.190'
-  sha256 'b8af3b631d73f9d741bc6b5557317f534bcf943cd68d1441b3ac06c664d4d4c8'
+  version '82.3.133'
+  sha256 'f9b30fd4bbd17aebef208bb22e4443706bf2035c826b290af961ece32671363f'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.