### PR TITLE
Update appcode-eap from 2020.1,201.6668.124 to 2020.2,202.5792.17

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,6 +1,6 @@
 cask 'appcode-eap' do
-  version '2020.1,201.6668.124'
-  sha256 '9748d842bfd542569a532a63e7dfcc5f112598e7f71abfcaa9dcc73b43cac759'
+  version '2020.2,202.5792.17'
+  sha256 '53888c2f45315b0c3c089521ff6c3b1f903544dce7aa497b8c3de8161d6ad179'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.after_comma}.dmg"
   name 'AppCode EAP'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).