### PR TITLE
Update lilypond-dev from 2.19.83-1 to 2.19.84-1

### DIFF
--- a/Casks/lilypond-dev.rb
+++ b/Casks/lilypond-dev.rb
@@ -1,6 +1,6 @@
 cask 'lilypond-dev' do
-  version '2.19.83-1'
-  sha256 '15e763e908d1371fb3f8151f73ece23bdd8ea7bc757f427f067d8418659c15c3'
+  version '2.19.84-1'
+  sha256 '14c7d0cee5c31fed433fa8f4d2dda94d83e4eff7ef4ab683071131a3d759a0fd'
 
   url "http://lilypond.org/downloads/binaries/darwin-x86/lilypond-#{version}.darwin-x86.tar.bz2"
   appcast 'http://lilypond.org/development.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.