### PR TITLE
Update signal-beta from 1.32.0-beta.1 to 1.32.0-beta.2

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.32.0-beta.1'
-  sha256 '810ae8d3dcc8bb6caa0f55076c60ad8c28baa32017b817adb4ccfd866a7da777'
+  version '1.32.0-beta.2'
+  sha256 '0fb8c96858657bdebf6d29b7f2e235cda6713cf2ded75059e0d63383b010a242'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.