### PR TITLE
Update microsoft-remote-desktop-beta from 10.3.6.1727,414 to 10.3.7.1731,417

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.3.6.1727,414'
-  sha256 'e1c9cf1a98c65d6c41f0e7645d4769f3e712f0b51c33c3e27756e3983d1d3682'
+  version '10.3.7.1731,417'
+  sha256 'e1c9d863663ffb16677a7d7c28df0c7b3b5ba51e9db55e6381900503ced44623'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.