### PR TITLE
Update rstudio-preview from 1.3.944 to 1.3.947

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.3.944'
-  sha256 '3097a0cbc7e702b1ea61562169e6a56ce04a6747e14eefb8116d0066e8148b76'
+  version '1.3.947'
+  sha256 '7aa906e891be6c950a82f56931670ac90d4806a1d1852a8e3f456a541f50533e'
 
   # s3.amazonaws.com/rstudio-ide-build/ was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.