### PR TITLE
Update appcode-eap from 2020.1,201.6487.7 to 2020.1,201.6668.20

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,6 +1,6 @@
 cask 'appcode-eap' do
-  version '2020.1,201.6487.7'
-  sha256 'ac007df59eeae7fc04e1b3e27cae625264bac8090c13686209b68abed6dcd73c'
+  version '2020.1,201.6668.20'
+  sha256 '3219c9030c185eda64c3fed5cdbeeef95c0f7e896149f2e2a0658402ccd7f1a4'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.after_comma}.dmg"
   name 'AppCode EAP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.