### PR TITLE
Update rstudio-preview from 1.3.937 to 1.3.938

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.3.937'
-  sha256 'e4f41fa2b0902d5a208e2df91f62431f4a5cba431355e084caf97c63b840814d'
+  version '1.3.938'
+  sha256 '78e79a510d4e2481c5b34f357da9515ab64328cc6564c02772e8a8a7029b6ea1'
 
   # s3.amazonaws.com/rstudio-ide-build was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.