### PR TITLE
Update visual-studio-code-insiders from 1.41.0,7cf4cca47aa025a590fc939af54932042302be63 to 1.41.0,97855786a014be2440751b038b373c3726e11fe8

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.41.0,7cf4cca47aa025a590fc939af54932042302be63'
-  sha256 'e8a25e0182c1b6dfb6d0f6dd84ef2d7f0dc3ca3fb23b2fa2a0c8c7eb5a466564'
+  version '1.41.0,97855786a014be2440751b038b373c3726e11fe8'
+  sha256 'd916a4c690bacfba8d662fa8c79912119290ca324cc37123c83eff3b5bc3eafa'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.