### PR TITLE
Update visual-studio-code-insiders from 1.41.0,29b99f85e54aa5af6cd4edf918a67d4f70a10aea to 1.41.0,bd8425fa9b6427dca51e882d39b9ae764c55e08c

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.41.0,29b99f85e54aa5af6cd4edf918a67d4f70a10aea'
-  sha256 '01c676e433eabadafea7a06e93826d9537b2d4baa504b009f6dad915f48ae6d2'
+  version '1.41.0,bd8425fa9b6427dca51e882d39b9ae764c55e08c'
+  sha256 '48a8371947c3d89cce0818567b646579090e43cdd7c78aeadf39af48f8d60a59'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.