### PR TITLE
Update visual-studio-code-insiders from 1.44.0,15297a9a4ee8d611d37f48cb59c33b3cb6145c70 to 1.45.0,2225d77536d12fea2eda04930f431a5eb0930bba

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.44.0,15297a9a4ee8d611d37f48cb59c33b3cb6145c70'
-  sha256 '78260134b2f617c991095e4dca59642a9c5a8ed64edd140d08db48910e580b58'
+  version '1.45.0,2225d77536d12fea2eda04930f431a5eb0930bba'
+  sha256 'e7043d026beb00e749d99c8f25d4fb7bb61a8b274c6e741524989059d2e2eca9'
 
   # az764295.vo.msecnd.net/insider was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.