### PR TITLE
Update brave-browser-beta from 1.1.1 to 1.1.3

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '1.1.1'
-  sha256 '6c665c65db1c1907f158e54e594456b8dca81683ec60f057136af8db2f8c73cc'
+  version '1.1.3'
+  sha256 '18b33e8b97cdb697945d7ad0c1e181faca7878fa910e5860996d091bcc3ac9dc'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.