### PR TITLE
Update wine-staging from 4.17 to 4.18

### DIFF
--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -1,6 +1,6 @@
 cask 'wine-staging' do
-  version '4.17'
-  sha256 '7b297c9942362f0a9073a6763a066cf776bc7bffeacc30467fc24c72cd00fa22'
+  version '4.18'
+  sha256 'b9baaa67ac0e83b9e47f43306009ecd0fbb7a6f19ca20d142f35089235341b27'
 
   # dl.winehq.org/wine-builds/macosx was verified as official when first introduced to the cask
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-staging-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.