### PR TITLE
Update mullvadvpn-beta from 2019.9-beta1 to 2019.10-beta2

### DIFF
--- a/Casks/mullvadvpn-beta.rb
+++ b/Casks/mullvadvpn-beta.rb
@@ -1,6 +1,6 @@
 cask 'mullvadvpn-beta' do
-  version '2019.9-beta1'
-  sha256 '76128b9418728289179de8962ecb1797091c6a91ef5cc1db8480f7561db2f74a'
+  version '2019.10-beta2'
+  sha256 'fb80c987c79dfd035fd55facb88db8cb2a5724837c149102cbf8076afadc4f4c'
 
   # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.