### PR TITLE
Update java-beta from 14,14 to 14,21

### DIFF
--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,6 +1,6 @@
 cask 'java-beta' do
-  version '14,14'
-  sha256 'e099496d4dd8851f3df75ee96e0a26f206020f1cd8863bbce01a01566886b60f'
+  version '14,21'
+  sha256 '6d775c1a53b5316fc227370fcd5720ad52482f537a4676c714be4057feee11c8'
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_osx-x64_bin.tar.gz"
   name 'OpenJDK Early Access Java Development Kit'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.