### PR TITLE
Update brave-browser-beta from 81.1.9.51,109.51 to .81.1.9.51,109.51

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,5 +1,5 @@
 cask 'brave-browser-beta' do
-  version '81.1.9.51,109.51'
+  version '.81.1.9.51,109.51'
   sha256 'b188e0c87fdd0906ca39530ec03839fd6199ac1582b654d095fc8d1ecc405bae'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser/ was verified as official when first introduced to the cask


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.