### PR TITLE
Update brave-browser-dev from 0.71.74 to 0.71.77

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '0.71.74'
-  sha256 'a51ac9d59fc38991c33136e1035c96416890e6ca3fead896d3d63cdc90330323'
+  version '0.71.77'
+  sha256 '592b55ea3cab45edcd2f3f483765c86a0fd4ebfdad90863871f2543af066e16f'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.