### PR TITLE
Update safari-technology-preview to 113

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -1,10 +1,10 @@
 cask "safari-technology-preview" do
   if MacOS.version <= :catalina
-    version "112,001-36858-20200817-24aabed5-4c89-4ed0-a1d9-2a50a6b99771"
-    sha256 "bcf47d0671913cc4e2122a6b54618b620e8c5751c71873e94d2516da065b769e"
+    version "113,001-46217-20200908-26bf578a-dcb0-4f70-b930-d9131bbf5d8a"
+    sha256 "09f86d0808e067a46584e9394767040012d7bbae453bb9842cabbf593d9185d9"
   else
-    version "112,001-37237-20200817-e8f512a3-4939-46ec-9404-6e673db90ab0"
-    sha256 "7729e983a498f45b00bf2e0938085e8b97732b05fb98041960c7ced14082562e"
+    version "113,001-43557-20200908-b620aaf9-e006-4855-8bdf-e7e76b5950bc"
+    sha256 "3dcf197b8c2c181861d0c3f3d00fbb65940d1c1aaf11511c76c94fb153d0a7f0"
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

----

Version as reported by safaridriver --version:
Included with Safari Technology Preview (Release 113, 15610.2.3.1)

Source: https://developer.apple.com/safari/download/
Build: https://dev.azure.com/foolip/safari-technology-preview-updater/_build/results?buildId=2080&view=logs