### PR TITLE
Update brave-browser-dev from 80.1.7.65,107.65 to 80.1.7.66,107.66

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '80.1.7.65,107.65'
-  sha256 '2d9bee17194532df3881f772c82912455b2ff9473cc4f0c377f9e756940133b6'
+  version '80.1.7.66,107.66'
+  sha256 'bb4e7f1a483215696f6e716f31a97cc7b524cc0b2bf7362e6fcf40824ce99d07'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.