### PR TITLE
Update mono-mdk-for-visual-studio from 6.6.0.166 to 6.8.0.123

### DIFF
--- a/Casks/mono-mdk-for-visual-studio.rb
+++ b/Casks/mono-mdk-for-visual-studio.rb
@@ -1,6 +1,6 @@
 cask 'mono-mdk-for-visual-studio' do
-  version '6.6.0.166'
-  sha256 '6169418b4f6967ed4e1bd460c4f224c3b78040e0d69f4681b3a96886a0a4412f'
+  version '6.8.0.123'
+  sha256 '93b7a3ec17d1d1f888f1c1c824a4b8529fb8d8da13df81daedba445222cc9f8e'
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   appcast 'https://www.mono-project.com/download/vs/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.