### PR TITLE
Update texstudio-beta from 2.12.16beta3 to 2.12.18beta1

### DIFF
--- a/Casks/texstudio-beta.rb
+++ b/Casks/texstudio-beta.rb
@@ -1,6 +1,6 @@
 cask 'texstudio-beta' do
-  version '2.12.16beta3'
-  sha256 '4368b5b0ed664d65ea145ae91a8df6e49af2c54f0b3e45c0db9b9e6927517b1f'
+  version '2.12.18beta1'
+  sha256 '1dfa02edb649545f4c99f6f121cf395d4f5eec86c347118bacd622ee4950f40d'
 
   # github.com/texstudio-org/texstudio was verified as official when first introduced to the cask
   url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.