### PR TITLE
Update visual-studio-code-insiders from 1.40.0,33cc09da7a314ea0ee5677d1927739af60d16734 to 1.40.0,93ee2fc3121b7f66ddf568c051f3bfff7db8d618

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.40.0,33cc09da7a314ea0ee5677d1927739af60d16734'
-  sha256 '93abff82557220e1a84e1ffe682d5f603116db8d85c6083cb0e94000c9d25b79'
+  version '1.40.0,93ee2fc3121b7f66ddf568c051f3bfff7db8d618'
+  sha256 '5662543d7fe1c4cd896c964d7fe8ba28d3578b438a9f0924c0c277ef95bf09a0'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.