### PR TITLE
Update julia-nightly from 1.4 to 1.5

### DIFF
--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -1,5 +1,5 @@
 cask 'julia-nightly' do
-  version '1.4'
+  version '1.5'
   sha256 :no_check # required as upstream package is updated in-place
 
   url 'https://julialangnightlies-s3.julialang.org/bin/mac/x64/julia-latest-mac64.dmg'

--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -7,7 +7,7 @@ cask 'julia-nightly' do
   homepage 'https://julialang.org/'
 
   app "Julia-#{version}.app"
-  binary "#{appdir}/Julia-#{version}.app/Contents/Resources/julia/bin/julia"
+  binary "#{appdir}/Julia-#{version}.app/Contents/Resources/julia/bin/julia", target: 'julia-nightly'
 
   zap trash: '~/.julia'
 end


### PR DESCRIPTION
This change includes:

1. Updating julia-nightly from 1.4 to 1.5
2. Making the binary target `julia-nightly` rather than `julia` (to avoid conflicts with the primary julia cask).

I've placed these changes as separate commits in one PR, but I'm happy to squash or make separate PRs if requested.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
  - NOTE: The middle commit doesn't change the version, but I can always squash it if you prefer?
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
