### PR TITLE
Update tunnelblick-beta from 3.8.4beta01,5530 to 3.8.4beta02,5540

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask "tunnelblick-beta" do
-  version "3.8.4beta01,5530"
-  sha256 "717597032ad400e32f694a342f90a1e44f8c75577f459ccc9bd9587dd030df57"
+  version "3.8.4beta02,5540"
+  sha256 "72f9a1b46a1c0b76c00a6bb5ed62ab28222ef4172dc9fb7ffb569f5a82e5d76a"
 
   # github.com/Tunnelblick/Tunnelblick/ was verified as official when first introduced to the cask
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.