### PR TITLE
Update github-beta from 2.1.3-beta1-7f4b003f to 2.2.0-beta2-50b281c1

### DIFF
--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask 'github-beta' do
-  version '2.1.3-beta1-7f4b003f'
-  sha256 'd6ec74d946c3d02e31529ce415934d94cb41324b9d7afa5a03e2cc7bd6b8931b'
+  version '2.2.0-beta2-50b281c1'
+  sha256 '467b5edd73985c4608ba7dd040430a40ff0859b7992e5daf961ff2fba5ebc792'
 
   # githubusercontent.com was verified as official when first introduced to the cask
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.