### PR TITLE
Update processing2 url

### DIFF
--- a/Casks/processing2.rb
+++ b/Casks/processing2.rb
@@ -2,7 +2,7 @@ cask "processing2" do
   version "2.2.1"
   sha256 "8c237b3eb50626e8ffc648bfdeddaa18ceffbd6a48f8fec77a8eab5b774971fc"
 
-  url "http://download.processing.org/processing-#{version}-macosx.zip"
+  url "https://download.processing.org/processing-#{version}-macosx.zip"
   name "Processing"
   homepage "https://processing.org/"
 

--- a/Casks/processing2.rb
+++ b/Casks/processing2.rb
@@ -2,8 +2,7 @@ cask "processing2" do
   version "2.2.1"
   sha256 "8c237b3eb50626e8ffc648bfdeddaa18ceffbd6a48f8fec77a8eab5b774971fc"
 
-  # github.com/processing/processing/ was verified as official when first introduced to the cask
-  url "https://github.com/processing/processing/releases/download/processing-0227-#{version}/processing-#{version}-macosx.zip"
+  url "http://download.processing.org/processing-#{version}-macosx.zip"
   name "Processing"
   homepage "https://processing.org/"
 


### PR DESCRIPTION
Updated the `url` to prevent the `audit` warning:
```
Download uses GitHub releases, please add an appcast.
```
Note that this cask is for an [older version](https://processing.org/download/).