### PR TITLE
Update brave-browser-beta from 84.1.12.98,112.98 to 84.1.12.103,112.103

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,20 +1,20 @@
-cask 'brave-browser-beta' do
-  version '84.1.12.98,112.98'
-  sha256 '0b342bd5326badb40d26d4ffb0140e4dbc5843926ab5b1aa4f59cb16cbd259d0'
+cask "brave-browser-beta" do
+  version "84.1.12.103,112.103"
+  sha256 "51691bb5697fe0f0bf69abbc80fc6eee7e2ec6069a17254c6e77a46786b0aedd"
 
   # updates-cdn.bravesoftware.com/sparkle/Brave-Browser/ was verified as official when first introduced to the cask
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/beta/#{version.after_comma}/Brave-Browser-Beta.dmg"
-  appcast 'https://updates.bravesoftware.com/sparkle/Brave-Browser/beta/appcast.xml'
-  name 'Brave Beta'
-  homepage 'https://brave.com/download-beta/'
+  appcast "https://updates.bravesoftware.com/sparkle/Brave-Browser/beta/appcast.xml"
+  name "Brave Beta"
+  homepage "https://brave.com/download-beta/"
 
   auto_updates true
 
-  app 'Brave Browser Beta.app'
+  app "Brave Browser Beta.app"
 
   zap trash: [
-               '~/Library/Application Support/brave',
-               '~/Library/Preferences/com.electron.brave.plist',
-               '~/Library/Saved Application State/com.electron.brave.savedState',
-             ]
+    "~/Library/Application Support/brave",
+    "~/Library/Preferences/com.electron.brave.plist",
+    "~/Library/Saved Application State/com.electron.brave.savedState",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).