### PR TITLE
Update toggl-dev from 7.4.1065 to 7.4.1080

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.1065'
-  sha256 '70ab7f1f27c96a5c22a8cba2a1950b7ca36843ab383871d64b828c16b167df5b'
+  version '7.4.1080'
+  sha256 '13c7595ac506df66cfea52579066254162d97ef91cfebdba1d231d13adeddc0d'
 
   # github.com/toggl-open-source/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.