### PR TITLE
Update telegram-desktop-dev from 2.0.0 to 2.0.1

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '2.0.0'
-  sha256 '47921cd559c2774c207bc81fb53491344f3c637a653a276c7cc4346182396f5c'
+  version '2.0.1'
+  sha256 'aa3e28e587ff13446727add123a11855eb4342cf25844029e7f1836840c1a765'
 
   # github.com/telegramdesktop/tdesktop was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.