### PR TITLE
Update java6 to install also on Catalina

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -18,11 +18,10 @@ cask 'java6' do
   else
     container nested: 'JavaForOSX.pkg'
 
-    artifact 'Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
+    artifact 'JavaForOSX/JavaForOSX.pkg/Payload/Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
 
     preflight do
-      system_command 'pkgutil', chdir: staged_path, args: ['--expand', 'JavaForOSX.pkg', 'JavaForOSX']
-      system_command 'tar', chdir: staged_path, args: ['-xzf', 'JavaForOSX/JavaForOSX.pkg/Payload']
+      system_command 'pkgutil', chdir: staged_path, args: ['--expand-full', 'JavaForOSX.pkg', 'JavaForOSX']
     end
   end
 end

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -7,12 +7,22 @@ cask 'java6' do
   name 'Apple Java 6 Standard Edition Development Kit'
   homepage 'https://support.apple.com/kb/DL1572'
 
-  container nested: 'JavaForOSX.pkg'
+  if MacOS.version <= :mojave
+    pkg 'JavaForOSX.pkg'
 
-  artifact 'Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
+    uninstall pkgutil: [
+                         'com.apple.pkg.JavaForMacOSX107',
+                         'com.apple.pkg.JavaMDNS',
+                         'com.apple.pkg.JavaEssentials',
+                       ]
+  else
+    container nested: 'JavaForOSX.pkg'
 
-  preflight do
-    `cd "#{staged_path}" && pkgutil --expand JavaForOSX.pkg JavaForOSX`
-    `cd "#{staged_path}" && (gunzip < JavaForOSX/JavaForOSX.pkg/Payload | pax -r)`
+    artifact 'Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
+
+    preflight do
+      `cd "#{staged_path}" && pkgutil --expand JavaForOSX.pkg JavaForOSX`
+      `cd "#{staged_path}" && (gunzip < JavaForOSX/JavaForOSX.pkg/Payload | pax -r)`
+    end
   end
 end

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -21,8 +21,8 @@ cask 'java6' do
     artifact 'Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
 
     preflight do
-      `cd "#{staged_path}" && pkgutil --expand JavaForOSX.pkg JavaForOSX`
-      `cd "#{staged_path}" && (gunzip < JavaForOSX/JavaForOSX.pkg/Payload | pax -r)`
+      system_command '/usr/sbin/pkgutil', args: ['--expand', "#{staged_path}/JavaForOSX.pkg", "#{staged_path}/JavaForOSX" ]
+      system_command '/usr/bin/tar', args: ['-xz', '-C', "#{staged_path}", '-f', "#{staged_path}/JavaForOSX/JavaForOSX.pkg/Payload" ]
     end
   end
 end

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -7,11 +7,12 @@ cask 'java6' do
   name 'Apple Java 6 Standard Edition Development Kit'
   homepage 'https://support.apple.com/kb/DL1572'
 
-  pkg 'JavaForOSX.pkg'
+  container nested: 'JavaForOSX.pkg'
 
-  uninstall pkgutil: [
-                       'com.apple.pkg.JavaForMacOSX107',
-                       'com.apple.pkg.JavaMDNS',
-                       'com.apple.pkg.JavaEssentials',
-                     ]
+  artifact 'Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
+
+  preflight do
+    `cd "#{staged_path}" && pkgutil --expand JavaForOSX.pkg JavaForOSX`
+    `cd "#{staged_path}" && (gunzip < JavaForOSX/JavaForOSX.pkg/Payload | pax -r)`
+  end
 end

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -12,8 +12,6 @@ cask 'java6' do
 
     uninstall pkgutil: [
                          'com.apple.pkg.JavaForMacOSX107',
-                         'com.apple.pkg.JavaMDNS',
-                         'com.apple.pkg.JavaEssentials',
                        ]
   else
     artifact 'JavaForOSX/JavaForOSX.pkg/Payload/Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -21,8 +21,8 @@ cask 'java6' do
     artifact 'Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
 
     preflight do
-      system_command '/usr/sbin/pkgutil', args: ['--expand', "#{staged_path}/JavaForOSX.pkg", "#{staged_path}/JavaForOSX" ]
-      system_command '/usr/bin/tar', args: ['-xz', '-C', "#{staged_path}", '-f', "#{staged_path}/JavaForOSX/JavaForOSX.pkg/Payload" ]
+      system_command 'pkgutil', chdir: staged_path, args: ['--expand', 'JavaForOSX.pkg', 'JavaForOSX']
+      system_command 'tar', chdir: staged_path, args: ['-xzf', 'JavaForOSX/JavaForOSX.pkg/Payload']
     end
   end
 end

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -10,9 +10,7 @@ cask 'java6' do
   if MacOS.version <= :mojave
     pkg 'JavaForOSX.pkg'
 
-    uninstall pkgutil: [
-                         'com.apple.pkg.JavaForMacOSX107',
-                       ]
+    uninstall pkgutil: 'com.apple.pkg.JavaForMacOSX107'
   else
     artifact 'JavaForOSX/JavaForOSX.pkg/Payload/Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
 

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -16,8 +16,6 @@ cask 'java6' do
                          'com.apple.pkg.JavaEssentials',
                        ]
   else
-    container nested: 'JavaForOSX.pkg'
-
     artifact 'JavaForOSX/JavaForOSX.pkg/Payload/Library/Java/JavaVirtualMachines/1.6.0.jdk', target: '/Library/Java/JavaVirtualMachines/1.6.0.jdk'
 
     preflight do


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.