### PR TITLE
Update broken java-beta to jdk 16, build 20

### DIFF
--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,4 +1,6 @@
-cask "java-beta" do
+# frozen_string_literal: true
+
+cask("java-beta") do
   version "16,20"
   sha256 "5cc94a6165d433c7070464edebaf971d563f90cda7f59196dffadc03eab40961"
 

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,6 +1,6 @@
 cask "java-beta" do
-  version "15,26"
-  sha256 "e6587942e4530f55536a9c5572d0219d55c291da459c61284c411ab108abec04"
+  version "16,20"
+  sha256 "5cc94a6165d433c7070464edebaf971d563f90cda7f59196dffadc03eab40961"
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_osx-x64_bin.tar.gz"
   name "OpenJDK Early Access Java Development Kit"

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,12 +1,10 @@
-# frozen_string_literal: true
-
-cask("java-beta") do
+cask "java-beta" do
   version "16,20"
   sha256 "5cc94a6165d433c7070464edebaf971d563f90cda7f59196dffadc03eab40961"
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_osx-x64_bin.tar.gz"
   name "OpenJDK Early Access Java Development Kit"
-  desc "Early access runtime for the Java programming language"
+  desc "Early access development kit for the Java programming language"
   homepage "https://jdk.java.net/"
 
   artifact "jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk"

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -4,6 +4,7 @@ cask "java-beta" do
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_osx-x64_bin.tar.gz"
   name "OpenJDK Early Access Java Development Kit"
+  desc "Early access runtime for the Java programming language"
   homepage "https://jdk.java.net/"
 
   artifact "jdk-#{version.before_comma}.jdk", target: "/Library/Java/JavaVirtualMachines/openjdk-#{version.before_comma}.jdk"


### PR DESCRIPTION
The previous java-beta version doesn't work anymore because this returns a 404:

https://download.java.net/java/early_access/jdk15/26/GPL/openjdk-15-ea+26_osx-x64_bin.tar.gz

jdk 15 is no longer early access, but jdk 16 is:

- [x] `brew cask audit --download {{cask_file}}` is error-free.  **<- this complained about not having a desc, so I added one by copying the one in the java6 cask**
- [x] `brew cask style --fix {{cask_file}}` reports no offenses. **<- this was complaining about string literals not being frozen, so I fixed that as well. (Java dev here, so if there's a more elegant way of doing this, please let me know!)**
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
