### PR TITLE
Update keka-beta from 1.1.5,2 to 1.2.0-dev.3575 + homepage + appcast

### DIFF
--- a/Casks/keka-beta.rb
+++ b/Casks/keka-beta.rb
@@ -6,7 +6,7 @@ cask 'keka-beta' do
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom'
   name 'Keka'
-  homepage 'https://www.kekaosx.com/'
+  homepage 'https://www.keka.io/#beta'
 
   auto_updates true
   conflicts_with cask: 'keka'

--- a/Casks/keka-beta.rb
+++ b/Casks/keka-beta.rb
@@ -4,7 +4,7 @@ cask 'keka-beta' do
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
-  appcast 'https://github.com/aonez/Keka/releases.atom'
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://beta.keka.io'
   name 'Keka'
   homepage 'https://www.keka.io/#beta'
 

--- a/Casks/keka-beta.rb
+++ b/Casks/keka-beta.rb
@@ -1,9 +1,9 @@
 cask 'keka-beta' do
-  version '1.1.5,2'
-  sha256 '82480e14daf94097710a3a3be0f01e6413cd7f45ea8b516aa8fdc4801c8418c8'
+  version '1.2.0-dev.3575'
+  sha256 'd72b75c1a613cb80a5506a2ae45a867258bdd62a9a41ec697dfe0bdb6003128b'
 
   # github.com/aonez/Keka was verified as official when first introduced to the cask
-  url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}-rc.#{version.after_comma}/Keka-#{version.before_comma}-rc.#{version.after_comma}.dmg"
+  url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg"
   appcast 'https://github.com/aonez/Keka/releases.atom'
   name 'Keka'
   homepage 'https://www.kekaosx.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.
---
1. Bump version from 1.1.5-rc2 -> 1.2.0-dev.3575
2. Change URL so that it's not hardcoded to being applicable only to RCs
3. Update homepage to point to project's new home
4. Change appcast to be specific to the beta releases instead of mixed with stable