### PR TITLE
Update sublime-text-dev from 3.210 to 4.056

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -4,6 +4,7 @@ cask 'sublime-text-dev' do
 
   url "https://download.sublimetext.com/sublime_text_build_#{version.no_dots}_mac.zip"
   appcast "https://www.sublimetext.com/updates/#{version.major}/dev_update_check"
+          configuration: version.no_dots
   name 'Sublime Text'
   homepage "https://www.sublimetext.com/dev"
 

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -1,12 +1,11 @@
 cask 'sublime-text-dev' do
-  version '3.210'
-  sha256 'a52f309f5dc708b016ceb8ee0960d24252050c8fcc9f3a6f22c275b8a27e1767'
+  version '4.056'
+  sha256 '475c2fae70ee79e67c994e53e53e8b3d3a4d1bb89c139efabbc495d5fee5cb99'
 
-  url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
-  appcast "https://www.sublimetext.com/updates/#{version.major}/dev/appcast_osx.xml",
-          configuration: version.no_dots
+  url "https://download.sublimetext.com/sublime_text_build_#{version.no_dots}_mac.zip"
+  appcast "https://www.sublimetext.com/updates/#{version.major}/dev_update_check"
   name 'Sublime Text'
-  homepage "https://www.sublimetext.com/#{version.major}dev"
+  homepage "https://www.sublimetext.com/dev"
 
   auto_updates true
   conflicts_with cask: 'sublime-text'
@@ -17,7 +16,8 @@ cask 'sublime-text-dev' do
   uninstall quit: "com.sublimetext.#{version.major}"
 
   zap trash: [
-               "~/Library/Application Support/Sublime Text #{version.major}",
+               "~/Library/Application Support/Sublime Text",
+               "~/Library/Application Support/Sublime Text (Safe Mode)",
                "~/Library/Caches/com.sublimetext.#{version.major}",
                "~/Library/Preferences/com.sublimetext.#{version.major}.plist",
                "~/Library/Saved Application State/com.sublimetext.#{version.major}.savedState",

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -3,7 +3,7 @@ cask 'sublime-text-dev' do
   sha256 '475c2fae70ee79e67c994e53e53e8b3d3a4d1bb89c139efabbc495d5fee5cb99'
 
   url "https://download.sublimetext.com/sublime_text_build_#{version.no_dots}_mac.zip"
-  appcast "https://www.sublimetext.com/updates/#{version.major}/dev_update_check"
+  appcast "https://www.sublimetext.com/updates/#{version.major}/dev_update_check",
           configuration: version.no_dots
   name 'Sublime Text'
   homepage "https://www.sublimetext.com/dev"

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -6,7 +6,7 @@ cask 'sublime-text-dev' do
   appcast "https://www.sublimetext.com/updates/#{version.major}/dev_update_check",
           configuration: version.no_dots
   name 'Sublime Text'
-  homepage "https://www.sublimetext.com/dev"
+  homepage 'https://www.sublimetext.com/dev'
 
   auto_updates true
   conflicts_with cask: 'sublime-text'
@@ -17,8 +17,8 @@ cask 'sublime-text-dev' do
   uninstall quit: "com.sublimetext.#{version.major}"
 
   zap trash: [
-               "~/Library/Application Support/Sublime Text",
-               "~/Library/Application Support/Sublime Text (Safe Mode)",
+               '~/Library/Application Support/Sublime Text',
+               '~/Library/Application Support/Sublime Text (Safe Mode)',
                "~/Library/Caches/com.sublimetext.#{version.major}",
                "~/Library/Preferences/com.sublimetext.#{version.major}.plist",
                "~/Library/Saved Application State/com.sublimetext.#{version.major}.savedState",


### PR DESCRIPTION
- appcasts now use JSON format instead of XML
  - similar to sublime-merge(-dev)
- homepage hasn't been updated, yet
- running `subl --safe-mode` mimicks a clean install with its own application data
  - cleared upon next launch in safe mode