### PR TITLE
android-studio-preview-canary.rb: conflicts_with string

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -7,9 +7,7 @@ cask "android-studio-preview-canary" do
   name "Android Studio Preview (Canary)"
   homepage "https://developer.android.com/studio/preview/"
 
-  conflicts_with cask: [
-    "android-studio-preview-beta",
-  ]
+  conflicts_with cask: "android-studio-preview-beta"
 
   app "Android Studio #{version.major_minor} Preview.app"
 


### PR DESCRIPTION
No need to be an array.