### PR TITLE
Update dropbox-beta from 84.3.160 to 85.3.133

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '84.3.160'
-  sha256 'e92abc73eb386ccdd2edb721ba0e09a7d0f8e694bc1e6ad383a5bed3fe99b047'
+  version '85.3.133'
+  sha256 'e0c0b661d38b6f4a539eec6b2b7ad1d46a9d79e4b77709e1e6fe481b044fd20b'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.