### PR TITLE
Update chirp-daily from 20191206 to 20200207

### DIFF
--- a/Casks/chirp-daily.rb
+++ b/Casks/chirp-daily.rb
@@ -1,6 +1,6 @@
 cask 'chirp-daily' do
-  version '20191206'
-  sha256 'c3f9ab4af1f19971cc75adfa82048c5b2cb66332a47c423256e61630d1029e11'
+  version '20200207'
+  sha256 'e587afd42a7ce22299bb764a81f81346cd37f09be3ff9b3901c7e9cc2c31e256'
 
   url "https://trac.chirp.danplanet.com/chirp_daily/LATEST/chirp-daily-#{version}.app.zip"
   appcast 'https://trac.chirp.danplanet.com/chirp_daily/LATEST/SHA1SUM'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.