### PR TITLE
Update affinity-designer-beta from 1.8.3.0 to 1.8.3.1

### DIFF
--- a/Casks/affinity-designer-beta.rb
+++ b/Casks/affinity-designer-beta.rb
@@ -1,6 +1,6 @@
 cask 'affinity-designer-beta' do
-  version '1.8.3.0'
-  sha256 'b0ae34ffdea4075a9b4172f82401e4d082221c9d30f191d63acd898425f8a8e1'
+  version '1.8.3.1'
+  sha256 'f1eb788f42a194931260691edada98e629d5c0b33c8b33240f886845bc73c5e3'
 
   # affinity-beta.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://affinity-beta.s3.amazonaws.com/download/Affinity%20Designer%20Beta.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.