### PR TITLE
Update airmail-beta to 4.0,456

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,9 +1,9 @@
 cask 'airmail-beta' do
-  version '4.0,456:1d5be16b070a28f1d94639690cb9764faf862fce'
+  version '4.0,456'
   sha256 'b319e3ab6e7ffc159bac49c3c882e50d44c472c0745d09e6fb41436d26fb61fd'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.before_colon}?format=zip&mctoken=#{version.after_comma.after_colon}"
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.before_colon}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -3,7 +3,7 @@ cask 'airmail-beta' do
   sha256 'b319e3ab6e7ffc159bac49c3c882e50d44c472c0745d09e6fb41436d26fb61fd'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.before_colon}?format=zip&"
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,9 +1,9 @@
 cask 'airmail-beta' do
-  version '4.0,450'
-  sha256 '09f6728d73531b98150f888f913dffed5d31dbc01ec93bb9d9ab29ea96d5457f'
+  version '4.0,456:1d5be16b070a28f1d94639690cb9764faf862fce'
+  sha256 'b319e3ab6e7ffc159bac49c3c882e50d44c472c0745d09e6fb41436d26fb61fd'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
+  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma.before_colon}?format=zip&mctoken=#{version.after_comma.after_colon}"
   appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'


### PR DESCRIPTION
Include `mctoken` in `version` as it is needed when downloading old version.

---
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
