### PR TITLE
Update iterm2-beta from 3.3.9beta1 to 3.3.10beta1

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.9beta1'
-  sha256 '0f29e912ef047600a73603cf0d84a602d6e17b87a82f0e24137df3c9350c2392'
+  version '3.3.10beta1'
+  sha256 '94bdd8c177b604234df127ecc3af41b7f77c8b09953fa2b623a169eff5c85d6f'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.