### PR TITLE
Update airmail-beta from 4.0,456 to 4.0,589

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '4.0,456'
-  sha256 'b319e3ab6e7ffc159bac49c3c882e50d44c472c0745d09e6fb41436d26fb61fd'
+  version '4.0,589'
+  sha256 '1f5b5413383fa54b0703d6614c5d9c03b16ae2c8a6e0b9a16d585c3aa74ef3b0'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.