### PR TITLE
New cask: Public Beta Environment for League of Legends

### DIFF
--- a/Casks/league-of-legends-pbe.rb
+++ b/Casks/league-of-legends-pbe.rb
@@ -1,0 +1,25 @@
+cask 'league-of-legends-pbe' do
+  version :latest
+  sha256 :no_check
+
+  # lol.secure.dyn.riotcdn.net/ was verified as official when first introduced to the cask
+  url 'https://lol.secure.dyn.riotcdn.net/channels/public/x/installer/current/pbe.pbe.zip'
+  name 'League of Legends (PBE)'
+  homepage 'https://pbesignup.na.leagueoflegends.com/en_US/pbe'
+
+  app 'League of Legends (PBE).app'
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.riotgames.maccontainer.sfl*',
+               '~/Library/Saved Application State/com.riotgames.LeagueofLegends.GameClient.savedState',
+               '~/Library/Saved Application State/com.riotgames.LeagueofLegends.LeagueClientUx.savedState',
+               '~/Library/Preferences/com.riotgames.LeagueofLegends.LeagueClientUxHelper.plist',
+               '~/Library/Caches/com.riotgames.LeagueofLegends.LeagueClient',
+               '/Users/Shared/Riot Games/RiotClientInstalls.json',
+               '/Users/Shared/Riot Games/com.riot.riotclient.checkinstalls-lock',
+             ],
+      rmdir: [
+               '~/Documents/League of Legends',
+               '/Users/Shared/Riot Games/Riot Client.app',
+               '/Users/Shared/Riot Games/Metadata',
+             ]


### PR DESCRIPTION
Added cask for League of Legends' public beta environment.

- [✓] `brew cask audit --download {{cask_file}}` is error-free.
- [✓] `brew cask style --fix {{cask_file}}` reports no offenses.
- [✓] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [✓] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [✓] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
    **Note:** the above reference does not mention what to do with brackets.  The app is officially named 'League of Legends (PBE).app', so I have called the cask 'league-of-legends-pbe'
- [ X ] `brew cask install {{cask_file}}` worked successfully.
   **I AM UNSURE WHAT TO DO FROM HERE!**  Upon running `brew cask install {{cask_file}}`, I get the error:
   ```
   Error: It seems the App source '/usr/local/Caskroom/league-of-legends-pbe/latest/League of Legends (PBE).app' is not there.
   ```
    I think this is because the download needs to be extracted form its `zip` archive, which extracts into an installer application.  I will need help to get this cask working from here, sorry.

- [ X ] `brew cask uninstall {{cask_file}}` worked successfully.
- [✓] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [✓] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
