### PR TITLE
Update chromedriver-beta from 80.0.3987.16 to 81.0.4044.20

### DIFF
--- a/Casks/chromedriver-beta.rb
+++ b/Casks/chromedriver-beta.rb
@@ -1,6 +1,6 @@
 cask 'chromedriver-beta' do
-  version '80.0.3987.16'
-  sha256 '9206eef3422a62c3f7abed55dc99e1bdf839deb7a74e9031a7eb4a7ab98007da'
+  version '81.0.4044.20'
+  sha256 'e1e884c4ddb41711defedd4e5c65b512eb2f8a20d084ef3c4cafbc824481b770'
 
   # chromedriver.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.