### PR TITLE
Update tor-browser-alpha from 9.5a5 to 9.5a6

### DIFF
--- a/Casks/tor-browser-alpha.rb
+++ b/Casks/tor-browser-alpha.rb
@@ -3,7 +3,7 @@ cask 'tor-browser-alpha' do
   sha256 'f4856bfcd813e824dcb49faf627be08f5f02160180f1306b9a38aca5c3350500'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
-  appcast 'https://dist.torproject.org/torbrowser/'
+  appcast 'https://www.torproject.org/download/alpha/'
   name 'Tor Browser'
   homepage 'https://www.torproject.org/projects/torbrowser.html'
 

--- a/Casks/tor-browser-alpha.rb
+++ b/Casks/tor-browser-alpha.rb
@@ -1,6 +1,6 @@
 cask 'tor-browser-alpha' do
-  version '9.5a5'
-  sha256 '003ccb7d8808bd2a54daf849f35307f015183021e2c0c88efab1690c7849fd5f'
+  version '9.5a6'
+  sha256 'f4856bfcd813e824dcb49faf627be08f5f02160180f1306b9a38aca5c3350500'
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://dist.torproject.org/torbrowser/'

--- a/Casks/tor-browser-alpha.rb
+++ b/Casks/tor-browser-alpha.rb
@@ -5,7 +5,7 @@ cask 'tor-browser-alpha' do
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-osx64_en-US.dmg"
   appcast 'https://www.torproject.org/download/alpha/'
   name 'Tor Browser'
-  homepage 'https://www.torproject.org/projects/torbrowser.html'
+  homepage 'https://www.torproject.org/'
 
   auto_updates true
   conflicts_with cask: 'tor-browser'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.