### PR TITLE
Update brave-browser-beta from 81.1.8.83,108.83 to 81.1.9.45,109.45

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-beta' do
-  version '81.1.8.83,108.83'
-  sha256 '1a9d920cad50000a4202ad315ebc77cfc3698d55d37452f0d49b62604abb44b2'
+  version '81.1.9.45,109.45'
+  sha256 '71d35d9b1f2a3f468483ec8e81ced777309cb98a47907f0ab9074dd049984feb'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser/ was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/beta/#{version.after_comma}/Brave-Browser-Beta.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.