### PR TITLE
Update visual-studio-code-insiders from 1.45.0,a250df703de955a38aed427a917bce8278ab3331 to 1.45.0,d4b8ec9da3bf1061a948fbb1b0d9d3db750cc79f

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask 'visual-studio-code-insiders' do
-  version '1.45.0,a250df703de955a38aed427a917bce8278ab3331'
-  sha256 '42fb63140d4a96584578e400e8831135885ba7e9fa9dda5445ae22e981b4c1de'
+  version '1.45.0,d4b8ec9da3bf1061a948fbb1b0d9d3db750cc79f'
+  sha256 '71cf386a44aa797b045fa3b7eb88da25367001fd40af49a0cf17ce8764a98f29'
 
   # az764295.vo.msecnd.net/insider/ was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.