### PR TITLE
Update chirp-daily from 20200227 to 20200409

### DIFF
--- a/Casks/chirp-daily.rb
+++ b/Casks/chirp-daily.rb
@@ -1,6 +1,6 @@
 cask 'chirp-daily' do
-  version '20200227'
-  sha256 '7cc47a9873a97c00a76d7b1c50853b9aacd373178233ee211ba234b80923c2fd'
+  version '20200409'
+  sha256 'd12a5fb48805c58334e52bffa8ebdc36eff85e759eb632e0de265a1dee9c4504'
 
   url "https://trac.chirp.danplanet.com/chirp_daily/LATEST/chirp-daily-#{version}.app.zip"
   appcast 'https://trac.chirp.danplanet.com/chirp_daily/LATEST/SHA1SUM'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.