### PR TITLE
handbrake-nightly: update url do

### DIFF
--- a/Casks/handbrake-nightly.rb
+++ b/Casks/handbrake-nightly.rb
@@ -5,7 +5,8 @@ cask "handbrake-nightly" do
   url do
     require "open-uri"
     base_url = "https://handbrake.fr/nightly.php"
-    URI(base_url).open.read.scan(/href="([^"]+.dmg)"/).flatten.first
+    file = URI(base_url).open.read.scan(/href="([^"]+.dmg)"/).flatten.first
+    "#{file}"
   end
   name "HandBrake"
   homepage "https://handbrake.fr/nightly.php"


### PR DESCRIPTION
Output of `brew cask fetch` before:
```
|-> brew cask fetch handbrake-nightly

==> Downloading external files for Cask handbrake-nightly
Error: Download failed on Cask 'handbrake-nightly' with message: wrong number of arguments (given 0, expected 1)
```
Output after:
```
|-> brew cask fetch handbrake-nightly

==> Downloading external files for Cask handbrake-nightly
==> Downloading https://nightly.handbrake.fr/HandBrake-20200806172008-58f415251-master.dmg
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'handbrake-nightly', skipping verification.
==> Success! Downloaded to -> /Users/miccal/Library/Caches/Homebrew/downloads/a5c9d9fd493da183f171f5bafcdcb2e96a96d6b53c725e088e30c604812ba32e--HandBrake-20200806172008-58f415251-master.dmg
```