### PR TITLE
Update opera-beta from 72.0.3815.86 to 72.0.3815.133

### DIFF
--- a/Casks/opera-beta.rb
+++ b/Casks/opera-beta.rb
@@ -1,6 +1,6 @@
 cask "opera-beta" do
-  version "72.0.3815.86"
-  sha256 "27061b8db89feac6690b40077aad5a3b91da9b79dd6ebf3668c470626f724333"
+  version "72.0.3815.133"
+  sha256 "cad8515715b69e9aa38acae9c4edfa8a6657ab7da431360e54a19c7bd78204b0"
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name "Opera Beta"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).