### PR TITLE
Update visual-studio-code-insiders from 1.41.0,97855786a014be2440751b038b373c3726e11fe8 to 1.41.0,bbf00d8ea6aa7e825ca3393364d746fe401d3299

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.41.0,97855786a014be2440751b038b373c3726e11fe8'
-  sha256 'd916a4c690bacfba8d662fa8c79912119290ca324cc37123c83eff3b5bc3eafa'
+  version '1.41.0,bbf00d8ea6aa7e825ca3393364d746fe401d3299'
+  sha256 'd93dde09ac51f0ce9fd0a94b7890af6926a39d032c17d0448fbfcb208f0e98f8'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.