### PR TITLE
Update dropbox-beta from 83.3.123 to 83.3.129

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '83.3.123'
-  sha256 '9431db0789a50ca0aff0506c69432776c311cadd43207a355b64355375a20b5d'
+  version '83.3.129'
+  sha256 '7506f6993947ef9cd184d8e5664797b896cbcb96f2fa17f042f0c07dbb77b697'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.