### PR TITLE
Update safari-technology-preview to 94

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask 'safari-technology-preview' do
   if MacOS.version <= :mojave
-    version '93,061-25020-20191001-a0512a8b-e239-4770-a65a-abb385b725b8'
-    sha256 '2f33c86eb89e1dde7faa310155b45424bb8e4ead29f75219ab538c43923e9882'
+    version '94,061-31541-20191015-bf563e61-b1cc-49fb-81d0-2021f4d8c8e4'
+    sha256 'aec3a10e4c83b307824c7bc9dfcd13631309e48c959f5287ebdbf8e046da542f'
   else
-    version '93,061-24849-20191001-f34f8e1e-b3a8-43ab-8f3b-46af122df56c'
-    sha256 '2c9b39785a60e1ae5afa376da2e5c1770fd930461ba396da54edabf4ea9e99e0'
+    version '94,061-31537-20191015-f413b43e-3cff-4ceb-a193-7e36faa83c78'
+    sha256 '7ee3349e07d50b74887758875a734ba1f5af68f20124032f79863dc907a6407c'
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

----

Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 94, 14609.1.6.1)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=888&view=logs