### PR TITLE
Update brave-browser-dev from 79.1.4.49,104.49 to 79.1.4.51,104.51

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '79.1.4.49,104.49'
-  sha256 'f4bdee8357458eb4a4f2e0638126bf1974399288e520afbb49b542ae11459c6f'
+  version '79.1.4.51,104.51'
+  sha256 '8f2fbc87ac1b8b9e40dbb5631417ebd9d7ad0894f1db30dca36a93afec6d1fd6'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.