### PR TITLE
Update dropbox-beta from 96.3.166 to 96.3.168

### DIFF
--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,6 +1,6 @@
 cask 'dropbox-beta' do
-  version '96.3.166'
-  sha256 '1c035726860bb8a2c862012a01ff6b0dfa35ef76ee263dbaa33d5a2ceccc88aa'
+  version '96.3.168'
+  sha256 'e19fef32a2a24b88babb64bce4c5a909be6970c1f35a17b0d555457064ab42b6'
 
   # dropbox.com/ was verified as official when first introduced to the cask
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.