### PR TITLE
Update transmit4.rb

### DIFF
--- a/Casks/transmit4.rb
+++ b/Casks/transmit4.rb
@@ -2,7 +2,7 @@ cask 'transmit4' do
   version '4.4.13'
   sha256 '0d7095351378aa3c581de064f99fedecbfac683377048a4c0457976f5ce79f3b'
 
-  url "https://download.panic.com/transmit/Transmit%204/Transmit%20#{version}.zip"
+  url "https://download.panic.com/transmit/Transmit%20#{version.major}/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}/"
   name 'Transmit'
   homepage 'https://panic.com/transmit/'

--- a/Casks/transmit4.rb
+++ b/Casks/transmit4.rb
@@ -2,7 +2,7 @@ cask 'transmit4' do
   version '4.4.13'
   sha256 '0d7095351378aa3c581de064f99fedecbfac683377048a4c0457976f5ce79f3b'
 
-  url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
+  url "https://download.panic.com/transmit/Transmit%204/Transmit%20#{version}.zip"
   appcast "https://library.panic.com/releasenotes/transmit#{version.major}/"
   name 'Transmit'
   homepage 'https://panic.com/transmit/'


### PR DESCRIPTION
Use Panic’s File Museum for download, old URL is offline.

---

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
