### PR TITLE
Update workflowy-beta from 1.3.4-beta.4612 to 1.3.5-beta.4649

### DIFF
--- a/Casks/workflowy-beta.rb
+++ b/Casks/workflowy-beta.rb
@@ -1,6 +1,6 @@
 cask 'workflowy-beta' do
-  version '1.3.4-beta.4612'
-  sha256 'fb3e939f2d2ab5dfc646bc512b3c2b32ce5c0fe800de929e44080973859325b5'
+  version '1.3.5-beta.4649'
+  sha256 'bee83d700efdd79937f976912692fd06f7dccd5cc23a5399bcf4d8d3f8dfec61'
 
   # github.com/workflowy/desktop-beta was verified as official when first introduced to the cask
   url "https://github.com/workflowy/desktop-beta/releases/download/v#{version}/WorkFlowy-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.