### PR TITLE
Add missing `conflicts_with` statement

### DIFF
--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -7,11 +7,7 @@ cask 'android-studio-preview-beta' do
   name 'Android Studio Preview (Beta)'
   homepage 'https://developer.android.com/studio/preview/'
 
-  # for release candidates:
   app 'Android Studio.app'
-
-  # for non-RC beta releases:
-  # app "Android Studio #{version.major_minor} Preview.app"
 
   conflicts_with cask: 'android-studio'
   conflicts_with cask: 'android-studio-preview-canary'

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -7,10 +7,12 @@ cask 'android-studio-preview-beta' do
   name 'Android Studio Preview (Beta)'
   homepage 'https://developer.android.com/studio/preview/'
 
-  app 'Android Studio.app'
+  conflicts_with cask: [
+                         'android-studio',
+                         'android-studio-preview-canary',
+                       ]
 
-  conflicts_with cask: 'android-studio'
-  conflicts_with cask: 'android-studio-preview-canary'
+  app 'Android Studio.app'
 
   zap trash: [
                '~/Library/Android/sdk',

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -13,6 +13,9 @@ cask 'android-studio-preview-beta' do
   # for non-RC beta releases:
   # app "Android Studio #{version.major_minor} Preview.app"
 
+  conflicts_with cask: 'android-studio'
+  conflicts_with cask: 'android-studio-preview-canary'
+
   zap trash: [
                '~/Library/Android/sdk',
                "~/Library/Application Support/AndroidStudio#{version.major_minor}",

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -7,7 +7,11 @@ cask 'android-studio-preview-beta' do
   name 'Android Studio Preview (Beta)'
   homepage 'https://developer.android.com/studio/preview/'
 
-  app "Android Studio #{version.major_minor} Preview.app"
+  # for release candidates:
+  app 'Android Studio.app'
+
+  # for non-RC beta releases:
+  # app "Android Studio #{version.major_minor} Preview.app"
 
   zap trash: [
                '~/Library/Android/sdk',

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -7,6 +7,11 @@ cask 'android-studio-preview-canary' do
   name 'Android Studio Preview (Canary)'
   homepage 'https://developer.android.com/studio/preview/'
 
+  conflicts_with cask: [
+                         'android-studio',
+                         'android-studio-preview-beta',
+                       ]
+
   app "Android Studio #{version.major_minor} Preview.app"
 
   zap trash: [


### PR DESCRIPTION
While fixing issues with #9093 I realized I was missing `conflicts with` statement on this cask too.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

_(Will rebase after other PR is merged)_