### PR TITLE
Update microsoft-remote-desktop-beta from 10.3.9.1763,437 to 10.4.0.1769,530

### DIFF
--- a/Casks/microsoft-remote-desktop-beta.rb
+++ b/Casks/microsoft-remote-desktop-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-remote-desktop-beta' do
-  version '10.3.9.1763,437'
-  sha256 '9e7641619757d043dbff99b0a8c5946d4adc7e33dd5cc91421fa15e0f65227c7'
+  version '10.4.0.1769,530'
+  sha256 'a28975e1f7a73e8b05e4d2a2f839ab76f7fe8539a2317d4094fa05dc94999ce5'
 
   url "https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/5e0c144289a51fca2d3bfa39ce7f2b06',


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.