### PR TITLE
Update airmail-beta from 4.0,603 to 4.0,609

### DIFF
--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -4,7 +4,8 @@ cask 'airmail-beta' do
 
   # appcenter-filemanagement-distrib2ede6f06e.azureedge.net/a61ee875-4fc5-4d5c-a05e-c2530ece39cf was verified as official when first introduced to the cask
   url 'https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/a61ee875-4fc5-4d5c-a05e-c2530ece39cf/Airmail%20Beta.app.zip?sv=2018-03-28&sr=c&sig=v421mFWezOf2Ny6eiA5EI7pLwQBOqUd1JbihMWX88sw%3D&se=2020-03-03T21%3A16%3A08Z&sp=r&download_origin=appcenter'
-  appcast 'https://install.appcenter.ms/orgs/airmail-devs-organization/apps/airmail-beta/distribution_groups/all-users-of-airmail-beta'
+  appcast 'https://install.appcenter.ms/api/v0.1/apps/airmail-devs-organization/airmail-beta/distribution_groups/all-users-of-airmail-beta/public_releases',
+          configuration: version.after_comma
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'
 

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -4,7 +4,7 @@ cask 'airmail-beta' do
 
   # appcenter-filemanagement-distrib2ede6f06e.azureedge.net/a61ee875-4fc5-4d5c-a05e-c2530ece39cf was verified as official when first introduced to the cask
   url 'https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/a61ee875-4fc5-4d5c-a05e-c2530ece39cf/Airmail%20Beta.app.zip?sv=2018-03-28&sr=c&sig=v421mFWezOf2Ny6eiA5EI7pLwQBOqUd1JbihMWX88sw%3D&se=2020-03-03T21%3A16%3A08Z&sp=r&download_origin=appcenter'
-  appcast 'https://install.appcenter.ms/orgs/cogsci-apps/apps/hook/distribution_groups/hook%20productivity%20app%20general%20availability'
+  appcast 'https://install.appcenter.ms/orgs/airmail-devs-organization/apps/airmail-beta/distribution_groups/all-users-of-airmail-beta'
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'
 

--- a/Casks/airmail-beta.rb
+++ b/Casks/airmail-beta.rb
@@ -1,10 +1,10 @@
 cask 'airmail-beta' do
-  version '4.0,603'
-  sha256 'bd9dd4124676f358cacffdccd2f9a94ef8e4e2217d6b07f9288321194796e26b'
+  version '4.0,609'
+  sha256 '2193a03781ece28031f07af3558a36d18a9502c9e0c345a5ed0d91b73a26ea41'
 
-  # hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04 was verified as official when first introduced to the cask
-  url "https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04/app_versions/#{version.after_comma}?format=zip&"
-  appcast 'https://rink.hockeyapp.net/api/2/apps/84be85c3331ee1d222fd7f0b59e41b04'
+  # appcenter-filemanagement-distrib2ede6f06e.azureedge.net/a61ee875-4fc5-4d5c-a05e-c2530ece39cf was verified as official when first introduced to the cask
+  url 'https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/a61ee875-4fc5-4d5c-a05e-c2530ece39cf/Airmail%20Beta.app.zip?sv=2018-03-28&sr=c&sig=v421mFWezOf2Ny6eiA5EI7pLwQBOqUd1JbihMWX88sw%3D&se=2020-03-03T21%3A16%3A08Z&sp=r&download_origin=appcenter'
+  appcast 'https://install.appcenter.ms/orgs/cogsci-apps/apps/hook/distribution_groups/hook%20productivity%20app%20general%20availability'
   name 'Airmail'
   homepage 'https://airmailapp.com/beta/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

The old URL format no longer works, but I'm not sure if the new URL I've used is temporary (i.e. it may expire).