### PR TITLE
textmate-preview.rb: update zap trash and add quit functionality to uninstall

### DIFF
--- a/Casks/textmate-preview.rb
+++ b/Casks/textmate-preview.rb
@@ -14,9 +14,7 @@ cask 'textmate-preview' do
   app 'TextMate.app'
   binary "#{appdir}/TextMate.app/Contents/Resources/mate"
 
-  uninstall quit: [
-                    'com.macromates.TextMate',
-                  ]
+  uninstall quit: 'com.macromates.TextMate'
 
   zap trash: [
                '~/Library/Application Support/TextMate',
@@ -24,8 +22,5 @@ cask 'textmate-preview' do
                '~/Library/Preferences/com.macromates.TextMate.plist',
                '~/Library/Saved Application State/com.macromates.TextMate.savedState',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macromates.textmate.sfl2',
-             ],
-      quit:  [
-               'com.macromates.TextMate',
              ]
 end

--- a/Casks/textmate-preview.rb
+++ b/Casks/textmate-preview.rb
@@ -14,15 +14,18 @@ cask 'textmate-preview' do
   app 'TextMate.app'
   binary "#{appdir}/TextMate.app/Contents/Resources/mate"
 
+  uninstall quit: [
+                    'com.macromates.TextMate',
+                  ]
+
   zap trash: [
-               '~/Library/Application Support/Avian',
                '~/Library/Application Support/TextMate',
                '~/Library/Caches/com.macromates.TextMate',
-               '~/Library/Preferences/com.macromates.TextMate.preview.LSSharedFileList.plist',
-               '~/Library/Preferences/com.macromates.TextMate.preview.plist',
                '~/Library/Preferences/com.macromates.TextMate.plist',
-               '~/Library/Preferences/com.macromates.textmate.webpreview.plist',
-               '~/Library/Preferences/com.macromates.textmate.latex_config.plist',
                '~/Library/Saved Application State/com.macromates.TextMate.savedState',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macromates.textmate.sfl2',
+             ],
+      quit:  [
+               'com.macromates.TextMate',
              ]
 end


### PR DESCRIPTION
Added quit functionality to uninstall and updated trash files in zap stanza

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

