### PR TITLE
Update opera-beta from 65.0.3467.32 to 66.0.3515.3

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '65.0.3467.32'
-  sha256 '85be55f7cf4845fbe773d363ce4ae0ffbdc21e1dc3981aa74390dd649fdaab5d'
+  version '66.0.3515.3'
+  sha256 '01ec9270d41085c44ce0b40e68f2b63e4b2f6295f6ef144eddffe2263d4dc0c8'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.