### PR TITLE
Update microsoft-edge-beta from 79.0.309.58 to 79.0.309.63

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '79.0.309.58'
-  sha256 'f74a987d1a3c1f44d7406024fa7b4f43caf404651ef5b75b44cf1aecb1ca92a9'
+  version '79.0.309.63'
+  sha256 '7d1c2a0978fc156a727c386502d59315ce0d5cdb4ff3117158d1256d089686e5'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.