### PR TITLE
Update signal-beta from 1.32.0-beta.4 to 1.32.0-beta.5

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.32.0-beta.4'
-  sha256 '3bffdfd0f4e04761e7922b1427b12d1f405bd201ab3951b55467cf20c26da3c7'
+  version '1.32.0-beta.5'
+  sha256 'e93232fcfa86b90ed2e72b2770d37dff671b09242b54f29421fcbc5b19ac514e'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.