### PR TITLE
Update telegram-alpha from 5.8.1-185688,2323 to 5.8.2-185882,2360

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8.1-185688,2323'
-  sha256 '70e9e705587b5feb331d1dc766706b67ba36c757d0f989ecc1707a239544ac4e'
+  version '5.8.2-185882,2360'
+  sha256 '1f45cbe25163c98b730bdf48b237868025641187fd1502c4e9c35f51b81d8a4a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.