### PR TITLE
Update visual-studio-code-insiders from 1.43.0,0eebaf9ad23748baca2afc0da425650922bc23de to 1.43.0,d1c48c103cabc6e729f59787c0b9c86fb3d39e73

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.43.0,0eebaf9ad23748baca2afc0da425650922bc23de'
-  sha256 '33ec6662fc60baca0b1dd67f885e55ed182f6928fee2ff61b7137514f9720bbf'
+  version '1.43.0,d1c48c103cabc6e729f59787c0b9c86fb3d39e73'
+  sha256 'b73f3924d2de3d72b73621602ef5610c818fe27c24843f9c45228e7169029158'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.