### PR TITLE
Update java6

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -1,5 +1,5 @@
 cask "java6" do
-  version "1.6.0_65-b14-468"
+  version "1.6.0,65-b14-468"
   sha256 "3a91bd24a0524df4cde9433f2ac56182818f78aacda36c7529b3d548e0c12e63"
 
   # updates.cdn-apple.com/ was verified as official when first introduced to the cask
@@ -12,7 +12,7 @@ cask "java6" do
 
     uninstall pkgutil: "com.apple.pkg.JavaForMacOSX107"
   else
-    artifact "JavaForOSX/JavaForOSX.pkg/Payload/Library/Java/JavaVirtualMachines/1.6.0.jdk", target: "/Library/Java/JavaVirtualMachines/1.6.0.jdk"
+    artifact "JavaForOSX/JavaForOSX.pkg/Payload/Library/Java/JavaVirtualMachines/#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/#{version.before_comma}.jdk"
 
     preflight do
       system_command "pkgutil", chdir: staged_path, args: ["--expand-full", "JavaForOSX.pkg", "JavaForOSX"]


### PR DESCRIPTION
This should prevent this cask failing the style checks, as the presence of `#{version.` will ensure [`.rubocop.yml`](https://github.com/Homebrew/brew/blob/master/Library/.rubocop.yml#L183-L186) ignores the offending line.