### PR TITLE
Update microsoft-edge-beta from 80.0.361.53 to 81.0.416.12

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '80.0.361.53'
-  sha256 '3f117c316c4f8aa321f4f57d5f2705175d51e8a4666e9445a5080ee695638d40'
+  version '81.0.416.12'
+  sha256 '212787bad6e05205171a0ef8a9da995089cd1b406097fb44e59e93ac3222df7b'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.