### PR TITLE
Update rstudio-preview from 1.3.947 to 1.3.952

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,6 +1,6 @@
 cask 'rstudio-preview' do
-  version '1.3.947'
-  sha256 '7aa906e891be6c950a82f56931670ac90d4806a1d1852a8e3f456a541f50533e'
+  version '1.3.952'
+  sha256 '7f56cb1ef6493b47fce1c3696254a6dbacbeacff104b5ca93bc622253cc7765e'
 
   # s3.amazonaws.com/rstudio-ide-build/ was verified as official when first introduced to the cask
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.