### PR TITLE
Update brave-browser-dev from 80.1.6.49,106.49 to 80.1.6.50,106.50

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '80.1.6.49,106.49'
-  sha256 '584a8fd6881b0cc8ba90a95830b7928b93bc0f9dadbedfba895346ce0f1fcc67'
+  version '80.1.6.50,106.50'
+  sha256 '97b35223010c183f53dbf3a2dfd4b753aa301aee3bd2843a7f4cedcb55e5c4be'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.