### PR TITLE
Fix url for android studio preview beta

### DIFF
--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -1,5 +1,5 @@
 cask 'android-studio-preview-beta' do
-  version '4.0.0.15,193.645338'
+  version '4.0.0.15,193.6453388'
   sha256 '78d1ec72245f3d5646256f75ce141926293ca7c5f730a0f76eb1963a9c6a6bf3'
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask


### PR DESCRIPTION
🤦 

`https://dl.google.com/dl/android/studio/ide-zips/4.0.0.15/android-studio-ide-193.6453388-mac.zip`
 
is the correct URL, not 

`https://dl.google.com/dl/android/studio/ide-zips/4.0.0.15/android-studio-ide-193.645338-mac.zip`