### PR TITLE
Update android-studio-preview-canary from 4.1.0.9,201.6466190 to 4.1.0.10,201.6507185

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-preview-canary' do
-  version '4.1.0.9,201.6466190'
-  sha256 '8f45a6f1e286d73a27627cccfa62e197f925bd7b7642facdfa9d71be39a45e99'
+  version '4.1.0.10,201.6507185'
+  sha256 'f5bf9f1359df2cf1a8eab7bf91ede765c49eca4b06b49ade11862fe6e8daddc7'
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.