### PR TITLE
Update discord-canary from 0.0.243 to 0.0.244

### DIFF
--- a/Casks/discord-canary.rb
+++ b/Casks/discord-canary.rb
@@ -1,6 +1,6 @@
 cask 'discord-canary' do
-  version '0.0.243'
-  sha256 '641bdfbb1075958e0cfa6f8ae33d057a459872ddbe317b147cebda1c262c710f'
+  version '0.0.244'
+  sha256 'fb87deedf4dfc194204b8e4146fa95d6deee8d0313cefa6fb80bb3ec1e9ff4eb'
 
   url "https://cdn-canary.discordapp.com/apps/osx/#{version}/DiscordCanary.dmg"
   appcast 'https://discordapp.com/api/canary/updates?platform=osx'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.