### PR TITLE
Update microsoft-edge-dev from 79.0.301.2 to 79.0.308.1

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -13,15 +13,16 @@ cask 'microsoft-edge-dev' do
 
   pkg "MicrosoftEdgeDev-#{version}.pkg"
 
-  uninstall pkgutil: 'com.microsoft.edgemac.Dev'
+  uninstall pkgutil: 'com.microsoft.edgemac.Dev',
+            rmdir:   '/Library/Application Support/Microsoft'
 
   zap launchctl: [
                    'com.microsoft.autoupdate.helper',
                    'com.microsoft.update.agent',
                  ],
       pkgutil:   'com.microsoft.package.Microsoft_AutoUpdate.app',
+      delete:    '/Library/PrivilegedHelperTools/com.microsoft.autoupdate.helper',
       trash:     [
-                   '/Library/PrivilegedHelperTools/com.microsoft.autoupdate.helper',
                    '~/Library/Preferences/com.microsoft.edgemac.Dev.plist',
                    '/Library/Application Support/Microsoft',
                    '~/Library/Application Support/Microsoft Edge Dev',

--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '79.0.301.2'
-  sha256 '5ae92bf86fa3e9c7ccc718ffc790cfa0024a23f8f155253b3662289e0622f0d1'
+  version '79.0.308.1'
+  sha256 '21b1bcded1ecb2aef94716a8b3622b5b6e3fa16ced57aeec4d7f573ac20a226a'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.