### PR TITLE
Update mullvadvpn-beta from 2019.10-beta2 to 2020.1-beta1

### DIFF
--- a/Casks/mullvadvpn-beta.rb
+++ b/Casks/mullvadvpn-beta.rb
@@ -1,6 +1,6 @@
 cask 'mullvadvpn-beta' do
-  version '2019.10-beta2'
-  sha256 'fb80c987c79dfd035fd55facb88db8cb2a5724837c149102cbf8076afadc4f4c'
+  version '2020.1-beta1'
+  sha256 '495d8a2e7b57c3d0744d8e853a92b28766af9f9107c0b4d6ae555d15113413a6'
 
   # github.com/mullvad/mullvadvpn-app was verified as official when first introduced to the cask
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.