### PR TITLE
Update corretto8 from 8.242.08.1 to 8.242.08.2

### DIFF
--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -3,7 +3,7 @@ cask 'corretto8' do
   sha256 '61c31c07b8ce4266ca609dbc76de4260c396f5eb0876627647e50d75dc4d93e5'
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
-  appcast "https://docs.aws.amazon.com/en_us/corretto/latest/corretto-#{version.major}-ug/corretto-#{version.major}-ug.rss"
+  appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg"
   name 'Amazon Corretto'
   homepage 'https://corretto.aws/'
 

--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,13 +1,13 @@
 cask 'corretto8' do
-  version '8.242.08.1'
-  sha256 'bf45f7e741124ef0086e31261c93b5462ac490f350a47c988ad8c41a70d01a26'
+  version '8.242.08.2'
+  sha256 '61c31c07b8ce4266ca609dbc76de4260c396f5eb0876627647e50d75dc4d93e5'
 
-  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-1-macosx-x64.pkg"
+  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast "https://docs.aws.amazon.com/en_us/corretto/latest/corretto-#{version.major}-ug/corretto-#{version.major}-ug.rss"
   name 'Amazon Corretto'
   homepage 'https://corretto.aws/'
 
-  pkg "amazon-corretto-#{version}-1-macosx-x64.pkg"
+  pkg "amazon-corretto-#{version}-macosx-x64.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
 end

--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -3,7 +3,7 @@ cask 'corretto8' do
   sha256 '61c31c07b8ce4266ca609dbc76de4260c396f5eb0876627647e50d75dc4d93e5'
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
-  appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg"
+  appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg'
   name 'Amazon Corretto'
   homepage 'https://corretto.aws/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

This also reverts the `-1` suffix that was added in #8513.