### PR TITLE
Update Docker Edge from 2.4.1.0,48583 to 2.4.2.0,48975

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,11 +1,12 @@
 cask "docker-edge" do
-  version "2.4.1.0,48583"
-  sha256 "6b4b796a3f051df20a326dbb51efc4fc4272e83cfff4b6b3ff2e855b10c1f60d"
+  version "2.4.2.0,48975"
+  sha256 "422cc92f8d9eb09f28e9dcc0b213836e70dd225c86206e0e4ff3bc1794946970"
 
-  url "https://download.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
-  appcast "https://download.docker.com/mac/edge/appcast.xml"
+  url "https://desktop.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
+  appcast "https://desktop.docker.com/mac/edge/appcast.xml"
   name "Docker Community Edition for Mac (Edge)"
   name "Docker CE for Mac (Edge)"
+  desc "App to build and share containerized applications and microservices"
   homepage "https://www.docker.com/products/docker-desktop"
 
   auto_updates true


### PR DESCRIPTION
The download location for the installer has been moved to a new sub-domain.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
