### PR TITLE
Update wine-devel from 4.21 to 5.0-rc2

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '4.21'
-  sha256 'af23d743f787e74c3bf12da3e7d9cd22990f49a2f2eb20b05d36835b776eb459'
+  version '5.0-rc2'
+  sha256 '46b624af7680c39da03469ce1577f7fcff35cf04de61cf990bb15f5074778cd6'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.