### PR TITLE
Update appcode-eap from 2020.1,201.6668.54 to 2020.1,201.6668.124

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,6 +1,6 @@
 cask 'appcode-eap' do
-  version '2020.1,201.6668.54'
-  sha256 'def9781ac2efd06a70baed43000547130c05a3de901afb594292e9f98282ed8c'
+  version '2020.1,201.6668.124'
+  sha256 '9748d842bfd542569a532a63e7dfcc5f112598e7f71abfcaa9dcc73b43cac759'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.after_comma}.dmg"
   name 'AppCode EAP'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.