### PR TITLE
Update lando-edge from 3.0.15 to 3.0.16

### DIFF
--- a/Casks/lando-edge.rb
+++ b/Casks/lando-edge.rb
@@ -1,6 +1,6 @@
 cask "lando-edge" do
-  version "3.0.15"
-  sha256 "3386e769378d49dc68c99ca05c8380c915c2c5c9ed5b8fae4be18f95a98a7a6d"
+  version "3.0.16"
+  sha256 "e34323772ad96a65f39a5d44cd3618f49754863d14ebbd5b21520eda84b57bc0"
 
   # github.com/lando/lando/ was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.