### PR TITLE
Update visual-studio-code-insiders from 1.51.0,2ed16d0ce8713a5dfed9729071141be0ccf7fbec to 1.51.0,74ef0a92fe8be7034d7d5f513e31262ab77d3bf1

### DIFF
--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask "termius-beta" do
-  version "7.0.0"
-  sha256 "ad32699788b6dc6b214340d121247aae459d4f34bed2302f5eb0b208bc68d9bb"
+  version "6.6.0"
+  sha256 "e22229b2fc183475597f716c3f34b3fd1d4f8ebedd450747b10d462766ec97ae"
 
   url "https://www.termius.com/beta/download/mac/Termius+Beta.dmg"
   name "Termius Beta"

--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,6 +1,6 @@
 cask "termius-beta" do
-  version "6.6.0"
-  sha256 "e22229b2fc183475597f716c3f34b3fd1d4f8ebedd450747b10d462766ec97ae"
+  version "7.0.0"
+  sha256 "ad32699788b6dc6b214340d121247aae459d4f34bed2302f5eb0b208bc68d9bb"
 
   url "https://www.termius.com/beta/download/mac/Termius+Beta.dmg"
   name "Termius Beta"

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,6 +1,6 @@
 cask "visual-studio-code-insiders" do
-  version "1.51.0,2ed16d0ce8713a5dfed9729071141be0ccf7fbec"
-  sha256 "1b2b839d4578d49376e6392c4fd066bf7d8099f7204080f0ca575b9ea5e1a959"
+  version "1.51.0,74ef0a92fe8be7034d7d5f513e31262ab77d3bf1"
+  sha256 "2c69acb71b4a0b66a371cb5536c76b676b5c9569a6bcc6819f5fa34a5b5520c0"
 
   # az764295.vo.msecnd.net/insider/ was verified as official when first introduced to the cask
   url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-insider.zip"

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -7,6 +7,7 @@ cask "visual-studio-code-insiders" do
   appcast "https://vscode-update.azurewebsites.net/api/update/darwin/insider/VERSION"
   name "Microsoft Visual Studio Code"
   name "VS Code - Insiders"
+  desc "Integrated development environment"
   homepage "https://code.visualstudio.com/insiders"
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).