### PR TITLE
Update microsoft-edge-beta from 81.0.416.58 to 81.0.416.62

### DIFF
--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-beta' do
-  version '81.0.416.58'
-  sha256 '05760b8ac14453b186d1d28cf8e4417754525229dd2d49d729e4380496cc9e6b'
+  version '81.0.416.62'
+  sha256 '4cd968432bbf6954dbed5374d713adfba6f59b39987bc3f3965dfb0efa284626'
 
   # officecdn-microsoft-com.akamaized.net/ was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.