### PR TITLE
Update microsoft-edge-dev from 81.0.416.11 to 82.0.425.3

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '81.0.416.11'
-  sha256 '56ef2011a320ed792af6be39621e27792ddfa2a3effabf891c6d963f661746f0'
+  version '82.0.425.3'
+  sha256 '79d568ef5e63865bff4c4246aad43e1d2ea3db2c0e36bf7de71b4608d5065bc5'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.