### PR TITLE
vlc-nightly: update url do

### DIFF
--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -4,9 +4,11 @@ cask "vlc-nightly" do
 
   url do
     require "open-uri"
-    base_url = "https://nightlies.videolan.org/build/macosx-intel/last/"
-    file = URI(base_url).open.read.scan(/href="([^"]+.dmg)"/).flatten.first
-    "#{base_url}#{file}"
+    base_url = "https://artifacts.videolan.org/vlc/nightly-macos/"
+    folder = URI(base_url).read[/\d+-\d+/]
+    updated_url = "#{base_url}#{folder}/"
+    file = URI.join(updated_url).read[/href="([^"]+.dmg)"/, 1]
+    "#{updated_url}#{file}"
   end
   name "VLC media player"
   desc "Open-source cross-platform multimedia player"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Closes https://github.com/Homebrew/homebrew-cask-versions/issues/9700

I have set this up to download the nightly builds of VLC version 4:

https://artifacts.videolan.org/vlc/nightly-macos/

Nightly builds of version 3 are located at:

https://artifacts.videolan.org/vlc-3.0/nightly-macos/

which would change the `base_url`.