### PR TITLE
Update signal-beta from 1.28.0-beta.3 to 1.28.0-beta.4

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.28.0-beta.3'
-  sha256 'a41372eeb7a2464379329884cf13faf822f2ece841480a5f7c53ac156e23b406'
+  version '1.28.0-beta.4'
+  sha256 '50b858ba2e82f36a5ecb654c4418626b7af490d3e6130c67ec88c888bf9de249'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.