### PR TITLE
Update termius-beta from 5.3.2 to 5.4.1

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask 'termius-beta' do
-  version '5.3.2'
-  sha256 '1a695ab916d5e35348a64a35ffd522d27f2019ed96c543eb726bb0e53fcc5769'
+  version '5.4.1'
+  sha256 '5544d3d79825b59612977295e55d5be58786baafffddae65bd322241d9e26b8c'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.