### PR TITLE
Update microsoft-remote-desktop-beta from 10.3.5.1723,405 to 10.3.6.1724,411

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.3.5.1723,405'
-  sha256 '7ec1d24fc3e6843751bc67b71c66c1659bdd8345d561f0dbf5dbba9b919852e5'
+  version '10.3.6.1724,411'
+  sha256 '536f577347f244d593a9ea59855978dea77ea580fd895912c762261ee8ce03fa'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.