### PR TITLE
Update opera-developer from 69.0.3630.0 to 69.0.3638.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask 'opera-developer' do
-  version '69.0.3630.0'
-  sha256 '5ffe711961d3cecaaa6890c2c440ea4f9d458ebde3d62e5c3de040c2261137f6'
+  version '69.0.3638.0'
+  sha256 'a05af1c0c65098936dfd273b28cc153c4ed3fb1d536b2107ef938e28f671797f'
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name 'Opera Developer'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.