### PR TITLE
Update appcode-eap from 2020.2,202.6109.28 to 2020.2,202.6250.25

### DIFF
--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,6 +1,6 @@
 cask 'appcode-eap' do
-  version '2020.2,202.6109.28'
-  sha256 'fd1f68467ecb2d19f62b6b67633719d09acdf773418beb3657242433bf502d5a'
+  version '2020.2,202.6250.25'
+  sha256 '65455772f6701ff9d170b0a3a94c117c58734ee2f74a1809e7d0db3865f1f8d0'
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.after_comma}.dmg"
   name 'AppCode EAP'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).