### PR TITLE
Update vivaldi-snapshot from 2.8.1664.26 to 2.8.1664.32

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.8.1664.26'
-  sha256 'ed40ce79f97b066d5149b04a951db2df8884ae96aec167dc29aebd01ea416de2'
+  version '2.8.1664.32'
+  sha256 '276f07902ed1ab0ed465fd1d5d850e90bd489238a8fcc9c9edfdb37ef98b408a'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.