### PR TITLE
Update daedalus-flight from 2.2.0 to 2.3.0-FC1

### DIFF
--- a/Casks/daedalus-flight.rb
+++ b/Casks/daedalus-flight.rb
@@ -1,6 +1,6 @@
 cask "daedalus-flight" do
-  version "2.2.0,14238"
-  sha256 "395e0a57da910903127cc6aaaa793df42edc375e7423ead1df90a870c2f28116"
+  version "2.3.0-FC1,14562"
+  sha256 "8561cde63ce713bac9173e8d243b15ffed65a71507ce3fe83cd71653ec19fbfa"
 
   # update-cardano-mainnet-flight.iohk.io/ was verified as official when first introduced to the cask
   url "https://update-cardano-mainnet-flight.iohk.io/daedalus-#{version.before_comma}-mainnet_flight-#{version.after_comma}.pkg"

--- a/Casks/daedalus-flight.rb
+++ b/Casks/daedalus-flight.rb
@@ -9,6 +9,7 @@ cask "daedalus-flight" do
   desc "Pre-release of Daedalus cryptocurrency wallet for ada on the Cardano blockchain"
   homepage "https://daedaluswallet.io/en/flight/"
 
+  auto_updates true
   depends_on macos: ">= :high_sierra"
 
   pkg "daedalus-#{version.before_comma}-mainnet_flight-#{version.after_comma}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).