### PR TITLE
Update brave-browser-beta from 79.1.3.107,103.107 to 79.1.4.80,104.80

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '79.1.3.107,103.107'
-  sha256 'de889ab239563939c8d996188c91b42f38291ea5660861d289c84f9983c25b96'
+  version '79.1.4.80,104.80'
+  sha256 'a1a1e2f190bd2d7b39cec755b63a7d3423b89fcd4cf65fe5c861ee0312a440ee'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/beta/#{version.after_comma}/Brave-Browser-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.