### PR TITLE
Update microsoft-remote-desktop-beta from 10.3.4.1676,346 to 10.3.4.1684,359

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.3.4.1676,346'
-  sha256 '93271606a0dc70a7db5cd92dd60a142daffd3731941112fa0156c63def883477'
+  version '10.3.4.1684,359'
+  sha256 '7cb5761cf694a2b3d25be753d7168a6802db317bc08fab4d4ac1f621dc42dc34'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.