### PR TITLE
Update termius-beta from 5.12.0 to 5.13.0

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask 'termius-beta' do
-  version '5.12.0'
-  sha256 '629060c853ef4ffab88098f2bf3fbeb0e5b9ee55b659ce278d300a4267860c72'
+  version '5.13.0'
+  sha256 '4652a04ca861a35e93fe90f96025d55a35bcbf4ac3d20a96944ff46f8e357db1'
 
   url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'
   name 'Termius Beta'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).