### PR TITLE
Update 1password-beta 7.4.4.BETA-0 conflicts_with

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -8,6 +8,7 @@ cask '1password-beta' do
   homepage 'https://1password.com/'
 
   auto_updates true
+  conflicts_with cask: '1password'
 
   app "1Password #{version.major}.app"
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
Currently, this cask's is at major version 7 which causes the conflict. When the beta's major version is changed to 8, this conflict should be able to be removed.