### PR TITLE
Update opera-beta from 67.0.3575.23 to 67.0.3575.28

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '67.0.3575.23'
-  sha256 '9de0cb84de30df696c48b634817ee00991cd203f0e7ba7662e7c8d7c3d304921'
+  version '67.0.3575.28'
+  sha256 '5de30ce0bad6b360cc0f52e130c089cd5834afc4d3b1a31a77b5a40edbd7b7c6'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.