### PR TITLE
Update brave-browser-dev from 1.2.2 to 1.2.4

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '1.2.2'
-  sha256 '203552c0555835bd73c326c694b0b2a68f704f266e2c9409cc916d9bb1263302'
+  version '1.2.4'
+  sha256 'd021bcf40f7180f61b7159130bb45d2fd6e07acb258162619a0bf876e7610fbb'
 
   # github.com/brave/brave-browser was verified as official when first introduced to the cask
   url "https://github.com/brave/brave-browser/releases/download/v#{version}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.