### PR TITLE
Update mullvadvpn-beta from 2020.4-beta2 to 2020.4-beta3

### DIFF
--- a/Casks/mullvadvpn-beta.rb
+++ b/Casks/mullvadvpn-beta.rb
@@ -1,6 +1,6 @@
 cask 'mullvadvpn-beta' do
-  version '2020.4-beta2'
-  sha256 '7d21dee538f53f78a9b1183443c078a3f64b0662f991d1fead36f5fd0a18b092'
+  version '2020.4-beta3'
+  sha256 '0927cb210e995813d4041c8c9351212650e84616f901377f996255be15ebc124'
 
   # github.com/mullvad/mullvadvpn-app/ was verified as official when first introduced to the cask
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.