### PR TITLE
Update visual-studio-code-insiders from 1.41.0,87c2e0be5d7359ce110c4c9ec9f6df71be996f8a to 1.41.0,455d8f73cd7c73285fba70ab039a26279f19bb57

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8.2-186679,2368'
-  sha256 'cc30c5e1efd8806032ff314265d3a3ef61c4826cce113f01379799d12cc233f7'
+  version '5.8.2-186833,2369'
+  sha256 'dfc0fa8d7b14e731ca73a3fc02d2b85fe63ed899f11d31adaa51ffd73eda350a'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.41.0,87c2e0be5d7359ce110c4c9ec9f6df71be996f8a'
-  sha256 'a4f2ebea720b199201fec6c6d9f7dce19910b6cbcbbf598551d386bbe8c1114e'
+  version '1.41.0,455d8f73cd7c73285fba70ab039a26279f19bb57'
+  sha256 'b91ae9048725b0c226fc438492358dbf87459da3bc565fb5580aae20587426b0'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.