### PR TITLE
Update visual-studio-code-insiders from 1.40.0,515f496d9a7617caf07f38298f610920f60834d6 to 1.40.0,86405ea23e3937316009fc27c9361deee66ffbf5

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.40.0,515f496d9a7617caf07f38298f610920f60834d6'
-  sha256 '5b3b9f8a96234adb72b57c1ce53fb3f43bc650b733085ed978dd70de6ef09540'
+  version '1.40.0,86405ea23e3937316009fc27c9361deee66ffbf5'
+  sha256 '88d066e0b2a2423211bf83ef67107db8435c4b8706853a99c65aef9830511695'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.