### PR TITLE
Update android-studio-preview-canary from 4.2.0.2,201.6582697 to 4.2.0.3,201.6630367

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -1,6 +1,6 @@
 cask 'android-studio-preview-canary' do
-  version '4.2.0.2,201.6582697'
-  sha256 '9d145c76ec6dbd410ce34f48a7528a6a9434b427c940a4ff8820403fc4e4681b'
+  version '4.2.0.3,201.6630367'
+  sha256 'c26233ab417a6258fb00c6f243201118e26adbcc273c6f8b6f62745f1eddffa8'
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).