### PR TITLE
Update wine-devel from 4.16 to 4.17

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '4.16'
-  sha256 '7e9cbb4ca8a600cd4aa0cb41d984f72a901649cd18212b2daa57d907087d216b'
+  version '4.17'
+  sha256 '3d1c47048a9f32e953eddcc77996055aad92989f7a6a1aa125134aeaceeb4e9a'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.