### PR TITLE
Update opera-developer from 68.0.3602.0 to 68.0.3609.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '68.0.3602.0'
-  sha256 '89c09681e8f549714f5f3a3f9f2c1c6e1c655069aa74c8273910218d203d7812'
+  version '68.0.3609.0'
+  sha256 'efec6bb6c658b9322801e7b080ece7b38fe213928bfd58dc6b3a085fd424a72b'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.