### PR TITLE
Update firefox-esr from 68.9.0 to 68.10.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,78 +1,78 @@
 cask 'firefox-esr' do
-  version '68.9.0'
+  version '68.10.0'
 
   language 'cs' do
-    sha256 '1568a23b34b2a425d758ad116ea70e2ec2211924a430b2274cf223c943cc4304'
+    sha256 '4250e888513066415a8ebbf88e668892bce9a0edc1d73009a5358d87d6027d63'
     'cs'
   end
 
   language 'de' do
-    sha256 '16ae4627e1f9e26f3494868d4fcf11d0951fa74e721f9ce878a0c3c55aa49748'
+    sha256 'fdb168bd32fde69020cc8767e8d47a4a6a4a73b32bfe23538a99bf2d99a38e4b'
     'de'
   end
 
   language 'en-GB' do
-    sha256 '66a27a0153b18ffa93190d5b7498e685054476d244ee3df60bcacaf1727c8d98'
+    sha256 'd9c11c30c5522af53b224cbde3e549b605abc9b4f93f9f4fdf7ed5e60f6200ad'
     'en-GB'
   end
 
   language 'en', default: true do
-    sha256 'b542f03b610ae7f894bef979ab5087762f0b601cf88ce8f9e86919cce632384e'
+    sha256 '7251efaa3dfb956631f5f9ea9293401c1e6aedf9c37824c6a60b0654e1b10174'
     'en-US'
   end
 
   language 'fr' do
-    sha256 '8af8bc17d3d40a4669ee36e1c292d60b45595644d07e6b9131aaa5e2a881a02b'
+    sha256 '350a36703c80dc6c054487ca08bdf3a68a951144e45c66bb9fc0c4a5e6999f81'
     'fr'
   end
 
   language 'gl' do
-    sha256 '50edbcc99e132ebc8e418ddf802109ce5f8bf8d933e2e2a0228809d1c20e59c5'
+    sha256 '6f3b867dfcedadd1ee40073e92298dda9ff64f109edebb09d34bff994a2d2ef6'
     'gl'
   end
 
   language 'it' do
-    sha256 '3bf6caaa33c95c0f19ca9d4d7c77728371fa4c01b41e6587650225484eb5e946'
+    sha256 '59cc9ba9751b2439d044a4185f257f78d4da63ace899b5f70a5323485c91ea32'
     'it'
   end
 
   language 'ja' do
-    sha256 'a4ad089441543d834154a39cb77f7048e7c24c782ae16b06eb3cf7f7f4b4d6bc'
+    sha256 '043dab4a3db0948c46672ee59c46346390fc81dc4125cb53cdab6313dd56ec24'
     'ja-JP-mac'
   end
 
   language 'nl' do
-    sha256 '40bbd243ad3a02994bc9b194c21a31af3805daff1de3821bf486b3d78b36aeca'
+    sha256 'bc2ec944b23ac27d6138fed4019817ba6c98735981dbd7cad5ab89c462f71d36'
     'nl'
   end
 
   language 'pl' do
-    sha256 '02f4e30f24e96a146322cf3367e1270370b3288a4bdbab4d03ca0a56d8b7e246'
+    sha256 '612b29244d0e241f51e5352c7f92b6a93328e6d3b83099876524526bff72b7b0'
     'pl'
   end
 
   language 'pt' do
-    sha256 '7191d48269db45153297c8efaf215e59a9b8eac9b4c6dce8c85459ea810586c6'
+    sha256 '379268d827cb92e5211b3ba29e9ce59cf5ad4d44e39579e89c65dfd68659db28'
     'pt-PT'
   end
 
   language 'ru' do
-    sha256 'f256bd5fec7a32c875907a8c9cd1384d4a840b74022f98902bc60772ecd0897b'
+    sha256 '10013375a8f28821e1c8204e436213754772ea1e72daaa15e59b80e3d9a15f38'
     'ru'
   end
 
   language 'uk' do
-    sha256 '3c0d493b1c6e341e03c44b4762302ed79f9d228c1be6db0788f9a79dd2a04d2a'
+    sha256 'bb342927a50a83ac7dfddbcb447cd4c0c1012590f910380361331935cc680591'
     'uk'
   end
 
   language 'zh-TW' do
-    sha256 '791ac23dd400e6615c95e22d6db7056b93af1b186ed23f7ea3c05df9a26777ea'
+    sha256 '8f8de60e52027fa4b957b009c47dbf0048a68dfad42a99935f7945ccc9c87cee'
     'zh-TW'
   end
 
   language 'zh' do
-    sha256 '3c2637cfa6020c2e12ae84118449e97c843ea0c659f159e9afe760d970130d51'
+    sha256 '4a4140e0c7fb3cde886903d755e535ec465160c66242040556be2310e4ff0081'
     'zh-CN'
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
