### PR TITLE
Update brave-browser-dev from 84.1.12.101,112.101 to 84.1.12.102,112.102

### DIFF
--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -1,20 +1,20 @@
-cask 'brave-browser-dev' do
-  version '84.1.12.101,112.101'
-  sha256 'a09a4dcbba9820cb6c905bc4480588b2bd577b6bca5a60fbd015e8f2b9a12c88'
+cask "brave-browser-dev" do
+  version "84.1.12.104,112.104"
+  sha256 "dbd0fdac266c2a363cb5aaf37f0239f3e1e4b9a6e8f3cd5759133d53301e3dba"
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser/ was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/dev/#{version.after_comma}/Brave-Browser-Dev.dmg"
-  appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml'
-  name 'Brave Dev'
-  homepage 'https://brave.com/download-dev/'
+  appcast "https://updates.bravesoftware.com/sparkle/Brave-Browser/dev/appcast.xml"
+  name "Brave Dev"
+  homepage "https://brave.com/download-dev/"
 
   auto_updates true
 
-  app 'Brave Browser Dev.app'
+  app "Brave Browser Dev.app"
 
   zap trash: [
-               '~/Library/Application Support/brave',
-               '~/Library/Preferences/com.electron.brave.plist',
-               '~/Library/Saved Application State/com.electron.brave.savedState',
-             ]
+    "~/Library/Application Support/brave",
+    "~/Library/Preferences/com.electron.brave.plist",
+    "~/Library/Saved Application State/com.electron.brave.savedState",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).