### PR TITLE
Update opera-beta from 68.0.3618.18 to 68.0.3618.24

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '68.0.3618.18'
-  sha256 '1942283d29fc84811a0b5fe62aba70a29f69a729db5143f9476ac58a974d1300'
+  version '68.0.3618.24'
+  sha256 '4f9c8462c7debd5a085b1b777f0344b2da4f9e3741a5d612ffd54754fb1fff5e'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.