### PR TITLE
Update brave-browser-beta from 80.1.7.57,107.57 to 80.1.7.61,107.64

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '80.1.7.57,107.57'
-  sha256 'c5cf83957afe8f47a64d61162e8cda53c39767408664026b666c5f29ddbf8ceb'
+  version '80.1.7.64,107.64'
+  sha256 'c837e31ea0c5958e27d59928062d040dcd9d20b6d9cc3492eb6c8ca4d45a09d9'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/beta/#{version.after_comma}/Brave-Browser-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.