### PR TITLE
Update opera-developer from 66.0.3489.0 to 66.0.3494.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '66.0.3489.0'
-  sha256 'df7005e2be511943adbf58792c13b5b34790590494c662657f2f0222c640636e'
+  version '66.0.3494.0'
+  sha256 '74d02fe363ae86481c39faa831e294c552ecf696f11d15f90d13fa0f97da190c'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.