### PR TITLE
Update textmate-preview.rb from 2.0.11 to 2.0.12

### DIFF
--- a/Casks/textmate-preview.rb
+++ b/Casks/textmate-preview.rb
@@ -20,7 +20,6 @@ cask 'textmate-preview' do
                '~/Library/Application Support/TextMate',
                '~/Library/Caches/com.macromates.TextMate',
                '~/Library/Preferences/com.macromates.TextMate.plist',
-               '~/Library/Preferences/com.macromates.TextMate.preview.plist',
                '~/Library/Saved Application State/com.macromates.TextMate.savedState',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macromates.textmate.sfl2',
              ]

--- a/Casks/textmate-preview.rb
+++ b/Casks/textmate-preview.rb
@@ -1,6 +1,6 @@
 cask 'textmate-preview' do
-  version '2.0.11'
-  sha256 'ec40804776087d25a5ad5b3945413e77279282eeb6ed928e1f001eb0c12073e9'
+  version '2.0.12'
+  sha256 '99b353d8f56442cd600a1d8dcef7ab7534683c7b3cd1555c9d9e6013652f0e5e'
 
   # github.com/textmate/textmate/ was verified as official when first introduced to the cask
   url "https://github.com/textmate/textmate/releases/download/v#{version}/TextMate_#{version}.tbz"
@@ -20,6 +20,7 @@ cask 'textmate-preview' do
                '~/Library/Application Support/TextMate',
                '~/Library/Caches/com.macromates.TextMate',
                '~/Library/Preferences/com.macromates.TextMate.plist',
+               '~/Library/Preferences/com.macromates.TextMate.preview.plist',
                '~/Library/Saved Application State/com.macromates.TextMate.savedState',
                '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.macromates.textmate.sfl2',
              ]


### PR DESCRIPTION
also added preview plist to zap stanca

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
