### PR TITLE
tla-plus-toolbox-nightly: secure url in livecheck

### DIFF
--- a/Casks/tla-plus-toolbox-nightly.rb
+++ b/Casks/tla-plus-toolbox-nightly.rb
@@ -5,7 +5,7 @@ cask "tla-plus-toolbox-nightly" do
   # tla.msr-inria.inria.fr/ was verified as official when first introduced to the cask
   url do
     require "open-uri"
-    base_url = "http://tla.msr-inria.inria.fr/tlatoolbox/ci/products/"
+    base_url = "https://tla.msr-inria.inria.fr/tlatoolbox/ci/products/"
     file = URI(base_url).open.read.scan(/href="([^"]+-macosx.cocoa.x86_64.zip)"/).flatten.first
     "#{base_url}#{file}"
   end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

```
Inspecting 1 file
.

1 file inspected, no offenses detected
==> Downloading https://tla.msr-inria.inria.fr/tlatoolbox/ci/products/TLAToolbox
==> No SHA-256 checksum defined for Cask 'tla-plus-toolbox-nightly', skipping ve
audit for tla-plus-toolbox-nightly: passed
```