### PR TITLE
Update slack-beta: add `appcast` and update `zap`

### DIFF
--- a/Casks/slack-beta.rb
+++ b/Casks/slack-beta.rb
@@ -4,6 +4,7 @@ cask 'slack-beta' do
 
   # downloads.slack-edge.com/ was verified as official when first introduced to the cask
   url "https://downloads.slack-edge.com/releases/macos/#{version}/beta/x64/Slack-#{version}-macOS.zip"
+  appcast 'https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://slack.com/ssb/download-osx-beta'
   name 'Slack'
   homepage 'https://slack.com/beta/osx'
 
@@ -25,8 +26,11 @@ cask 'slack-beta' do
                '~/Library/Cookies/com.tinyspeck.slackmacgap.binarycookies',
                '~/Library/Group Containers/*.com.tinyspeck.slackmacgap',
                '~/Library/Group Containers/*.slack',
+               '~/Library/Logs/Slack',
+               '~/Library/Preferences/ByHost/com.tinyspeck.slackmacgap.ShipIt.*.plist',
                '~/Library/Preferences/com.tinyspeck.slackmacgap.helper.plist',
                '~/Library/Preferences/com.tinyspeck.slackmacgap.plist',
                '~/Library/Saved Application State/com.tinyspeck.slackmacgap.savedState',
+               '~/Library/WebKit/com.tinyspeck.slackmacgap',
              ]
 end


### PR DESCRIPTION
Add `apcast` and update `zap` to match version in [main repo](https://github.com/homebrew/homebrew-cask/blob/master/Casks/slack.rb).