### PR TITLE
Update microsoft-edge-beta from 78.0.276.17 to 78.0.276.19

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '78.0.276.17'
-  sha256 '529797ba9a023f16a997b8c4d2b3d14b2e6252fc5e9d7bfa5374a7b1ce4a3ac3'
+  version '78.0.276.20'
+  sha256 '391cde847cda0f65e1589cd48e01b1608146fa1efbdf7bc6331e7521928e682f'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.