### PR TITLE
Update hex-fiend-beta from 2.13.0b4 to 2.13.0b5

### DIFF
--- a/Casks/hex-fiend-beta.rb
+++ b/Casks/hex-fiend-beta.rb
@@ -1,6 +1,6 @@
 cask 'hex-fiend-beta' do
-  version '2.13.0b4'
-  sha256 '90bd2478cc61cc280596ec1b99d701ba88cf1b44f71798395e1cc5a1d3077c00'
+  version '2.13.0b5'
+  sha256 '99ad82c4a40bd33c4c7c85523ddde65ae4c96fae851ffe826a319b6961c0687a'
 
   # github.com/ridiculousfish/HexFiend/ was verified as official when first introduced to the cask
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).