### PR TITLE
Update toggl-dev from 7.4.1080 to 7.4.1092

### DIFF
--- a/Casks/toggl-dev.rb
+++ b/Casks/toggl-dev.rb
@@ -1,6 +1,6 @@
 cask 'toggl-dev' do
-  version '7.4.1080'
-  sha256 '13c7595ac506df66cfea52579066254162d97ef91cfebdba1d231d13adeddc0d'
+  version '7.4.1092'
+  sha256 '0a6bb7925513e64e3d9cdce0ef2beb692051d628907ca21be39696796be57cda'
 
   # github.com/toggl-open-source/toggldesktop was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.