### PR TITLE
Update microsoft-remote-desktop-beta from 10.3.5.1713,365 to null.null,null

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,5 +1,5 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.3.5.1713,365'
+  version 'null.null,null'
   sha256 'e6e90cfb147e5b8657706e2c415bfaaed5583543fb1c427fcff6b6eb3a81e097'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.