### PR TITLE
Update termius-beta from 5.0.6 to 5.1.1

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8.2-186679,2368'
-  sha256 'cc30c5e1efd8806032ff314265d3a3ef61c4826cce113f01379799d12cc233f7'
+  version '5.8.2-186833,2369'
+  sha256 'dfc0fa8d7b14e731ca73a3fc02d2b85fe63ed899f11d31adaa51ffd73eda350a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"

--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask 'termius-beta' do
-  version '5.0.6'
-  sha256 '495e376118ffb6a5c27d4814f453aea2d564dade747c305ed291c857d7b1a1b3'
+  version '5.1.1'
+  sha256 'e6d7583eb9766f0fa37aa0f0df02393fe46a9b207afed9c8cfc76af7caafcd99'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.