### PR TITLE
Update signal-beta from 1.34.0-beta.2 to 1.34.0-beta.3

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,6 +1,6 @@
 cask 'signal-beta' do
-  version '1.34.0-beta.2'
-  sha256 'bae7b483b7cbc57c29670c23552398c9c24c0f954a776340c63ab6370fa2e0d6'
+  version '1.34.0-beta.3'
+  sha256 '65cfee96db974518a625f91453490ab341a0a28d985f8859b31ced17fb045646'
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
   appcast 'https://github.com/signalapp/Signal-Desktop/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.