### PR TITLE
Update android-studio-preview from 4.1.0.3,193.6297379 to 4.1.0.4,193.6325121

### DIFF
--- a/Casks/android-studio-preview.rb
+++ b/Casks/android-studio-preview.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-preview' do
-  version '4.1.0.3,193.6297379'
-  sha256 'e0d0ec6c28a88a23306c78ec8526caff5e67022ebe280d88975c68d96f1439c4'
+  version '4.1.0.4,193.6325121'
+  sha256 'a6ef7f2f76ee7466d037e5c87833ff213c3cf2afdfcf8ad450af6ed4dd97b8d7'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.