### PR TITLE
Update telegram-desktop-dev from 1.8.8 to 1.8.9

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.8.8'
-  sha256 '864ccc067d6a66824dbbc7eca0e92be97f29838dd04a0818206b49ed7ceff374'
+  version '1.8.9'
+  sha256 'ea23427dec8447420dd0437fcd6e382f7466b69312ed69e49c979b816ba7ce11'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.