### PR TITLE
Update brave-browser-dev from 80.1.7.76,107.76 to 80.1.7.78,107.78

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '80.1.7.76,107.76'
-  sha256 '5bce86c88bfd9ca081b624117c6a9fbce97fd2353ff644e0ed6451433cac717a'
+  version '80.1.7.78,107.78'
+  sha256 '239a07510b4d64aa3b5f206568b2f8b90d6c0d46393c89cc2d3c171086cd19bf'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.