### PR TITLE
Split Android Studio preview into beta and canary

### DIFF
--- a/Casks/android-studio-beta.rb
+++ b/Casks/android-studio-beta.rb
@@ -1,0 +1,26 @@
+cask 'android-studio-beta' do
+  version '4.0.0.15,193.645338'
+  sha256 '78d1ec72245f3d5646256f75ce141926293ca7c5f730a0f76eb1963a9c6a6bf3'
+
+  # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
+  url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
+  name 'Android Studio Preview (Beta)'
+  homepage 'https://developer.android.com/studio/preview/'
+
+  app "Android Studio #{version.major_minor} Preview.app"
+
+  zap trash: [
+               '~/Library/Android/sdk',
+               "~/Library/Application Support/AndroidStudio#{version.major_minor}",
+               "~/Library/Caches/AndroidStudio#{version.major_minor}",
+               "~/Library/Logs/AndroidStudio#{version.major_minor}",
+               "~/Library/Preferences/AndroidStudio#{version.major_minor}",
+               '~/Library/Preferences/com.android.Emulator.plist',
+               '~/Library/Saved Application State/com.google.android.studio.savedState',
+               '~/.android',
+             ],
+      rmdir: [
+               '~/AndroidStudioProjects',
+               '~/Library/Android',
+             ]
+end

--- a/Casks/android-studio-canary.rb
+++ b/Casks/android-studio-canary.rb
@@ -1,10 +1,10 @@
-cask 'android-studio-preview' do
+cask 'android-studio-canary' do
   version '4.1.0.9,201.6466190'
   sha256 '8f45a6f1e286d73a27627cccfa62e197f925bd7b7642facdfa9d71be39a45e99'
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
-  name 'Android Studio Preview'
+  name 'Android Studio Preview (Canary)'
   homepage 'https://developer.android.com/studio/preview/'
 
   app "Android Studio #{version.major_minor} Preview.app"


### PR DESCRIPTION
Fixes #8993  Convert latest 'preview' into canary and add a beta version.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
 _how can I test this *before* PR is merged?_
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
 _how can I test this *before* PR is merged?_
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].
