### PR TITLE
Update mongodb-compass-beta from 1.20.0-beta.8 to 1.20.0-beta.9

### DIFF
--- a/Casks/mongodb-compass-beta.rb
+++ b/Casks/mongodb-compass-beta.rb
@@ -1,6 +1,6 @@
 cask 'mongodb-compass-beta' do
-  version '1.20.0-beta.8'
-  sha256 'b8cba2ee882ec68eb328c0c4882d5e31cb683fe8f869c20582c6ac3ce435c848'
+  version '1.20.0-beta.9'
+  sha256 '69e118e4aab5688d8ed70e581043b951adc95da98272c6ea1b1117598607ce3c'
 
   url "https://downloads.mongodb.com/compass/beta/mongodb-compass-#{version}-darwin-x64.dmg"
   appcast 'https://www.mongodb.com/download-center/compass'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.