### PR TITLE
Update google-chrome-canary to remove depends_on macos: '>= :mavericks'

### DIFF
--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -6,8 +6,6 @@ cask 'google-chrome-canary' do
   name 'Google Chrome Canary'
   homepage 'https://www.google.com/chrome/browser/canary.html?platform=mac'
 
-  depends_on macos: '>= :mavericks'
-
   app 'Google Chrome Canary.app'
 
   uninstall launchctl: [


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/issues/58046#issuecomment-460004001