### PR TITLE
Update hex-fiend-beta from 2.13.0b2 to 2.13.0b3

### DIFF
--- a/Casks/hex-fiend-beta.rb
+++ b/Casks/hex-fiend-beta.rb
@@ -1,6 +1,6 @@
 cask 'hex-fiend-beta' do
-  version '2.13.0b2'
-  sha256 'c7e768637b469d5d5fb46c214849b7f256a87610feec00ba986184834bed5a23'
+  version '2.13.0b3'
+  sha256 'e9b893d5c547b03c806b12d489901cb7a638225ff0d771914743abdda6ba94e8'
 
   # github.com/ridiculousfish/HexFiend/ was verified as official when first introduced to the cask
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).