### PR TITLE
Update brave-browser-dev from 79.1.3.70,103.70 to 79.1.3.72,103.72

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '79.1.3.70,103.70'
-  sha256 '61dfd430af0003a4a6f0bae78d53731e505ebd57c605bee3a2dd5c15d67c9d21'
+  version '79.1.3.72,103.72'
+  sha256 '921daefff07ef837c5be2f16e2572c7a0f730dcfe2fb89688e8f99d3da64102e'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.