### PR TITLE
Update microsoft-edge-dev from 84.0.502.0 to 84.0.508.0

### DIFF
--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,6 @@
 cask 'microsoft-edge-dev' do
-  version '84.0.502.0'
-  sha256 '39faa27b198ae553c8aaee0ba4c37496ee6167d19c9531641107d171e67cdc6a'
+  version '84.0.508.0'
+  sha256 'fc76f7afee4386ab1e92058c193cccef826f35b7ff914de4e72d9686282548c8'
 
   # officecdn-microsoft-com.akamaized.net/ was verified as official when first introduced to the cask
   url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.