### PR TITLE
Update brave-browser-dev from 80.1.5.94,105.94 to 80.1.6.46,106.46

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '80.1.5.94,105.94'
-  sha256 'b7d0dc0fa19dd922adfa8d6c3130a247e56ec48c3700f4021cd9242dfd078e2b'
+  version '80.1.6.46,106.46'
+  sha256 '3be7bd369837383f5d15589e13123599df3a8a13330c025c4770d4ffea7b4f8f'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.