### PR TITLE
Update telegram-alpha from 5.9.1-190686,2422 to 5.9.2-190799,2425

### DIFF
--- a/Casks/telegram-alpha.rb
+++ b/Casks/telegram-alpha.rb
@@ -1,6 +1,6 @@
 cask 'telegram-alpha' do
-  version '5.9.1-190686,2422'
-  sha256 '89ca036ac0673b38d85b4e75cb9516c5a33232c3b409c336ec1c9bd2f6b40c48'
+  version '5.9.2-190799,2425'
+  sha256 '09ab0972b8bb6c7ac0dc879de29f5f39b6aff8a2c2a19422f8d81a0df35bff68'
 
   # hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/6ed2ac3049e1407387c2f1ffcb74e81f/app_versions/#{version.after_comma}?format=zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.