### PR TITLE
Long Term Support (LTS) version of Blender

### DIFF
--- a/Casks/blender-lts.rb
+++ b/Casks/blender-lts.rb
@@ -1,0 +1,28 @@
+cask "blender-lts" do
+  version "2.83.5"
+  sha256 "00a8e6ef52b84256ab64d33df3a079ebe5ac743aead06b74cd99987382be7f52"
+
+  url "https://download.blender.org/release/Blender#{version.major_minor.delete("a-z")}/blender-#{version}-macOS.dmg"
+  appcast "https://download.blender.org/release/",
+          must_contain: version.major_minor.delete("a-z")
+  name "Blender"
+  desc "Free and open-source 3D creation suite"
+  homepage "https://www.blender.org/"
+
+  conflicts_with cask: "blender"
+
+  app "Blender.app"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/blender.wrapper.sh"
+  binary shimscript, target: "blender"
+
+  preflight do
+    # make __pycache__ directories writable, otherwise uninstall fails
+    FileUtils.chmod "u+w", Dir.glob("#{staged_path}/*.app/**/__pycache__")
+
+    IO.write shimscript, <<~EOS
+      #!/bin/bash
+      '#{appdir}/Blender.app/Contents/MacOS/Blender' "$@"
+    EOS
+  end
+end

--- a/Casks/blender-lts.rb
+++ b/Casks/blender-lts.rb
@@ -2,9 +2,8 @@ cask "blender-lts" do
   version "2.83.5"
   sha256 "00a8e6ef52b84256ab64d33df3a079ebe5ac743aead06b74cd99987382be7f52"
 
-  url "https://download.blender.org/release/Blender#{version.major_minor.delete("a-z")}/blender-#{version}-macOS.dmg"
-  appcast "https://download.blender.org/release/",
-          must_contain: version.major_minor.delete("a-z")
+  url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macOS.dmg"
+  appcast "https://www.blender.org/download/lts/"
   name "Blender"
   desc "Free and open-source 3D creation suite"
   homepage "https://www.blender.org/"


### PR DESCRIPTION
This Blender LTS version will receive bugfixes until Q1 2022:
<https://www.blender.org/download/lts/>

The `.rb` file is copied from here:
<https://github.com/Homebrew/homebrew-cask/blob/96ce52a9ef8af1c3d5e4c47a051f1a903fa4eaf5/Casks/blender.rb>

Requested in this ticket:
<https://github.com/Homebrew/homebrew-cask/issues/88481>


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
