### PR TITLE
Update iterm2-beta from 3.3.7beta2 to 3.3.7beta3

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.7beta2'
-  sha256 'b8dd0c8ebdecfed7ca66cf09cb1764ff19696319b10e5489377f93cfe7e9e7e8'
+  version '3.3.7beta3'
+  sha256 '79e6b712b9ea513121fd3b749e40a4c77b92463dd16b6caa00ca3c91abd857e7'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.