### PR TITLE
Update textmate-preview from 2.0.4 to 2.0.11

### DIFF
--- a/Casks/textmate-preview.rb
+++ b/Casks/textmate-preview.rb
@@ -1,6 +1,6 @@
 cask 'textmate-preview' do
-  version '2.0.4'
-  sha256 '1660caf4cb1b6fe54047da647e6c5e28d1208a42c46cf1b9e055b45ea44f35b1'
+  version '2.0.11'
+  sha256 'ec40804776087d25a5ad5b3945413e77279282eeb6ed928e1f001eb0c12073e9'
 
   # github.com/textmate/textmate/ was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.