### PR TITLE
Update dolphin-dev from 5.0-11094 to 5.0-11518

### DIFF
--- a/Casks/dolphin-dev.rb
+++ b/Casks/dolphin-dev.rb
@@ -1,13 +1,19 @@
 cask 'dolphin-dev' do
-  version '5.0-11094'
-  sha256 '9f29ae7bc4a2a73e1e11eadcff4444209ad62679ef2d207678c7a08d1e6ac88f'
+  version '5.0-11518'
+  sha256 '5dc9e3b0931f8ce0a3eb0bcafdc78565bdfbf3cfb7b39daebef8e69f3500da2f'
 
-  url "https://dl.dolphin-emu.org/builds/dolphin-master-#{version}.dmg"
-  appcast 'https://github.com/dolphin-emu/dolphin/releases.atom'
+  url "https://dl.dolphin-emu.org/builds/75/70/dolphin-master-#{version}.dmg"
   name 'dolphin-dev'
   homepage 'https://dolphin-emu.org/'
 
+  auto_updates true
   conflicts_with cask: 'dolphin'
 
   app 'Dolphin.app'
+  app 'Dolphin Updater.app'
+
+  zap trash: [
+               '~/Library/Application Support/Dolphin',
+               '~/Library/Preferences/org.dolphin-emu.dolphin.plist',
+             ]
 end


### PR DESCRIPTION
Remove appcast since it's for the stable releases of Dolphin only.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
