### PR TITLE
Update termius-beta from 6.2.2 to 6.2.3

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,19 +1,19 @@
-cask 'termius-beta' do
-  version '6.2.2'
-  sha256 '9007c2b6ffa77cfaa6cdcfe83d5a47bcbd5f88f3934a9c7e861146b9fa9a0bfe'
+cask "termius-beta" do
+  version "6.2.3"
+  sha256 "b2b4386156454158fdc6c48663a7332d0dfda9f34a90be052eedd32b798935cd"
 
-  url 'https://www.termius.com/beta/download/mac/Termius+Beta.dmg'
-  name 'Termius Beta'
-  homepage 'https://www.termius.com/beta-program'
+  url "https://www.termius.com/beta/download/mac/Termius+Beta.dmg"
+  name "Termius Beta"
+  homepage "https://www.termius.com/beta-program"
 
-  app 'Termius Beta.app'
+  app "Termius Beta.app"
 
   zap trash: [
-               '~/.termius',
-               '~/Library/Application Support/Termius Beta',
-               '~/Library/Saved Application State/com.termius-beta.mac.savedState',
-               '/Library/Preferences/com.termius-beta.mac.helper.plist',
-               '/Library/Preferences/com.termius-beta.mac.plist',
-               '~/Library/Logs/Termius Beta',
-             ]
+    "~/.termius",
+    "~/Library/Application Support/Termius Beta",
+    "~/Library/Saved Application State/com.termius-beta.mac.savedState",
+    "/Library/Preferences/com.termius-beta.mac.helper.plist",
+    "/Library/Preferences/com.termius-beta.mac.plist",
+    "~/Library/Logs/Termius Beta",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).