### PR TITLE
Update rstudio-preview from 1.2.5025 to 1.2.5031

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.5025'
-  sha256 '95a5e41c36f7194efd38893854f35555e06ae25fe717140bd2939aba255f618b'
+  version '1.2.5031'
+  sha256 '45d2f45f812d1d51fe457769d098679d8c4f7bfa1cfa81147c3b064cd297d7ac'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.