### PR TITLE
Update texstudio-beta from 2.12.22beta1 to 2.12.22beta2

### DIFF
--- a/Casks/texstudio-beta.rb
+++ b/Casks/texstudio-beta.rb
@@ -1,6 +1,6 @@
 cask 'texstudio-beta' do
-  version '2.12.22beta1'
-  sha256 '5231402eba212a5cc3ce990e3e866c9374128b987427e1f0d0327b810277fe6b'
+  version '2.12.22beta2'
+  sha256 'e8b06b108321dbf238327a3645d6b8f21126f14819e09e6df3bad1ca29c63dfa'
 
   # github.com/texstudio-org/texstudio was verified as official when first introduced to the cask
   url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.