### PR TITLE
Update appcode-eap from 2020.1,201.4865.16 to 2020.1,201.5259.17

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,6 +1,6 @@
 cask 'appcode-eap' do
-  version '2020.1,201.4865.16'
-  sha256 'd39c9dc4fc07e9163f1a5918730f7af05a73d140489b150423f8c4b90e2d1652'
+  version '2020.1,201.5259.17'
+  sha256 '90d1b611923630945500b3c63eb620b624e7c68778588e91b2164353b5dcbe3f'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.after_comma}.dmg"
   name 'AppCode EAP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.