### PR TITLE
Update toggl-beta from 7.4.1023 to 7.4.1036

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,6 +1,6 @@
 cask 'toggl-beta' do
-  version '7.4.1023'
-  sha256 'cd87582ece7538f6d1b8731a794e97b2d38df60f206ace0796b9c532a5b9e3c3'
+  version '7.4.1036'
+  sha256 '45461031b0aa58bba6c4990606cbd71e8a0583d33bc87ab01443ac4bc6723e6e'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

---
- [Appcast](https://assets.toggl.com/installers/darwin_beta_appcast.xml) says 1034
- [Download link (!DIRECT LINK!)](https://toggl.github.io/toggldesktop/download/macos-beta/) redirects to 1036
- [GitHub releases](https://github.com/toggl/toggldesktop/releases) say 9008
- Stable is 1023