### PR TITLE
Update airmail-beta from 4.0,590 to 4.0,591

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '4.0,590'
-  sha256 'cd0d68dd346191d5045bb4e5f1bcb62870523b29695dbff8eb9e8763c9256bdf'
+  version '4.0,591'
+  sha256 '1b52a70e8c02231d433db0211b4bce7d42fd09fefa871b76460c87cef4e6ae03'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.