### PR TITLE
Update opera-developer from 68.0.3616.0 to 69.0.3623.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '68.0.3616.0'
-  sha256 'a7691ad2f29d099c716ef8da098935d6e2ade54c4badd8cdcb8cb03e8a381b9a'
+  version '69.0.3623.0'
+  sha256 'f78cba4df94c651ecaaaa2a0fd250ced34ea9bc340faaa788d8f6b7eb7449b73'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.