### PR TITLE
Update termius-beta from 5.9.3 to 5.10.0

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask 'termius-beta' do
-  version '5.9.3'
-  sha256 '7df082139cb395055abe21081a42ef897719fa9d58b83572c6add7bf4021e59b'
+  version '5.10.0'
+  sha256 '7dae81d2ea244a55f7a629cb77a5180d6d7c60063046a0081f6b97c9335334f4'
 
   url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'
   name 'Termius Beta'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.