### PR TITLE
Update vivaldi-snapshot from 2.10.1745.7 to 2.11.1789.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.10.1745.7'
-  sha256 '256fb58981df3237575c329fe1c67e2ac3de1d0d3f7cd32adb003ccb03107d5a'
+  version '2.11.1789.3'
+  sha256 'a9c5565e1123a64fea10d4105d809e0b0a38ec3e1161902a7f89c8482bc2f5c0'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.