### PR TITLE
Update opera-beta from 68.0.3618.45 to 68.0.3618.55

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '68.0.3618.45'
-  sha256 'a53c8622ec1378606edd6e9295f571589d2eecd16a51e780f94585ea271e5a81'
+  version '68.0.3618.55'
+  sha256 '10bd94e1e58f6bfc83c998e043ec92dbe531546f592c6ce314a4d125964b7fc9'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.