### PR TITLE
Add DisplayLink beta driver

### DIFF
--- a/Casks/displaylink-beta.rb
+++ b/Casks/displaylink-beta.rb
@@ -1,0 +1,47 @@
+cask 'displaylink-beta' do
+  version '5.2.1-beta.2,1433'
+  sha256 '7ad66ef562f19777caa332f5c75853aa7dcf6682be3ca3a35a012104f1de1888'
+
+  url "https://www.displaylink.com/downloads/file?id=#{version.after_comma}",
+      data:  {
+               'fileId'        => version.after_comma,
+               'accept_submit' => 'Accept',
+             },
+      using: :post
+  name 'DisplayLink USB Graphics Software'
+  homepage 'https://www.displaylink.com/'
+
+  conflicts_with cask: 'displaylink'
+  depends_on macos: :catalina
+
+  pkg 'DisplayLink Software Installer.pkg'
+
+  uninstall pkgutil:   [
+                         'com.displaylink.displaylinkdriver',
+                         'com.displaylink.displaylinkdriversigned',
+                         'com.displaylink.displaylinkdriverunsigned',
+                       ],
+            # 'kextunload -b com.displaylink.driver.DisplayLinkDriver' causes kernel panic
+            # kext:      [
+            #              'com.displaylink.driver.DisplayLinkDriver',
+            #              'com.displaylink.dlusbncm'
+            #            ],
+            launchctl: [
+                         '73YQY62QM3.com.displaylink.DisplayLinkAPServer',
+                         'com.displaylink.useragent-prelogin',
+                         'com.displaylink.useragent',
+                         'com.displaylink.displaylinkmanager',
+                       ],
+            quit:      'DisplayLinkUserAgent',
+            delete:    [
+                         '/Applications/DisplayLink',
+                         '/Library/LaunchAgents/com.displaylink.useragent-prelogin.plist',
+                         '/Library/LaunchAgents/com.displaylink.useragent.plist',
+                         '/Library/LaunchDaemons/com.displaylink.displaylinkmanager.plist',
+                       ]
+
+  caveats do
+    reboot
+    license @cask.url.to_s
+  end
+end


### PR DESCRIPTION
This includes support for macOS Catalina.

After making all changes to the cask:

- [x] `brew cask audit --download Casks/displaylink-beta.rb` is error-free.
- [x] `brew cask style --fix Casks/displaylink-beta.rb` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for ~[a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or~ a [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install Casks/displaylink-beta.rb` worked successfully.
- [x] `brew cask uninstall Casks/displaylink-beta.rb` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].
- [x] Attempted to find an [appcast].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
[appcast]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/appcast.md
