### PR TITLE
Update mono-mdk-for-visual-studio from 6.4.0.198 to 6.6.0.161

### DIFF
--- a/Casks/mono-mdk-for-visual-studio.rb
+++ b/Casks/mono-mdk-for-visual-studio.rb
@@ -1,6 +1,6 @@
 cask 'mono-mdk-for-visual-studio' do
-  version '6.4.0.198'
-  sha256 '07f3622e5ec47ed000c9668702d45acf19f49602c10b0aaa055cc7e454cdc695'
+  version '6.6.0.161'
+  sha256 '8f0b7f6a34321fc4c46e9e6d7ad83c73ae009289fb689ac9f846eebb51146a6e'
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://www.mono-project.com/download/vs/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.