### PR TITLE
update powershell-preview to 7.0.0-preview.4

### DIFF
--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -1,6 +1,6 @@
 cask 'powershell-preview' do
-  version '7.0.0-preview.3'
-  sha256 'dbe6e25be5a74cd91a1236f88b335135be952896e59e1c0d043bbf83b5a202dd'
+  version '7.0.0-preview.4'
+  sha256 '876cdf8fbe7558f2878468d25bd19b832af56e03f5c70fbc43d9430043cc2f2f'
 
   url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-x64.pkg"
   appcast 'https://github.com/PowerShell/PowerShell/releases.atom'


### PR DESCRIPTION
Updating the cask for PowerShell Preview since 7.0.0-preview.4 just released.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
