### PR TITLE
Update wine-devel from 5.3 to 5.4

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -1,6 +1,6 @@
 cask 'wine-devel' do
-  version '5.3'
-  sha256 '043c3979a0d21ff2e1f8a52a79938a10a7552744770a9715d54520ae969ddd2e'
+  version '5.4'
+  sha256 '2c773aabfb2b96797edc3c151ae6ed54c405c5f9fa70dee4ddaf40e17f4dd438'
 
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast 'https://dl.winehq.org/wine-builds/macosx/download.html'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.