### PR TITLE
Update vivaldi-snapshot from 2.9.1732.13 to 2.9.1735.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.9.1732.13'
-  sha256 '897bcd0863d2925d64b1607397f13256f14c1a2bc0fbe9e6750643b9e51ef1a6'
+  version '2.9.1735.3'
+  sha256 '3eb2c9bfb4d6152825f1a71448a680358885d7a8eb75f6d5e5c3cb02ee2a1c3d'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.