### PR TITLE
Update signal-beta from 1.29.0-beta.5 to 1.30.0-beta.1

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.29.0-beta.5'
-  sha256 '5d69a1f9a40c7d907a522496506cc65ba2ae0902ad5b1ef74507fa539a2a9670'
+  version '1.30.0-beta.1'
+  sha256 'd83309bc680a5cadaebeb14b64b0caa43d2049d9743901374ed53741e0c3d2ce'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.