### PR TITLE
Update brave-browser-dev from 79.1.3.69,103.69 to 79.1.3.70,103.70

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '79.1.3.69,103.69'
-  sha256 'a2def2bc0aef3be601f7ce3be1128f904d971628b184fceaca56aec73faea50a'
+  version '79.1.3.70,103.70'
+  sha256 '61dfd430af0003a4a6f0bae78d53731e505ebd57c605bee3a2dd5c15d67c9d21'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.