### PR TITLE
Update brave-browser-dev from 81.1.8.69,108.69 to 81.1.8.71,108.71

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '81.1.8.69,108.69'
-  sha256 '0eaec13f926918589230887f24af3b8912e1dbfd07e60921934796228551ef98'
+  version '81.1.8.71,108.71'
+  sha256 '5673e1e6dcc5883de5eb2f9a3023dd0375a6489cd6f9602d12c67c09ac4cffc0'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.