### PR TITLE
Update airmail-beta from 4.0,597 to 4.0,598

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '4.0,597'
-  sha256 '80fdb728766be51084c85869fa16d469a6034a326acc1a1f7a88e4b04fcf77bd'
+  version '4.0,598'
+  sha256 'ed86fc189501c4964448067471a3ecd2f60b95eb9795ca2ad74e5233e23b4c26'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.