### PR TITLE
Update corretto8 from 8.232.09.2 to 8.242.07.1

### DIFF
--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,12 +1,11 @@
 cask 'corretto8' do
-  version '8.232.09.2'
-  sha256 'b31250af04e1a88d4345997949154b380249afcde49baba6bdc3c035d10127dd'
+  version '8.242.07.1'
+  sha256 '12b765736520d91a8084837ac39c80bcb8e08cb12792d9e6e524239d1b085779'
 
-  # d3pxv6yz143wms.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d3pxv6yz143wms.cloudfront.net/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
+  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast "https://docs.aws.amazon.com/en_us/corretto/latest/corretto-#{version.major}-ug/corretto-#{version.major}-ug.rss"
   name 'Amazon Corretto'
-  homepage 'https://aws.amazon.com/corretto/'
+  homepage 'https://corretto.aws/'
 
   pkg "amazon-corretto-#{version}-macosx-x64.pkg"
 


### PR DESCRIPTION
This also updates the formula to use new url with corretto.aws domain. This matches the [change made to corretto 11](https://github.com/Homebrew/homebrew-cask/pull/75675) and the [Corretto 8 version specific downloads page](https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html#download).

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.