### PR TITLE
Update discord-ptb from 0.0.44 to 0.0.45

### DIFF
--- a/Casks/discord-ptb.rb
+++ b/Casks/discord-ptb.rb
@@ -1,6 +1,6 @@
 cask 'discord-ptb' do
-  version '0.0.44'
-  sha256 'ddbbc5834769c72bc48abf09c460cdd0b5291f2ba5f59de4ff60f7b589cc32a2'
+  version '0.0.45'
+  sha256 '664d4fc044ca32496adaf79fb8f43e61765dd213f1d7ffd36027c84916a9234f'
 
   url "https://cdn-ptb.discordapp.com/apps/osx/#{version}/DiscordPTB.dmg"
   appcast 'https://discordapp.com/api/ptb/updates?platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.