### PR TITLE
Update chromedriver-beta from 81.0.4044.69 to 83.0.4103.14

### DIFF
--- a/Casks/chromedriver-beta.rb
+++ b/Casks/chromedriver-beta.rb
@@ -1,6 +1,6 @@
 cask 'chromedriver-beta' do
-  version '81.0.4044.69'
-  sha256 '2172bb9be60f2dbe69ad00f707a72de6b75882403f2de7fcb031aa329770cda3'
+  version '83.0.4103.14'
+  sha256 '6e4eaa4adf086853f010678917f91c0ce6e59b3de572e3fe939ef49826b632b4'
 
   # chromedriver.storage.googleapis.com was verified as official when first introduced to the cask
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.