### PR TITLE
Update android-studio-preview-canary from 4.2.0.12,202.6847140 to 4.2.0.13,202.6863838

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -5,6 +5,7 @@ cask "android-studio-preview-canary" do
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name "Android Studio Preview (Canary)"
+  desc "Tools for building Android applications"
   homepage "https://developer.android.com/studio/preview/"
 
   conflicts_with cask: "android-studio-preview-beta"

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -1,6 +1,6 @@
 cask "android-studio-preview-canary" do
-  version "4.2.0.12,202.6847140"
-  sha256 "8f8671b15974e0336ac5b4f3f2f45af4ce3e1599c7724f839bee7073b488ed4b"
+  version "4.2.0.13,202.6863838"
+  sha256 "e3dd7f67e1212d410badfc2f566d762eeb01d625b20e2469dc79bb96c923e2c7"
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -6,7 +6,7 @@ cask "android-studio-preview-canary" do
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name "Android Studio Preview (Canary)"
   desc "Tools for building Android applications"
-  homepage "https://developer.android.com/studio/preview/"
+  homepage "https://developer.android.com/studio/preview"
 
   conflicts_with cask: "android-studio-preview-beta"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).