### PR TITLE
Update telegram-alpha from 5.8-184063,2281 to 5.8-185060,2307

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8-184063,2281'
-  sha256 'da183a077b8bd5892994a27e0d1ae99ea644b6a7a4daef67f7e1f4b7278ca3ed'
+  version '5.8-185060,2307'
+  sha256 'e6ca0ec521c9bf30852677725dbb645b7250a536ee84122b3191871a02fe7641'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.