### PR TITLE
Update hex-fiend-beta from 2.13.0b5 to 2.13.1b1

### DIFF
--- a/Casks/hex-fiend-beta.rb
+++ b/Casks/hex-fiend-beta.rb
@@ -1,9 +1,9 @@
 cask 'hex-fiend-beta' do
-  version '2.13.1b1'
+  version '2.13.1,b1'
   sha256 '7251b04719d3c58c49a3896ad85ee4b824f67eac36d490a5fd37364ccb580158'
 
   # github.com/ridiculousfish/HexFiend/ was verified as official when first introduced to the cask
-  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.sub(%r{b\d+}, '')}.dmg"
+  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version.before_comma}#{version.after_comma}/Hex_Fiend_#{version.before_comma}.dmg"
   appcast 'https://github.com/ridiculousfish/HexFiend/releases.atom'
   name 'Hex Fiend'
   homepage 'https://ridiculousfish.com/hexfiend/'

--- a/Casks/hex-fiend-beta.rb
+++ b/Casks/hex-fiend-beta.rb
@@ -1,9 +1,9 @@
 cask 'hex-fiend-beta' do
-  version '2.13.0b5'
-  sha256 '99ad82c4a40bd33c4c7c85523ddde65ae4c96fae851ffe826a319b6961c0687a'
+  version '2.13.1b1'
+  sha256 '7251b04719d3c58c49a3896ad85ee4b824f67eac36d490a5fd37364ccb580158'
 
   # github.com/ridiculousfish/HexFiend/ was verified as official when first introduced to the cask
-  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"
+  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.sub(%r{b\d+}, '')}.dmg"
   appcast 'https://github.com/ridiculousfish/HexFiend/releases.atom'
   name 'Hex Fiend'
   homepage 'https://ridiculousfish.com/hexfiend/'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
I updated the `url` stanza. Let me know if it should be done a different way.