### PR TITLE
Update termius-beta to v.4.10.4

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask 'termius-beta' do
-  version '4.10.2'
-  sha256 '7e88312c3734a53185229c2e9fdee249dd381f696a320f6de515912d3ee261d3'
+  version '4.10.4'
+  sha256 '157b7fe9fb055062ef22f6ec2f939f253a700c9c8f325add57fad74856357182'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'


### PR DESCRIPTION
Update termius-beta to v.4.10.4

After making all changes to the cask:
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
