### PR TITLE
Update google-chrome-beta to remove depends_on macos: '>= :mavericks'

### DIFF
--- a/Casks/google-chrome-beta.rb
+++ b/Casks/google-chrome-beta.rb
@@ -10,7 +10,6 @@ cask 'google-chrome-beta' do
                          'google-chrome',
                          'google-chrome-dev',
                        ]
-  depends_on macos: '>= :mavericks'
 
   app 'Google Chrome.app'
 


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/issues/58046#issuecomment-460004001