### PR TITLE
Update telegram-alpha from 5.8.1-185447,2313 to 5.8.1-185688,2323

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8.1-185447,2313'
-  sha256 '789bc72d46681a997d38b96d2356faf2bdc79470512df04bfa83e40dce55fee9'
+  version '5.8.1-185688,2323'
+  sha256 '70e9e705587b5feb331d1dc766706b67ba36c757d0f989ecc1707a239544ac4e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.