### PR TITLE
Update iterm2-beta from 3.3.10beta2 to 3.3.10beta3

### DIFF
--- a/Casks/iterm2-beta.rb
+++ b/Casks/iterm2-beta.rb
@@ -1,7 +1,7 @@
 cask 'iterm2-beta' do
   # note: "2" is not a version number, but an intrinsic part of the product name
-  version '3.3.10beta2'
-  sha256 '7ef1e989fae13dfd8e764b8038f38f7106318779b21d499c6223ff23ac94f92b'
+  version '3.3.10beta3'
+  sha256 '7587f540d1164345c24a34f1aa565ab23ff73d23f721ad6d5adfe0406f8f9848'
 
   url "https://iterm2.com/downloads/beta/iTerm2-#{version.dots_to_underscores}.zip"
   appcast 'https://iterm2.com/appcasts/testing3.xml'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.