### PR TITLE
Update tunnelblick-beta from 3.8.2beta03,5430 to 3.8.2beta04,5440

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick-beta' do
-  version '3.8.2beta03,5430'
-  sha256 '90494d8db75fb590209ac8679ba3ab21f5603afe1575fa909115d31cffca93a9'
+  version '3.8.2beta04,5440'
+  sha256 '5d596082474c8f5f4f7e1c40a63e7e11f948429b04a9c55f99250321fdd668f4'
 
   # github.com/Tunnelblick/Tunnelblick was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.