### PR TITLE
Update sublime-text-dev from 3.208 to 3.210

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -3,7 +3,8 @@ cask 'sublime-text-dev' do
   sha256 'a52f309f5dc708b016ceb8ee0960d24252050c8fcc9f3a6f22c275b8a27e1767'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
-  appcast "https://www.sublimetext.com/updates/#{version.major}/dev/appcast_osx.xml"
+  appcast "https://www.sublimetext.com/updates/#{version.major}/dev/appcast_osx.xml",
+          configuration: version.no_dots
   name 'Sublime Text'
   homepage "https://www.sublimetext.com/#{version.major}dev"
 

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,6 +1,6 @@
 cask 'sublime-text-dev' do
-  version '3.208'
-  sha256 '029121c0ff072a99a412ec53fc798c87d50fee71de09bbd7547006539f801a61'
+  version '3.210'
+  sha256 'a52f309f5dc708b016ceb8ee0960d24252050c8fcc9f3a6f22c275b8a27e1767'
 
   url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
   appcast "https://www.sublimetext.com/updates/#{version.major}/dev/appcast_osx.xml"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.