### PR TITLE
Update brave-browser-dev from 80.1.6.54,106.54 to 80.1.6.55,106.55

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '80.1.6.54,106.54'
-  sha256 'a4662e3dff577391aa49d64c7a653ae2001ee0f1def03a12c970f264a987c366'
+  version '80.1.6.55,106.55'
+  sha256 'ce7ba150faf07c3386ca05c51c51831226dd6493554f051e7fa3c95bee1091b1'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.