### PR TITLE
Add Spatterlight.app beta version 0.5.12b

### DIFF
--- a/Casks/spatterlight.rb
+++ b/Casks/spatterlight.rb
@@ -1,0 +1,30 @@
+cask 'spatterlight' do
+  version '0.5.12b'
+
+  if MacOS.version >= :catalina
+    # URL_SECTION recent releases are only on github and not ccxvii.net
+    sha256 '4f9f975bbdc747fe6ad0a33ed25ff1baf82340987b2f6937f8a08ff83c337b79'
+    url "https://github.com/angstsmurf/spatterlight/releases/download/v#{version}/Spatterlight_Catalina.zip"
+
+  elsif MacOS.version >= :mavericks
+    # URL_SECTION recent releases are only on github and not ccxvii.net
+    sha256 'f9fa79d5d8e81397058e0f4ccd1d4e944ef6c5c66b2dc92792456feeaf8379e6'
+    url "https://github.com/angstsmurf/spatterlight/releases/download/v#{version}/Spatterlight_Mavericks.zip"
+
+  elsif MacOS.version >= :lion
+    # URL_SECTION recent releases are only on github and not ccxvii.net
+    sha256 '96f5a07ba8b66d58e4317b8e36fdc14bf8855834b72af4c43a1d037f20e5755f'
+    url "https://github.com/angstsmurf/spatterlight/releases/download/v#{version}/Spatterlight_Lion.zip"
+
+  else
+    version '0.5.0'
+    sha256 '1729c51676f791149f4829454318f373eff43bf8d8388ecbe3b345308c669ba1'
+    url "http://ccxvii.net/spatterlight/download/spatterlight-#{version}.zip"
+  end
+
+  appcast 'https://github.com/angstsmurf/spatterlight/releases.atom'
+  name 'Spatterlight'
+  homepage 'http://ccxvii.net/spatterlight/'
+
+  app 'Spatterlight.app'
+end


### PR DESCRIPTION
Spatterlight v0.5.0, served by ccxvii.net, does not work on recent versions of MacOS.  This cask allows binary distributions of the beta version v0.5.12b to be installed according to the version of macOS in use.

According to the GitHub releases page, the Catalina build works on Catalina; the Mavericks build should work on Mavericks through Mojave; and the Lion build should work on Lion and Mountain Lion.

Tested by me on Catalina only (as that's all I have access to)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-versions/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
