### PR TITLE
Update background-music-pre from 0.3.0-SNAPSHOT-04f1730 to 0.4.0-SNAPSHOT-c024116

### DIFF
--- a/Casks/background-music-pre.rb
+++ b/Casks/background-music-pre.rb
@@ -1,8 +1,8 @@
 cask 'background-music-pre' do
-  version '0.3.0-SNAPSHOT-04f1730'
-  sha256 'dc040434549611d4bbb4344ca7c3cf30179559545583a06b0099185de28f8a9c'
+  version '0.4.0-SNAPSHOT-c024116'
+  sha256 '91bb417656a8b7c8f493993fd882acd89d8cb933f83da6ba5d88b81b89d6014d'
 
-  url "https://github.com/kyleneideck/BackgroundMusic/releases/download/#{version}/BackgroundMusic-#{version}.pkg"
+  url "https://github.com/kyleneideck/BackgroundMusic/releases/download/#{version}/BackgroundMusic-#{version}.unsigned.pkg"
   appcast 'https://github.com/kyleneideck/BackgroundMusic/releases.atom'
   name 'Background Music'
   homepage 'https://github.com/kyleneideck/BackgroundMusic'
@@ -10,7 +10,7 @@ cask 'background-music-pre' do
   conflicts_with cask: 'background-music'
   depends_on macos: '>= :yosemite'
 
-  pkg "BackgroundMusic-#{version}.pkg"
+  pkg "BackgroundMusic-#{version}.unsigned.pkg"
 
   uninstall launchctl: 'com.bearisdriving.BGM.XPCHelper',
             pkgutil:   'com.bearisdriving.BGM',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.