### PR TITLE
Update brave-browser-beta from 79.1.3.106,103.106 to 79.1.3.107,103.107

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '79.1.3.106,103.106'
-  sha256 '4b3d8bc5a73c39c8d9586748b04c7d89539b47e775828217efd6484e703887ff'
+  version '79.1.3.107,103.107'
+  sha256 'de889ab239563939c8d996188c91b42f38291ea5660861d289c84f9983c25b96'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/beta/#{version.after_comma}/Brave-Browser-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.