### PR TITLE
Update brave-browser-beta from 80.1.7.80,107.80 to 80.1.7.83,107.83

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '80.1.7.80,107.80'
-  sha256 '3e367a226cf197d79cd48b2cdeeea497d21b17bb5c4d325a4331fb25f472ba1a'
+  version '80.1.7.83,107.83'
+  sha256 'd0c095db218dfd43ab42db29313f32ea3024808aed8420ee1740c12b40ae0d61'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/beta/#{version.after_comma}/Brave-Browser-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.