### PR TITLE
Update opera-developer from 71.0.3756.0 to 71.0.3763.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,20 +1,20 @@
-cask 'opera-developer' do
-  version '71.0.3756.0'
-  sha256 '9f43210b8bd29c1cfb4fc1c53c7488bd873014eda4fd9c52c8d18e6045826b18'
+cask "opera-developer" do
+  version "71.0.3763.0"
+  sha256 "c68448802e0ec755ca1d60b37359a661c1bbe6afa79f1a23548d2aba15d7df56"
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
-  name 'Opera Developer'
-  homepage 'https://www.opera.com/computer/beta'
+  name "Opera Developer"
+  homepage "https://www.opera.com/computer/beta"
 
   auto_updates true
 
-  app 'Opera Developer.app'
+  app "Opera Developer.app"
 
   zap trash: [
-               '~/Library/Application Support/com.operasoftware.OperaDeveloper',
-               '~/Library/Caches/com.operasoftware.OperaDeveloper',
-               '~/Library/Cookies/com.operasoftware.OperaDeveloper.binarycookies',
-               '~/Library/Preferences/com.operasoftware.OperaDeveloper.plist',
-               '~/Library/Saved Application State/com.operasoftware.OperaDeveloper.savedState',
-             ]
+    "~/Library/Application Support/com.operasoftware.OperaDeveloper",
+    "~/Library/Caches/com.operasoftware.OperaDeveloper",
+    "~/Library/Cookies/com.operasoftware.OperaDeveloper.binarycookies",
+    "~/Library/Preferences/com.operasoftware.OperaDeveloper.plist",
+    "~/Library/Saved Application State/com.operasoftware.OperaDeveloper.savedState",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).