### PR TITLE
Update telegram-alpha from 5.9.1-189493,2413 to 5.9.1-190053,2414

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.9.1-189493,2413'
-  sha256 '126ac912dd5fd1d03bfb70bec800bb952a4c94bc9953edebaab3d35be13bf948'
+  version '5.9.1-190053,2414'
+  sha256 'b139e212aff7851a2ac41f5d2c69e2b184e64767c4c7ad8798927263726b85ca'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.