### PR TITLE
Update vivaldi-snapshot from 2.9.1745.9 to 2.9.1745.22

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.9.1745.9'
-  sha256 '45bf3d46873e94407c294ee690b45f1072ec8989587fd9caeaee7a806c77942d'
+  version '2.9.1745.22'
+  sha256 '5f75dc618337928a92978988fcbc314ab48be54ac91dd3ab62ef25bfd3710847'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.