### PR TITLE
Update sonos-s1-controller from 11.2 to 11.2.2

### DIFF
--- a/Casks/sonos-s1-controller.rb
+++ b/Casks/sonos-s1-controller.rb
@@ -1,6 +1,6 @@
 cask "sonos-s1-controller" do
-  version "11.2"
-  sha256 "1a98300bd16bb2f727eb1921db80777cc23178a483d56b44a9bb5d95d9ea6602"
+  version "11.2.2"
+  sha256 "ca9d7cdbc8d60970cd4933cbdff3c7600acaa905dc38d131777cef26bdd6eef8"
 
   url "https://update.sonos.com/software/mac/mdcr/SonosDesktopController#{version.no_dots}.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.sonos.com/en/redir/controller_software_mac",

--- a/Casks/sonos-s1-controller.rb
+++ b/Casks/sonos-s1-controller.rb
@@ -4,7 +4,7 @@ cask "sonos-s1-controller" do
 
   url "https://update.sonos.com/software/mac/mdcr/SonosDesktopController#{version.no_dots}.dmg"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://www.sonos.com/en/redir/controller_software_mac",
-          configuration: version.no_dots
+          must_contain: version.no_dots
   name "Sonos S1"
   homepage "https://www.sonos.com/"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).