### PR TITLE
Update dropbox-beta from 85.3.138 to 85.3.147

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '85.3.138'
-  sha256 '31ac52a3ceac1de0b254ecf2f26b26b67a8e6602d59b460b67d4306cb1f1ad4d'
+  version '85.3.147'
+  sha256 '25980735214ba9c3d20ea0b0b93ec97e6d956151674032bfc994eddc0369676d'
 
   # dropbox.com was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.