### PR TITLE
Update brave-browser-dev from 81.1.9.48,109.48 to 81.1.9.49,109.49

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '81.1.9.48,109.48'
-  sha256 'cc993a431b8bb17f776ea10d789514cc8832aa52537452d69ae682b03f44c218'
+  version '81.1.9.49,109.49'
+  sha256 '99757c688ffadd27d363dea6a48854bd2e4740e240b075785ba4f2aa3c91ba06'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser/ was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.