### PR TITLE
Update google-chrome-dev  to remove depends_on macos: '>= :mavericks'

### DIFF
--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -10,7 +10,6 @@ cask 'google-chrome-dev' do
                          'google-chrome',
                          'google-chrome-beta',
                        ]
-  depends_on macos: '>= :mavericks'
 
   app 'Google Chrome.app'
 


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/issues/58046#issuecomment-460004001