### PR TITLE
Update microsoft-edge-dev from 83.0.467.0 to 83.0.474.0

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '83.0.467.0'
-  sha256 '997bba0361b863800f39c5430f367f4bec2f6b8235cfa1f2094e8a0d4b1edc09'
+  version '83.0.474.0'
+  sha256 'e98834d086d28a80a76a8622fad7c7c57a59f57cdeaf61dcc955a37f3e3430a2'
 
   # officecdn-microsoft-com.akamaized.net was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.