### PR TITLE
Remove support for Mavericks

### DIFF
--- a/Casks/atom-nightly.rb
+++ b/Casks/atom-nightly.rb
@@ -6,8 +6,6 @@ cask 'atom-nightly' do
   name 'Github Atom Nightly'
   homepage 'https://atom.io/nightly'
 
-  depends_on macos: '>= :mavericks'
-
   app 'Atom Nightly.app'
   binary "#{appdir}/Atom Nightly.app/Contents/Resources/app/apm/bin/apm", target: 'apm-nightly'
   binary "#{appdir}/Atom Nightly.app/Contents/Resources/app/atom.sh", target: 'atom-nightly'

--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -9,7 +9,6 @@ cask 'brave-browser-beta' do
   homepage 'https://brave.com/download-beta/'
 
   auto_updates true
-  depends_on macos: '>= :mavericks'
 
   app 'Brave Browser Beta.app'
 

--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -9,7 +9,6 @@ cask 'brave-browser-dev' do
   homepage 'https://brave.com/download-dev/'
 
   auto_updates true
-  depends_on macos: '>= :mavericks'
 
   app 'Brave Browser Dev.app'
 

--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -11,8 +11,6 @@ cask 'brave-browser-nightly' do
   name 'Brave Nightly'
   homepage 'https://brave.com/download-nightly/'
 
-  depends_on macos: '>= :mavericks'
-
   app 'Brave Browser Nightly.app'
 
   zap trash: [

--- a/Casks/omnifocus2.rb
+++ b/Casks/omnifocus2.rb
@@ -1,9 +1,5 @@
 cask 'omnifocus2' do
-  if MacOS.version <= :mavericks
-    version '2.0.4'
-    sha256 '3282eb7e41ec2638f68a92a6509eddd96a96c39b65b954dcedcc4e62289f22a9'
-    url "https://downloads.omnigroup.com/software/MacOSX/10.9/OmniFocus-#{version}.dmg"
-  elsif MacOS.version <= :yosemite
+  if MacOS.version <= :yosemite
     version '2.7.4'
     sha256 'a273e55c15f82540fe305344f9e49ad7d0d9c326ba2c37c312076ffd73780f80'
     url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"

--- a/Casks/screenflow5.rb
+++ b/Casks/screenflow5.rb
@@ -7,7 +7,6 @@ cask 'screenflow5' do
   homepage 'https://www.telestream.net/screenflow/'
 
   auto_updates true
-  depends_on macos: '>= :mavericks'
 
   app 'ScreenFlow.app'
 end

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -10,7 +10,6 @@ cask 'visual-studio-code-insiders' do
   homepage 'https://code.visualstudio.com/insiders'
 
   auto_updates true
-  depends_on macos: '>= :mavericks'
 
   app 'Visual Studio Code - Insiders.app'
   binary "#{appdir}/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code", target: 'code-insiders'


### PR DESCRIPTION
With https://github.com/Homebrew/brew/pull/7698, Homebrew no longer runs on Mavericks.

In preparation, https://github.com/Homebrew/brew/pull/7716 has been merged, which removes support for the `:mavericks` symbol.

This causes `brew cask install` and `brew cask uninstall` to fail with the following error message if `cask-versions` is tapped:

```
Error: Cask 'brave-browser-nightly' definition is invalid: invalid 'depends_on macos' value: ">= :mavericks"
```

This PR fixes the issue by removing all references to `:mavericks`.

___

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free. **Fails for one of the casks (403 error for `brave-browser-dev`) but that’s unrelated to this PR.**
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
