### PR TITLE
Add missing conflicts_with for android-studio-preview-canary

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -7,6 +7,11 @@ cask 'android-studio-preview-canary' do
   name 'Android Studio Preview (Canary)'
   homepage 'https://developer.android.com/studio/preview/'
 
+  conflicts_with cask: [
+                         'android-studio',
+                         'android-studio-preview-beta',
+                       ]
+
   app "Android Studio #{version.major_minor} Preview.app"
 
   zap trash: [


### PR DESCRIPTION
After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Derp, #9134 got closed before I could rebase. So here it is again.