### PR TITLE
Add option to change app name for release candidates

### DIFF
--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -7,11 +7,7 @@ cask 'android-studio-preview-beta' do
   name 'Android Studio Preview (Beta)'
   homepage 'https://developer.android.com/studio/preview/'
 
-  # for release candidates:
   app 'Android Studio.app'
-
-  # for non-RC beta releases:
-  # app "Android Studio #{version.major_minor} Preview.app"
 
   conflicts_with cask: 'android-studio'
   conflicts_with cask: 'android-studio-preview-canary'

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -7,10 +7,12 @@ cask 'android-studio-preview-beta' do
   name 'Android Studio Preview (Beta)'
   homepage 'https://developer.android.com/studio/preview/'
 
-  app 'Android Studio.app'
+  conflicts_with cask: [
+                         'android-studio',
+                         'android-studio-preview-canary',
+                       ]
 
-  conflicts_with cask: 'android-studio'
-  conflicts_with cask: 'android-studio-preview-canary'
+  app 'Android Studio.app'
 
   zap trash: [
                '~/Library/Android/sdk',

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -13,6 +13,9 @@ cask 'android-studio-preview-beta' do
   # for non-RC beta releases:
   # app "Android Studio #{version.major_minor} Preview.app"
 
+  conflicts_with cask: 'android-studio'
+  conflicts_with cask: 'android-studio-preview-canary'
+
   zap trash: [
                '~/Library/Android/sdk',
                "~/Library/Application Support/AndroidStudio#{version.major_minor}",

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -7,7 +7,11 @@ cask 'android-studio-preview-beta' do
   name 'Android Studio Preview (Beta)'
   homepage 'https://developer.android.com/studio/preview/'
 
-  app "Android Studio #{version.major_minor} Preview.app"
+  # for release candidates:
+  app 'Android Studio.app'
+
+  # for non-RC beta releases:
+  # app "Android Studio #{version.major_minor} Preview.app"
 
   zap trash: [
                '~/Library/Android/sdk',


### PR DESCRIPTION
Android Studio developers call the release candidates just "Android Studio" not "Android Studio X.Y Preview"

I'm not sure the best way to handle this within the Cask. I'm open to suggestions. For now I just have both options and one will need to be commented out.

The current code was causing an install issue:

```
==> Verifying SHA-256 checksum for Cask 'android-studio-preview-beta'.
==> Installing Cask android-studio-preview-beta
==> Purging files for version 4.0.0.15,193.6453388 of Cask android-studio-preview-beta
Error: It seems the App source '/usr/local/Caskroom/android-studio-preview-beta/4.0.0.15,193.6453388/Android Studio 4.0 Preview.app' is not there.
```

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).