### PR TITLE
Update textmate-preview from 2.0-rc.30 to 2.0.1

### DIFF
--- a/Casks/textmate-preview.rb
+++ b/Casks/textmate-preview.rb
@@ -1,6 +1,6 @@
 cask 'textmate-preview' do
-  version '2.0-rc.30'
-  sha256 '8e2aad3bb2ed64c43283e5697629c831dd087a47aecef85c0072d60bde7765bf'
+  version '2.0.1'
+  sha256 'bb515daecf4f031a7d2f088ef8613a27699c774c08004202c8363d49e87c35f0'
 
   # github.com/textmate/textmate was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"


### PR DESCRIPTION
Since 2.0.1 is marked as pre-release in https://github.com/textmate/textmate/releases and Textmate/api states 2.0 as the latest release.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

