### PR TITLE
Update iterm2-beta from 3.3.8beta3 to 3.3.8beta4

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.8beta3'
-  sha256 '83dcc4f469a47e893de15c13cba4c734c374c6e3986502daeedd848fe02662de'
+  version '3.3.8beta4'
+  sha256 'cb080ea91af7a38c0ebd2b3866c827cac40b9a491523715ddcad52eabb388f47'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.