### PR TITLE
Update brave-browser-dev from 79.1.3.60,103.60 to 79.1.3.61,103.61

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '79.1.3.60,103.60'
-  sha256 '8fb3adb58d049b45a689b805e938e8acdd7729b4b461e2c6d9e6939eb14a7bed'
+  version '79.1.3.61,103.61'
+  sha256 '11f17a5340ace43285e7506584f44e3c718f0e5cb9016185caba41055834d93a'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"

--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8.2-186679,2368'
-  sha256 'cc30c5e1efd8806032ff314265d3a3ef61c4826cce113f01379799d12cc233f7'
+  version '5.8.2-186833,2369'
+  sha256 'dfc0fa8d7b14e731ca73a3fc02d2b85fe63ed899f11d31adaa51ffd73eda350a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.