### PR TITLE
Update rstudio-preview 1.2.5013

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -2,6 +2,7 @@ cask 'rstudio-preview' do
   version '1.2.5013'
   sha256 'c1f96a4e61af4b33e1a15146c8ef4d2fc4b16e9c6bd04492406055809732f912'
 
+  # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"
   name 'RStudio'
   homepage 'https://www.rstudio.com/products/rstudio/download/preview/'

--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -3,7 +3,7 @@ cask 'rstudio-preview' do
   sha256 'c1f96a4e61af4b33e1a15146c8ef4d2fc4b16e9c6bd04492406055809732f912'
 
   # rstudio-ide-build.s3.amazonaws.com was verified as official when first introduced to the cask
-  url "https://rstudio-ide-build.s3.amazonaws.com/desktop/macos/RStudio-#{version}.dmg"
+  url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"
   name 'RStudio'
   homepage 'https://www.rstudio.com/products/rstudio/download/preview/'
 

--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -2,7 +2,6 @@ cask 'rstudio-preview' do
   version '1.2.5013'
   sha256 'c1f96a4e61af4b33e1a15146c8ef4d2fc4b16e9c6bd04492406055809732f912'
 
-  # rstudio-ide-build.s3.amazonaws.com was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"
   name 'RStudio'
   homepage 'https://www.rstudio.com/products/rstudio/download/preview/'


### PR DESCRIPTION
The download link was changed from https://rstudio-ide-build.s3.amazonaws.com to https://s3.amazonaws.com/rstudio-ide-build

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
