### PR TITLE
Update airmail-beta from 4.0,592 to 4.0,596

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '4.0,592'
-  sha256 '13515ba9a5a3ada6a25ea87d87465ef1f9a37730a949c815ed0e0ccadc2f2dcc'
+  version '4.0,596'
+  sha256 '0e6f838004ece3c1ecaa121456d80fb5a5b3cef22334ba31dff736f43f1ef01d'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.