### PR TITLE
Update tunnelblick-beta from 3.8.2beta07,5470 to 3.8.3beta01,5490

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask 'tunnelblick-beta' do
-  version '3.8.2beta07,5470'
-  sha256 '006c7302324280c7fae9d55806f2ed7163da7d3da437b23c3b422f41250ca543'
+  version '3.8.3beta01,5490'
+  sha256 '6bdf6ddeed1b0d05d7346368a3398ee6993a590d074bb71f3ecb51ef8cc6a301'
 
   # github.com/Tunnelblick/Tunnelblick was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.