### PR TITLE
Update mongodb-compass-beta from 1.13.0-beta.7 to 1.20.0-beta.8

### DIFF
--- a/Casks/mongodb-compass-beta.rb
+++ b/Casks/mongodb-compass-beta.rb
@@ -1,8 +1,9 @@
 cask 'mongodb-compass-beta' do
-  version '1.13.0-beta.7'
-  sha256 '3f34019371275dca275701c3f46a1b2dafa7e17940fe9caecb4233f6a648d132'
+  version '1.20.0-beta.8'
+  sha256 'b8cba2ee882ec68eb328c0c4882d5e31cb683fe8f869c20582c6ac3ce435c848'
 
   url "https://downloads.mongodb.com/compass/beta/mongodb-compass-#{version}-darwin-x64.dmg"
+  appcast 'https://www.mongodb.com/download-center/compass'
   name 'MongoDB Compass'
   homepage 'https://www.mongodb.com/products/compass'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.