### PR TITLE
Update rstudio-preview from 1.2.5034 to 1.2.5036

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.2.5034'
-  sha256 '932c3d0f0cd9cf6f09ad702c16509ae63c324604b25048be4ccbff4125dd904a'
+  version '1.2.5036'
+  sha256 'b6632c07063aa0d998ef879f838ea99b36d24c98f477ce2f3f605d121149cdc3'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.