### PR TITLE
Update brave-browser-dev from 79.1.4.66,104.66 to 79.1.4.76,104.76

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '79.1.4.66,104.66'
-  sha256 'eeb03b69d7238fbb09a71fb610ebe169a7f053c147949537a3be70442e46eebc'
+  version '79.1.4.76,104.76'
+  sha256 'a5298975cd2cf22bde89b3ece303f79cc630f310e835385ad00ca2786ff17f55'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.