### PR TITLE
Update telegram-desktop-dev from 1.9.8 to 1.9.9

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '1.9.8'
-  sha256 '5086a21997837f4abb1ea6de0346b9e7748dd423b6a30fe2eef4bd9593943c65'
+  version '1.9.9'
+  sha256 '6e2d7cb794d47e40ff58cad3be1e16136cc2d3cb4b0def4a3911bf083c9940fc'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.