### PR TITLE
Update signal-beta from 1.32.0-beta.3 to 1.32.0-beta.4

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.32.0-beta.3'
-  sha256 '7b25102652fa31e7d2cd13ed8d58e7c02bdf5f8460b54c5790e9195f8a8755bf'
+  version '1.32.0-beta.4'
+  sha256 '3bffdfd0f4e04761e7922b1427b12d1f405bd201ab3951b55467cf20c26da3c7'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.