### PR TITLE
Update firefox-esr from 68.2.0 to 68.3.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '68.2.0'
+  version '68.3.0'
 
   language 'cs' do
-    sha256 '51b802afa1eec858f132d1bc9f21804e27501c4fa7f4b780169c913f223cf61f'
+    sha256 '433ea9843179108efe339d59aa21690a72154d9be29c8697c6749a0dca1c09e1'
     'cs'
   end
 
   language 'de' do
-    sha256 '3cf657e6a7fa39c983e06c320c662c1dbc413b221c78a9280efd624fd805feeb'
+    sha256 '0c2cdcf304598ca15a8ea68a2aed666c5c0562d3c45e5c1a4af567aed039ba0b'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '653f7e96d94df932f47ee6283ff277c5441edda2e1fed898c49e841cd89c212d'
+    sha256 '28c079b25d86e31d9455dce2a58d69366a708993373f93b425622a08cbda7a2a'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 '7e6b800f528288e3411fe58b3583772ba140587f9e020f2be437d9b5a7400233'
+    sha256 '637464c112068c430415636c725639615edd40eddd2ed3ddea19af3d7b8575e3'
     'en-US'
   end
 
   language 'fr' do
-    sha256 'b597d0ac68577cad5055924cdd28db4d245d4943a41528019308afe0a0d6f4f4'
+    sha256 '037cd6eb542037ba601d265d2aa2b2411c1e3da99fbff2b4e0d03bac940645f9'
     'fr'
   end
 
   language 'gl' do
-    sha256 '5ba7f557736c8b0f3966bc827f6a6827483a48015f62e7d434d5805800b13e55'
+    sha256 'e9fe183163f4a05f55ee174a24bd82f3d10955c5dcf85b8405cc94db3b3896d5'
     'gl'
   end
 
   language 'it' do
-    sha256 'afbf946fee0a77e8ec37086615d3e41bed811f07adc67629b5d18e8063bf394d'
+    sha256 'a9a5711560371a512b92dca1116775ee9227f217f19172bce3b9ace7f58c4a97'
     'it'
   end
 
   language 'ja' do
-    sha256 'b5aae13d65b8a956b8684319c280c2f77a8e26dfd254e2949d21e3a19c7e2418'
+    sha256 '780022ed6c5ad20a4a8e95b7252937e67e6ae4543dcb27d6537ed53bee5ccc35'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '56bd69f9ed937e4ffb51ea970a042d204f790849d17be97ed6dc104e619a4457'
+    sha256 '7ced447d029f5ec98ff099a4286950cda6770d9578c0d3b52bd8500d0c606d8d'
     'nl'
   end
 
   language 'pl' do
-    sha256 '188e99d2e207a625fcd658a1b1d12152d7b6f9af64b5be72e2e9085cfdc61d80'
+    sha256 '1d514859c0d9456dc3f6425d36bd8c32834a8353d05b2886d833880b4d773516'
     'pl'
   end
 
   language 'pt' do
-    sha256 '9ee7896a27dd02b3463b2e9dd2c4840b76bf304ce122babfe03e836290bbb565'
+    sha256 '098c5fc1e3ad6a7766b58de9fdc35a345ece5c8edd61a9e5e096e8d2d27af732'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'b3f115f7bee0dfc40e5e4efc5b8f4c81c2b5d45c2199ce14770c4d6923af3a38'
+    sha256 '3d86e1f07fb71ea01ecf68f717021bd5a90a8ad7888f3308ab159e24a8afffe8'
     'ru'
   end
 
   language 'uk' do
-    sha256 '990a013353fa806f9d674c7a486260940abaec7e7f78cfce6413fac1770018e0'
+    sha256 '9bd3c78252786582f20390fd5c0308e62406ba5b1665582f7076d3bcc7117849'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '0df3167bc78057467d26bc808a51ba1c9d729019aee823fba6c67a1b8826bbef'
+    sha256 '3fa0d190c00b95321fc5647e94bd03e16cd24c36b5f97c460e7d08147dc4078b'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '7b271fe4e7afc27e424b792835d078976e65f032ce23c1211e97c33b51953e36'
+    sha256 'e604d73685f98af29b6f2c22cf3ef0a0b683cee9cdae2794d4990caa38c5cc84'
     'zh-CN'
   end
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
