### PR TITLE
Update brave-browser-dev from 80.1.7.63,107.63 to 80.1.7.65,107.65

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '80.1.7.63,107.63'
-  sha256 '55a7fe89d7b61401b938941eb82bfc2d1f858af848fe9ff2fe730e6382af95c9'
+  version '80.1.7.65,107.65'
+  sha256 '2d9bee17194532df3881f772c82912455b2ff9473cc4f0c377f9e756940133b6'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.