### PR TITLE
openemu-experimental: fix depends_on macos according to releasers

### DIFF
--- a/Casks/openemu-experimental.rb
+++ b/Casks/openemu-experimental.rb
@@ -1,14 +1,20 @@
 cask "openemu-experimental" do
-  version "2.2.1"
-  sha256 "8977f563868a312b72298dc7cd2b8767c21b440bae598d16a7d3916a98d870e8"
+  if MacOS.version <= :yosemite
+    version "1.0.4"
+    sha256 "23b99cf31a11f84e1110c6ce9bf503b6b479583e5229987b6c663bacfed73f06"
+  elsif MacOS.version <= :high_sierra
+    version "2.0.9.1"
+    sha256 "62c44e823fef65c583cbf5e6f84faa03618d713f45610f73bc23fb34cbf64762"
+  else
+    version "2.2.1"
+    sha256 "8977f563868a312b72298dc7cd2b8767c21b440bae598d16a7d3916a98d870e8"
+  end
 
   # github.com/OpenEmu/OpenEmu/ was verified as official when first introduced to the cask
   url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}-experimental.zip"
   appcast "https://github.com/OpenEmu/OpenEmu/releases.atom"
   name "OpenEmu"
   homepage "https://openemu.org/"
-
-  depends_on macos: ">= :el_capitan"
 
   app "OpenEmu.app"
 

--- a/Casks/openemu-experimental.rb
+++ b/Casks/openemu-experimental.rb
@@ -16,6 +16,9 @@ cask "openemu-experimental" do
   name "OpenEmu"
   homepage "https://openemu.org/"
 
+  auto_updates true
+  conflicts_with cask: "openemu"
+
   app "OpenEmu.app"
 
   zap trash: [

--- a/Casks/openemu-experimental.rb
+++ b/Casks/openemu-experimental.rb
@@ -1,8 +1,5 @@
 cask "openemu-experimental" do
-  if MacOS.version <= :yosemite
-    version "1.0.4"
-    sha256 "23b99cf31a11f84e1110c6ce9bf503b6b479583e5229987b6c663bacfed73f06"
-  elsif MacOS.version <= :high_sierra
+  if MacOS.version <= :high_sierra
     version "2.0.9.1"
     sha256 "62c44e823fef65c583cbf5e6f84faa03618d713f45610f73bc23fb34cbf64762"
   else


### PR DESCRIPTION
After installed, when we open the application, the following warning message is showed:

```
Your Mac is too old for this version of OpenEmu

Since version 2.1, OpenEmu requires a GPU which supports Metal. Metal is available on all Macs that support macOS 10.14 or later.

As OpenEmu does not work with your current hardware/software configuration, it will now close.
```

The current formula for openemu in homebrew-cask was used as reference (sha256 were adjusted):

https://github.com/Homebrew/homebrew-cask/blob/e927fea62652ff5d6223ce3cb491ad981b914934/Casks/openemu.rb

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
