### PR TITLE
Update telegram-desktop-dev from 1.9.1.beta to 1.9.4

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.9.1.beta'
-  sha256 '697f1351eefb433c35c2efc92f7132b9b38f8d7edd467f6237f5c0dc64eba2f1'
+  version '1.9.4'
+  sha256 'a2f341c8ec713742d2800457c44eabd4266e8a3a94827573d286fe6721989508'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.