### PR TITLE
Update tap_migrations.json

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,3 @@
 {
-  "java11": "homebrew/core",
+  "java11": "homebrew/core"
 }


### PR DESCRIPTION
Causes the following error when `brew update` reports `java11` as `Deleted Casks`:
```
Error: 767: unexpected token at '{
  "java11": "homebrew/core",
}
'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/json/common.rb:156:in `parse'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/json/common.rb:156:in `parse'
/usr/local/Homebrew/Library/Homebrew/tap.rb:544:in `tap_migrations'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:300:in `block in migrate_tap_migration'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:298:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:298:in `migrate_tap_migration'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:122:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:122:in `update_report'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```