### PR TITLE
Update vivaldi-snapshot from 2.11.1811.28 to 2.12.1854.5

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask 'vivaldi-snapshot' do
-  version '2.11.1811.28'
-  sha256 '2f3b3092c07829a13cdfbcb601c7d1d466331f71755cccf8e05bfb0fb829d444'
+  version '2.12.1854.5'
+  sha256 '57474008497cb62ef5254623a9f2ff032afd1b8c3e6fa06d1cc989d6a34bf71b'
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast 'https://update.vivaldi.com/update/1.0/mac/appcast.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.