### PR TITLE
Update alfred3 from 3.8.2_963 to 3.8.4_968

### DIFF
--- a/Casks/alfred3.rb
+++ b/Casks/alfred3.rb
@@ -1,6 +1,6 @@
 cask 'alfred3' do
-  version '3.8.2_963'
-  sha256 'f5ed0056bfb149fe5eb06f11c720e09760ee20b05e95014da3d0998cdaf3338b'
+  version '3.8.4_968'
+  sha256 '2a8932200e2208074465e5612fbd769ac830fc62155588635acf310ff776b298'
 
   url "https://cachefly.alfredapp.com/Alfred_#{version}.dmg"
   appcast 'https://www.alfredapp.com/app/update/general.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.