### PR TITLE
Update rstudio-preview from 1.3.878 to 1.3.903

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.3.878'
-  sha256 '54373433731e68942c1817031a69091c8c767d3fb02ec432d2de010fbfa7ec67'
+  version '1.3.903'
+  sha256 'bf73509c9d3bd7e8be09c0218e28239359c33e645c90be88f423089fd0f5a6ae'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.