### PR TITLE
iina-nightly: Remove conflict with removed iina-beta cask

### DIFF
--- a/Casks/iina-nightly.rb
+++ b/Casks/iina-nightly.rb
@@ -16,10 +16,7 @@ cask 'iina-nightly' do
   name 'iina-nightly'
   homepage 'https://iina.io/'
 
-  conflicts_with cask: [
-                         'iina',
-                         'iina-beta',
-                       ]
+  conflicts_with cask: 'iina'
   depends_on macos: '>= :el_capitan'
 
   app 'IINA.app'


### PR DESCRIPTION
`iina-beta` was removed in #8108. I forgot to remove the conflict in iina-nightly in this PR. Sorry for the inconvenience.