### PR TITLE
Update signal-beta from 1.30.0-beta.3 to 1.30.0-beta.4

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.30.0-beta.3'
-  sha256 '13521c3bb7e0b0fc72cfd00f130f046b62562fe28d51f11d028eb60b4487e899'
+  version '1.30.0-beta.4'
+  sha256 'da601c9cba6ebb15810c711cec7b2f7f54933eb550d7ba52b13403141ab0abbf'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.