### PR TITLE
Allow wine-* to be installed on Catalina

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -12,7 +12,6 @@ cask 'wine-devel' do
                             'wine-stable',
                             'wine-staging',
                           ]
-  depends_on macos: '<= :mojave'
   depends_on x11: true
 
   pkg "winehq-devel-#{version}.pkg",

--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -13,7 +13,6 @@ cask 'wine-staging' do
                             'wine-stable',
                             'wine-devel',
                           ]
-  depends_on macos: '<= :mojave'
   depends_on x11: true
 
   pkg "winehq-staging-#{version}.pkg",


### PR DESCRIPTION
As changes for `wine-stable` [are reverted](https://github.com/Homebrew/homebrew-cask/pull/72487), changes for `wine-devel` and `wine-staging` should be reverted as well.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).