### PR TITLE
Update brave-browser-dev from 80.1.7.68,107.68 to 80.1.7.70,107.70

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '80.1.7.68,107.68'
-  sha256 'b7a0c8a7d9aeadacf0f458b6de0d2127ca2aef8e588cd93c409fff65f724d899'
+  version '80.1.7.70,107.70'
+  sha256 '8b10e80594db3d7836c98460d2b07959bdb03ad1e99376329932b96ecbfd96a0'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.