### PR TITLE
Update microsoft-edge-beta from 79.0.309.12 to 79.0.309.18

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '79.0.309.12'
-  sha256 'd6f559fecb7d99c2fe18b09bb9509d1dcdb27006c29c8ea6f9c7d2c140f51b83'
+  version '79.0.309.18'
+  sha256 'f9d8f34504067189d4a72448c2adf1a58db1d86f29d0053aa4996d5731fffeff'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.