### PR TITLE
Add MacDown.app v0.8.0d71

### DIFF
--- a/Casks/macdown-dev.rb
+++ b/Casks/macdown-dev.rb
@@ -4,7 +4,7 @@ cask 'macdown-dev' do
 
   # github.com/MacDownApp/macdown/ was verified as official when first introduced to the cask
   url "https://github.com/MacDownApp/macdown/releases/download/v#{version}/MacDown.app.zip"
-  appcast 'https://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml'
+  appcast 'https://github.com/MacDownApp/macdown/releases.atom'
   name 'MacDown'
   homepage 'https://macdown.uranusjr.com/'
 

--- a/Casks/macdown-dev.rb
+++ b/Casks/macdown-dev.rb
@@ -1,0 +1,25 @@
+cask 'macdown-dev' do
+  version '0.8.0d71'
+  sha256 '6376343fe54a8f4c1dfe3b7c2a2bef0988d636692e2ffc2d20bd4f21543cc78f'
+
+  # github.com/MacDownApp/macdown/ was verified as official when first introduced to the cask
+  url "https://github.com/MacDownApp/macdown/releases/download/v#{version}/MacDown.app.zip"
+  appcast 'https://macdown.uranusjr.com/sparkle/macdown/stable/appcast.xml'
+  name 'MacDown'
+  homepage 'https://macdown.uranusjr.com/'
+
+  auto_updates true
+
+  app 'MacDown.app'
+  binary "#{appdir}/MacDown.app/Contents/SharedSupport/bin/macdown"
+
+  zap trash: [
+               '~/Library/Application Support/MacDown',
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.uranusjr.macdown.sfl*',
+               '~/Library/Caches/com.uranusjr.macdown',
+               '~/Library/Cookies/com.uranusjr.macdown.binarycookies',
+               '~/Library/Preferences/com.uranusjr.macdown.plist',
+               '~/Library/Saved Application State/com.uranusjr.macdown.savedState',
+               '~/Library/WebKit/com.uranusjr.macdown',
+             ]
+end


### PR DESCRIPTION
Adding dev build for homebrew testing so issue with 0.7.3 can be resolved by MacDown developer.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
