### PR TITLE
Update safari-technology-preview to 109

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,6 +1,11 @@
 cask 'safari-technology-preview' do
-  version '109,001-21354-20200624-98a4e372-cb40-4d35-9b8c-8b8abcde5272'
-  sha256 '4dff98feb0723d0408a313d3b195ac4448a6d9c9dda8d88e6efd03114585d162'
+  if MacOS.version <= :catalina
+    version '109,001-21354-20200624-98a4e372-cb40-4d35-9b8c-8b8abcde5272'
+    sha256 '4dff98feb0723d0408a313d3b195ac4448a6d9c9dda8d88e6efd03114585d162'
+  else
+    version '109,001-01921-20200624-789b06ac-f1c4-43e7-9e02-636204e11bb1'
+    sha256 '169d1eb786eb4bf8ef03392aa42c4a3738db0355e28c991627ce6ca279a70088'
+  end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
   appcast 'https://developer.apple.com/safari/download/'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

----

Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 109, 15610.1.17.2)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=1940&view=logs