### PR TITLE
Update visual-studio-code-insiders from 1.41.0,abbf52b1378e2976803f81b1317fe3a5e6e39c23 to 1.41.0,a63d88ec550107a66c08d813fb5d3c32c9e131a7

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.41.0,abbf52b1378e2976803f81b1317fe3a5e6e39c23'
-  sha256 '69e658be8225b32b01bf16a35b47c9ebca4d5fabb73daafc8539d9de18a42539'
+  version '1.41.0,a63d88ec550107a66c08d813fb5d3c32c9e131a7'
+  sha256 '8f275181a05cba51ff75a1054e09d165dbb46af5e0f5f3cb4d7df6ebcc03dc7c'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.