### PR TITLE
Update android-studio-preview from 4.1.0.8,193.6423924 to 4.1.0.9,201.6466190

### DIFF
--- a/Casks/android-studio-preview.rb
+++ b/Casks/android-studio-preview.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-preview' do
-  version '4.1.0.8,193.6423924'
-  sha256 '142d5cb8021462bdc316fb89e4f8ab5b0a9575b4877a2ac7f5b51508c8d60661'
+  version '4.1.0.9,201.6466190'
+  sha256 '8f45a6f1e286d73a27627cccfa62e197f925bd7b7642facdfa9d71be39a45e99'
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.