### PR TITLE
Update brave-browser-dev from 79.1.4.52,104.52 to 79.1.4.53,104.53

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '79.1.4.52,104.52'
-  sha256 'a36302b7ef455c7769f1b0a282c0efca41101a859208b2606c1c4cec2482219f'
+  version '79.1.4.53,104.53'
+  sha256 '0d8ddec8f1db67da81eae38d95935612b9fe9555eeb1a21d000b0122c3123bc2'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.