### PR TITLE
Update visual-studio-code-insiders from 1.41.0,f24f483428f592a262dc73d68a3f05745c562b31 to 1.41.0,599c076d91be1374cf51004cec610f3bcaf4c9cd

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.41.0,f24f483428f592a262dc73d68a3f05745c562b31'
-  sha256 '4e88099e4e7b70e4f2bd813dd21e6dd06c046f14ce91c29d111ac8dcb5f9c0b8'
+  version '1.41.0,599c076d91be1374cf51004cec610f3bcaf4c9cd'
+  sha256 '2fcdd28037ff101e7027a0d3d65b91331825e91ba23e431efeaa242d62380c60'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.