### PR TITLE
Update openemu-experimental from 2.2 to 2.2.1

### DIFF
--- a/Casks/openemu-experimental.rb
+++ b/Casks/openemu-experimental.rb
@@ -1,6 +1,6 @@
 cask 'openemu-experimental' do
-  version '2.2'
-  sha256 'a966b6a286b7d0cc74da7abca43b715a26a7ea87cd11bde030380b84c8047a14'
+  version '2.2.1'
+  sha256 '8977f563868a312b72298dc7cd2b8767c21b440bae598d16a7d3916a98d870e8'
 
   # github.com/OpenEmu/OpenEmu was verified as official when first introduced to the cask
   url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}-experimental.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.