### PR TITLE
Update telegram-alpha from 5.8.1-185447,2313 to 5.3.1-185677,2322

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8.1-185447,2313'
-  sha256 '789bc72d46681a997d38b96d2356faf2bdc79470512df04bfa83e40dce55fee9'
+  version '5.3.1-185677,2322'
+  sha256 'eb66177c36d866d308f513106abad1c90c96c942901b8aae174920bda5bed622'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.