### PR TITLE
Update opera-beta from 69.0.3686.30 to 70.0.3728.8

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask 'opera-beta' do
-  version '69.0.3686.30'
-  sha256 'f4da80c1fd5327efbe3b2e8af010819241b1afa13d584983d3a360a40407d510'
+  version '70.0.3728.8'
+  sha256 '3a618015b85812719b6443a5eac559868de383cd97711d5ccb8b1357ceec4d5f'
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name 'Opera Beta'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).