### PR TITLE
Support for the old arq v5 branch

### DIFF
--- a/Casks/arq5.rb
+++ b/Casks/arq5.rb
@@ -3,7 +3,6 @@ cask 'arq5' do
   sha256 '0bdc77398c4c04167181383a84ce9623c2a5e1cac787d30822ccd346b3d5df85'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq_#{version.major}.#{version.minor}.zip"
-  appcast 'https://www.arqbackup.com/download/'
   name 'Arq'
   homepage 'https://www.arqbackup.com/'
 

--- a/Casks/arq5.rb
+++ b/Casks/arq5.rb
@@ -3,7 +3,7 @@ cask 'arq5' do
   sha256 '0bdc77398c4c04167181383a84ce9623c2a5e1cac787d30822ccd346b3d5df85'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq_#{version.major}.#{version.minor}.zip"
-  appcast 'https://www.arqbackup.com/'
+  appcast 'https://www.arqbackup.com/download/'
   name 'Arq'
   homepage 'https://www.arqbackup.com/'
 

--- a/Casks/arq5.rb
+++ b/Casks/arq5.rb
@@ -7,6 +7,7 @@ cask 'arq5' do
   homepage 'https://www.arqbackup.com/'
 
   auto_updates true
+  conflicts_with cask: 'arq'
 
   app 'Arq.app'
 end

--- a/Casks/arq5.rb
+++ b/Casks/arq5.rb
@@ -1,0 +1,13 @@
+cask 'arq' do
+  version '5.18.0'
+  sha256 '0bdc77398c4c04167181383a84ce9623c2a5e1cac787d30822ccd346b3d5df85'
+
+  url "https://www.arqbackup.com/download/arqbackup/Arq_#{version.major}.#{version.minor}.zip"
+  appcast 'https://www.arqbackup.com/'
+  name 'Arq'
+  homepage 'https://www.arqbackup.com/'
+
+  auto_updates true
+
+  app 'Arq.app'
+end

--- a/Casks/arq5.rb
+++ b/Casks/arq5.rb
@@ -1,10 +1,10 @@
-cask 'arq' do
+cask 'arq5' do
   version '5.18.0'
   sha256 '0bdc77398c4c04167181383a84ce9623c2a5e1cac787d30822ccd346b3d5df85'
 
   url "https://www.arqbackup.com/download/arqbackup/Arq_#{version.major}.#{version.minor}.zip"
   appcast 'https://www.arqbackup.com/'
-  name 'Arq5'
+  name 'Arq'
   homepage 'https://www.arqbackup.com/'
 
   auto_updates true

--- a/Casks/arq5.rb
+++ b/Casks/arq5.rb
@@ -4,7 +4,7 @@ cask 'arq' do
 
   url "https://www.arqbackup.com/download/arqbackup/Arq_#{version.major}.#{version.minor}.zip"
   appcast 'https://www.arqbackup.com/'
-  name 'Arq'
+  name 'Arq5'
   homepage 'https://www.arqbackup.com/'
 
   auto_updates true


### PR DESCRIPTION
As the main arq cask continued with version 6, this adds support fo version 5, old technology and old license support.
Be aware with updates to v6 - as currently some major bugs occur

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
