### PR TITLE
Update affinity-photo-beta from 1.8.3.177 to 1.8.3.178

### DIFF
--- a/Casks/affinity-photo-beta.rb
+++ b/Casks/affinity-photo-beta.rb
@@ -1,6 +1,6 @@
 cask 'affinity-photo-beta' do
-  version '1.8.3.177'
-  sha256 '79f3bcd26e801e96df008dc3c2924a959772ca3cf0ece5ab623b9c303fe96a04'
+  version '1.8.3.178'
+  sha256 '82476b6661304f14623a7e2e7865548e9ed07f721f377cd7922f23190392bb5f'
 
   # affinity-beta.s3.amazonaws.com was verified as official when first introduced to the cask
   url 'https://affinity-beta.s3.amazonaws.com/download/Affinity%20Photo%20Customer%20Beta.zip'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.