### PR TITLE
Update telegram-desktop-dev from 2.1.2 to 2.1.3

### DIFF
--- a/Casks/telegram-desktop-dev.rb
+++ b/Casks/telegram-desktop-dev.rb
@@ -1,6 +1,6 @@
 cask 'telegram-desktop-dev' do
-  version '2.1.2'
-  sha256 '2017a64dda68af04cce88cc6382d61bdc0b8f69c08ec206c8cd5a8f64d313e7c'
+  version '2.1.3'
+  sha256 'b825372e0f601b745700f14b7f0caffe1d05cef7c5b5644fc89bb52e3cfee6c7'
 
   # github.com/telegramdesktop/tdesktop/ was verified as official when first introduced to the cask
   url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version.major_minor_patch}/tsetup.#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.