### PR TITLE
Update opera-developer from 72.0.3784.0 to 72.0.3791.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask "opera-developer" do
-  version "72.0.3784.0"
-  sha256 "52c885f6016b45db260d7db5b8a1951a33f42d714fea178fb51028376bb71e27"
+  version "72.0.3791.0"
+  sha256 "0cfbe2683f6397e86a532bc95e294ec9becec3c8b42612707108d316185e504e"
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name "Opera Developer"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).