### PR TITLE
Update toggl-dev from 7.4.1023 to 7.4.9011

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.1023'
-  sha256 'cd87582ece7538f6d1b8731a794e97b2d38df60f206ace0796b9c532a5b9e3c3'
+  version '7.4.9010'
+  sha256 '554a4dcf24c88ea8c5318072be55d592b4a3258fd15f7d59aafb4f6fb63874ee'
 
   # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.