### PR TITLE
Remove false conflicts_with on android studio beta

### DIFF
--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -7,9 +7,7 @@ cask "android-studio-preview-beta" do
   name "Android Studio Preview (Beta)"
   homepage "https://developer.android.com/studio/preview/"
 
-  conflicts_with cask: [
-    "android-studio-preview-canary",
-  ]
+  conflicts_with cask: "android-studio-preview-canary"
 
   app "Android Studio #{version.major_minor} Preview.app"
 

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -8,7 +8,6 @@ cask "android-studio-preview-beta" do
   homepage "https://developer.android.com/studio/preview/"
 
   conflicts_with cask: [
-    "android-studio",
     "android-studio-preview-canary",
   ]
 


### PR DESCRIPTION
There is no reason why someone can not run beta + stable along side each other. See https://github.com/Homebrew/homebrew-cask-versions/pull/9324#issuecomment-680721953

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).