### PR TITLE
google-chrome-{beta,canary,dev}: add desc

### DIFF
--- a/Casks/google-chrome-beta.rb
+++ b/Casks/google-chrome-beta.rb
@@ -4,6 +4,7 @@ cask "google-chrome-beta" do
 
   url "https://dl.google.com/chrome/mac/beta/googlechrome.dmg"
   name "Google Chrome"
+  desc "Cross-platform web browser"
   homepage "https://www.google.com/chrome/beta/"
 
   conflicts_with cask: [

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -4,6 +4,7 @@ cask "google-chrome-canary" do
 
   url "https://dl.google.com/release2/q/canary/googlechrome.dmg"
   name "Google Chrome Canary"
+  desc "Cross-platform web browser"
   homepage "https://www.google.com/chrome/canary/"
 
   app "Google Chrome Canary.app"

--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -4,6 +4,7 @@ cask "google-chrome-dev" do
 
   url "https://dl.google.com/chrome/mac/dev/googlechrome.dmg"
   name "Google Chrome"
+  desc "Cross-platform web browser"
   homepage "https://www.google.com/chrome/dev/"
 
   conflicts_with cask: [


### PR DESCRIPTION
Add `desc` stanza to the Google Chrome casks to match the one in the [main repository](https://github.com/homebrew/homebrew-cask/blob/master/Casks/google-chrome.rb).