### PR TITLE
Update toggl-beta from 7.4.1036 to 7.5.26

### DIFF
--- a/Casks/toggl-beta.rb
+++ b/Casks/toggl-beta.rb
@@ -1,9 +1,9 @@
 cask 'toggl-beta' do
-  version '7.4.1036'
-  sha256 '45461031b0aa58bba6c4990606cbd71e8a0583d33bc87ab01443ac4bc6723e6e'
+  version '7.5.26'
+  sha256 '81ec58d5e4bfb29c8c9122eac54f12472ff3fd592fa3d3ce4565644fbbf2ab51'
 
-  # github.com/toggl/toggldesktop was verified as official when first introduced to the cask
-  url "https://github.com/toggl/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
+  # github.com/toggl-open-source/toggldesktop was verified as official when first introduced to the cask
+  url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"
   appcast 'https://assets.toggl.com/installers/darwin_beta_appcast.xml'
   name 'TogglDesktop'
   homepage 'https://www.toggl.com/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.