### PR TITLE
Update dropbox-beta from 84.3.155 to 84.3.160

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '84.3.155'
-  sha256 'ac09cdbf63802cebf85283fac95cc97b93079bd0d5ae40686220acb176419917'
+  version '84.3.160'
+  sha256 'e92abc73eb386ccdd2edb721ba0e09a7d0f8e694bc1e6ad383a5bed3fe99b047'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.