### PR TITLE
Update termius-beta from 5.4.1 to 5.5.0

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,5 +1,5 @@
 cask 'termius-beta' do
-  version '5.4.1'
+  version '5.5.0'
   sha256 '2493b2d5156f185be59e01408d4249f32586c0a723496a97d78112b9279a9e02'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.