### PR TITLE
Update corretto8 from 8.262.10.1 to 8.265.01.1

### DIFF
--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,6 +1,6 @@
 cask "corretto8" do
-  version "8.262.10.1"
-  sha256 "2e98933dd2aec483afac71a4198b05f5d26affd54ae12eb978f043b59add23e0"
+  version "8.265.01.1"
+  sha256 "2244f6f5603a08257d57e25dddc17eceb33aa948d34d82be4ea22c34cba1004f"
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.