### PR TITLE
Update vivaldi-snapshot from 2.12.1873.3 to 3.3.2001.3

### DIFF
--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,6 +1,6 @@
 cask "vivaldi-snapshot" do
-  version "2.12.1873.3"
-  sha256 "419609ef091853c553b2843499dd3dbd4137ad2497c26b10606139a5a42997d4"
+  version "3.2.1967.38"
+  sha256 "c2e38bfee9433524524f481a044f6fc5f615b67ba6d7b3da9027be0684b2249f"
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
   appcast "https://update.vivaldi.com/update/1.0/mac/appcast.xml"

--- a/Casks/vivaldi-snapshot.rb
+++ b/Casks/vivaldi-snapshot.rb
@@ -1,13 +1,13 @@
 cask "vivaldi-snapshot" do
-  version "3.2.1967.38"
-  sha256 "c2e38bfee9433524524f481a044f6fc5f615b67ba6d7b3da9027be0684b2249f"
+  version "3.3.2001.3"
+  sha256 "491a1487e5d8513a4743e0ecad14e31541db260c8ed217982a8f9a920a7c558a"
 
   url "https://downloads.vivaldi.com/snapshot/Vivaldi.#{version}.dmg"
-  appcast "https://update.vivaldi.com/update/1.0/mac/appcast.xml"
+  appcast "https://update.vivaldi.com/update/1.0/snapshot/mac/appcast.xml"
   name "Vivaldi"
   homepage "https://vivaldi.com/"
 
   auto_updates true
 
-  app "Vivaldi.app"
+  app "Vivaldi Snapshot.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).