### PR TITLE
Actions: update to macOS-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ci:
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     steps:
       - name: brew pull
         run: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   style:
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     steps:
       - name: debug
         run: |


### PR DESCRIPTION
The macOS 10.14 VM has been deprecated, so this needs to update to target the latest version. 10.15 is now the [only supported macOS version](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners).

(I've removed the PR template since this doesn't touch an actual cask. 😄)