### PR TITLE
Update telegram-alpha from 5.8.2-188447,2386 to 5.8.2-189012,2394

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.8.2-188447,2386'
-  sha256 '98e449abac106c33e5ed060a80a1c186917dba2963de625d354ef66efa834ee5'
+  version '5.8.2-189012,2394'
+  sha256 '47bb6b339a8a8f61a3ad93e1aef87c67e266e9c0b8684f5b3844c1bbd1d3a12e'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.