### PR TITLE
zulu13 13.0.2,13.29.9-ca (new cask)

### DIFF
--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -1,0 +1,13 @@
+cask 'zulu13' do
+  version '13.0.2,13.29.9-ca'
+  sha256 '80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880'
+
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
+      referer: 'https://www.azul.com/downloads/zulu/zulu-mac/'
+  name 'Azul Zulu Java Standard Edition Development Kit'
+  homepage 'https://www.azul.com/downloads/zulu/zulu-mac/'
+
+  pkg "Double-Click to Install Zulu #{version.major}.pkg"
+
+  uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"
+end

--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -1,6 +1,6 @@
 cask 'zulu13' do
   version '13.0.2,13.29.9-ca'
-  sha256 '80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880'
+  sha256 'e4c7f6bc9caa1bba2659e8d0019e75002b84b43b4bd67de7e740d6698f629900'
 
   url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
       referer: 'https://www.azul.com/downloads/zulu/zulu-mac/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

---

Ported over from Homebrew/homebrew-cask because 14 is out but 13 is still an MTS release.  See [this page](https://www.azul.com/downloads/zulu-community/):
> The current LTS (Long Term Supported) major Zulu versions are 7, 8, and 11. The latest MTS (Medium Term Support) major Zulu version is 13 (see DZone Reference Card on Java 13 for more details).
