### PR TITLE
Update brave-browser-beta from 0.70.112 to 0.70.116

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '0.70.112'
-  sha256 'b80765721888bd0873032dc801b5875839f3e0bb73a6dadeab6d1282fe74d319'
+  version '0.70.116'
+  sha256 '24c5343dc2c13a0543f3fcf2d83da649b6101e0640b354696ef8244676aaf917'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.