### PR TITLE
Update brave-browser-dev from 80.1.6.59,106.59 to 80.1.7.55,107.55

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '80.1.6.59,106.59'
-  sha256 '11214083fe9b45ec45bc701a5918071c5234299928444ef039f6304c48d9fc7c'
+  version '80.1.7.55,107.55'
+  sha256 'c89adc206bcead6b0fc952a7066397297bea6dd4c4728b708720d8b48b21c6ad'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.