### PR TITLE
Update termius-beta from 5.5.3 to 5.6.1

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask 'termius-beta' do
-  version '5.5.3'
-  sha256 '47655f0afe26b0ae4cffbc2900198272d5c21dc467225d604d46488a58ceb08b'
+  version '5.6.1'
+  sha256 'bbab9dc4c8eac802763e7357d47592010060bc714b0af2300069bc01541dea02'
 
   # s3.amazonaws.com/termius.desktop.autoupdate/mac was verified as official when first introduced to the cask
   url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.