### PR TITLE
Update android-studio-preview from 4.1.0.5,193.6362631 to 4.1.0.6,193.6381907

### DIFF
--- a/Casks/android-studio-preview.rb
+++ b/Casks/android-studio-preview.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-preview' do
-  version '4.1.0.5,193.6362631'
-  sha256 '82b7a1c36c270874067bca143667b587900ed3e56060e6cd2be91394ca178a36'
+  version '4.1.0.6,193.6381907'
+  sha256 'c6e6b57add48ec683304c7a669a01edb0aefeb34188472c6502c1feaa2f11675'
 
   # google.com/dl/android/studio was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.