### PR TITLE
Update surge2 from 2.6.5 to 2.6.7

### DIFF
--- a/Casks/surge2.rb
+++ b/Casks/surge2.rb
@@ -1,6 +1,6 @@
 cask 'surge2' do
-  version '2.6.5,652'
-  sha256 '494e714a508e8ab44612179c26c59d2afa663805973ce1bb5f57ec7a08cb7048'
+  version '2.6.7,656'
+  sha256 '6689cea266fb0b45e5272ef6b8bc76fbd111b438511243a929af9391a868cb2f'
 
   url "https://nssurge.com/mac/Surge-#{version.before_comma}-#{version.after_comma}.zip"
   name 'Surge'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
