### PR TITLE
Update telegram-alpha from 5.8.2-186513,2365 to 5.8.2-186601,2367

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8.2-186513,2365'
-  sha256 '5bf38d017949bfd971e10c747a43fe56a4c6ef57fddaa269b131f7dffa19cd86'
+  version '5.8.2-186601,2367'
+  sha256 'beac75d5932e273efef2dbb57110c8f58d569edd43b3438f533ca70f0a305684'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.