### PR TITLE
Update termius-beta from 5.13.0 to 5.13.2

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,5 +1,5 @@
 cask 'termius-beta' do
-  version '5.13.0'
+  version '5.13.2'
   sha256 '4652a04ca861a35e93fe90f96025d55a35bcbf4ac3d20a96944ff46f8e357db1'
 
   url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.