### PR TITLE
Update airmail-beta from 4.0,599 to 4.0,603

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,6 +1,6 @@
 cask 'airmail-beta' do
-  version '4.0,599'
-  sha256 '5f9ab244dd3cd41707206464aa9c149ea9da7b834de8f7d2149ac63fdaf760d0'
+  version '4.0,603'
+  sha256 'bd9dd4124676f358cacffdccd2f9a94ef8e4e2217d6b07f9288321194796e26b'
 
   # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.