### PR TITLE
Update termius-beta to v6.5.1

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask "termius-beta" do
-  version "6.5.0"
-  sha256 "3d8f516b5f5ed2b339e9aeb797e965460c35254eda0b579c34402681cdc81b85"
+  version "6.5.1"
+  sha256 "400138867ea318c8f5ca4f05682dd0ce5e2bbba5a931932f291bff62d31b36d8"
 
   url "https://www.termius.com/beta/download/mac/Termius+Beta.dmg"
   name "Termius Beta"


### PR DESCRIPTION
Update termius-beta to v6.5.1

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
