### PR TITLE
new cask: inkscape-beta, 1.0beta1

### DIFF
--- a/Casks/inkscape-beta.rb
+++ b/Casks/inkscape-beta.rb
@@ -1,0 +1,18 @@
+cask 'inkscape-beta' do
+  version '1.0beta1'
+  sha256 '68831989b3919e3137d5acfb130a844933706748addc8b4cd7f957348c1c60a3'
+
+  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}_OEMhoXK.dmg"
+  name 'Inkscape'
+  homepage 'https://inkscape.org/'
+
+  conflicts_with cask: 'inkscape'
+
+  app 'Inkscape.app'
+
+  zap trash: [
+               '~/Library/Application Support/Inkscape',
+               '~/Library/Saved Application State/org.inkscape.Inkscape.savedState',
+               '~/.cache/inkscape',
+             ]
+end


### PR DESCRIPTION
As @yurikoles mentioned in #7765 latest stable version of Inkscape is 32-bit app thus leaving Catalina users unable to run it. But apart for already available nighty version there is also an upcoming 1.0 release: https://inkscape.org/release/inkscape-1.0/?latest=1 that is currently in beta and covered by this pr.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256