### PR TITLE
Added new cask telegram-beta to replace telegram-alpha

### DIFF
--- a/Casks/telegram-beta.rb
+++ b/Casks/telegram-beta.rb
@@ -1,0 +1,24 @@
+cask 'telegram-beta' do
+  version :latest
+  sha256 :no_check
+
+  # api.appcenter.ms/v0.1/public/sdk/apps/6ed2ac30-49e1-4073-87c2-f1ffcb74e81f/releases/latest was verified as official when first introduced to the cask
+  url do
+    require 'open-uri'
+    require 'json'
+    base_url = 'https://api.appcenter.ms/v0.1/public/sdk/apps/6ed2ac30-49e1-4073-87c2-f1ffcb74e81f/releases/latest'
+    URI(base_url).open do |release_page|
+      latest_json = release_page.read
+      JSON.parse(latest_json)['download_url']
+    end
+  end
+  name 'Telegram for macOS'
+  name 'Telegram Swift'
+  homepage 'https://macos.telegram.org/'
+
+  auto_updates
+  conflicts_with cask: 'telegram'
+  depends_on macos: '>= :yosemite'
+
+  app 'Telegram.app'
+end


### PR DESCRIPTION
I migrated the cask telegram-alpha to this cask with the latest version stanza,
because of new API-Endpoints (New DL-Links are not simply generatable anymore,
so this solution made more sence to me).

I will also file a PR to delete `telegram-alpha`.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
This is not the case, because there is `version :latest` and `auto_updates` which are triggering a warning. I thought it would be bad to just omit `auto_updates`, because the beta of telegram also supports auto-updates.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
