### PR TITLE
Update iterm2-beta from 3.3.8beta1 to 3.3.8beta2

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.8beta1'
-  sha256 'cc71fa2e515a74ee8d4b70b9c91ebb6627dcd409f9dded180b20fcdba454fb00'
+  version '3.3.8beta2'
+  sha256 '9b07fad5549de04b88599d88c4435decb17a41ebf863195f88d0d950405e0a60'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.