### PR TITLE
Update brave-browser-dev from 83.1.11.53,111.53 to 83.1.11.62,111.62

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,6 +1,6 @@
 cask 'brave-browser-dev' do
-  version '83.1.11.53,111.53'
-  sha256 '128258deadbc8c15e060fda16d321c5cfeab1fb63cec9e2e29c5db7b7470dff7'
+  version '83.1.11.62,111.62'
+  sha256 '73288a052cf22e0fd3fafb14b881d487c040fda847875eb9dca8a7c3ac6b8de0'
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser/ was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.