### PR TITLE
Update corretto8 from 8.242.08.2 to 8.252.09.1

### DIFF
--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,6 +1,6 @@
 cask 'corretto8' do
-  version '8.242.08.2'
-  sha256 '61c31c07b8ce4266ca609dbc76de4260c396f5eb0876627647e50d75dc4d93e5'
+  version '8.252.09.1'
+  sha256 'b0564c88d77ddf7e02a5d62b08c3da207f3009ffa6a3fb2c9e3ebc799556afc3'
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast 'https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.