### PR TITLE
Update signal-beta from 1.29.0-beta.2 to 1.29.0-beta.3

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.29.0-beta.2'
-  sha256 '941687434efbd660b065bdc63585ba8789025b74a23ea0fc8f00e6b62c317346'
+  version '1.29.0-beta.3'
+  sha256 'e3a1dd30373eea77f3d3815be2a9c80bd7952060fecd36f35a569b142488fdb5'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.