### PR TITLE
Fix chirp-daily, update to version 20200516

### DIFF
--- a/Casks/chirp-daily.rb
+++ b/Casks/chirp-daily.rb
@@ -1,13 +1,13 @@
 cask 'chirp-daily' do
-  version '20200409'
-  sha256 'd12a5fb48805c58334e52bffa8ebdc36eff85e759eb632e0de265a1dee9c4504'
+  version '20200516'
+  sha256 '7dfab75731dab76635c33b643f62f54bbd2861a19cbf9f19e19a4d4b91c80ea2'
 
-  url "https://trac.chirp.danplanet.com/chirp_daily/LATEST/chirp-daily-#{version}.app.zip"
+  url "https://trac.chirp.danplanet.com/chirp_daily/LATEST/chirp-unified-daily-#{version}.app.zip"
   appcast 'https://trac.chirp.danplanet.com/chirp_daily/LATEST/SHA1SUM'
   name 'CHIRP'
   homepage 'https://chirp.danplanet.com/projects/chirp/wiki/Home'
 
   depends_on cask: 'kk7ds-python-runtime'
 
-  app "chirp-daily-#{version}.app"
+  app 'CHIRP.app'
 end


### PR DESCRIPTION
Switches to [recommended](https://trac.chirp.danplanet.com/chirp_daily/LATEST/) macOS unified application from legacy application so that the cask now actually runs on macOS Catalina 10.15.4. Updates app name to CHIRP.app to match manual download from https://trac.chirp.danplanet.com/chirp_daily/LATEST/

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for a [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).