### PR TITLE
fix: url

### DIFF
--- a/Casks/alfred3.rb
+++ b/Casks/alfred3.rb
@@ -2,7 +2,7 @@ cask 'alfred3' do
   version '3.8.5_970'
   sha256 'b3b2341ac9574b0a6a78b62c747e852a41ecd54fae921e446e05b076166b5102'
 
-  url "https://cachefly.alfredapp.com/Alfred_#{version}.dmg"
+  url "https://cachefly.alfredapp.com/960Alfred_#{version}.dmg"
   appcast 'https://www.alfredapp.com/app/update/general.xml'
   name 'Alfred'
   homepage 'https://www.alfredapp.com/'


### PR DESCRIPTION
i manually went to the url above and it redirects. Using ansible to install alfred3 it is failing. I thought this might be why?

brew cask info alfred3 shows a the right item.
brew cask install alfred3 says it is unavailable.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
