### PR TITLE
Update sublime-merge-dev from 1117 to 1118

### DIFF
--- a/Casks/sublime-merge-dev.rb
+++ b/Casks/sublime-merge-dev.rb
@@ -1,6 +1,6 @@
 cask 'sublime-merge-dev' do
-  version '1117'
-  sha256 '59642318887fae78330680067844624cc77b14971adbc231d576d5267fd47100'
+  version '1118'
+  sha256 '7be28bb78dace264d6b8130d22bf069609806c999e7b2c7757ae2e66f1789f90'
 
   # download.sublimetext.com was verified as official when first introduced to the cask
   url "https://download.sublimetext.com/sublime_merge_build_#{version}_mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.