### PR TITLE
Update microsoft-edge-dev from 80.0.355.1 to 81.0.381.0

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '80.0.355.1'
-  sha256 'c4cf66b30f934adee912721115179d00464659523a7cd3246d811927b3489a6b'
+  version '81.0.381.0'
+  sha256 '346248538476a3d72a5b149bf06563dbffeac786981634a623a1e82299f721b1'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.