### PR TITLE
Update papers3 from 3.4.23_587 to 3.4.25_600

### DIFF
--- a/Casks/papers3.rb
+++ b/Casks/papers3.rb
@@ -1,10 +1,11 @@
 cask "papers3" do
-  version "3.4.23_587"
-  sha256 "6960a5ad8d886d67cf9ab39730baa04f9fb5fb64a2c28cd0c25073f9b515f565"
+  version "3.4.25_600"
+  sha256 "3a67540bcc9c676301567bf8654ae745fb900cd5736a90715f504458de272282"
 
   # downloads.mekentosj.com was verified as official when first introduced to the cask
   url "https://downloads.mekentosj.com/papers_#{version.no_dots}.dmg"
   name "Papers"
+  desc "Your personal library of research"
   homepage "https://support.papersapp.com/support/solutions/articles/30000031865-existing-papers-3-users-accessing-papers-3-program-files-for-additional-device-installs"
 
   app "Papers.app"

--- a/Casks/papers3.rb
+++ b/Casks/papers3.rb
@@ -5,7 +5,7 @@ cask "papers3" do
   # downloads.mekentosj.com was verified as official when first introduced to the cask
   url "https://downloads.mekentosj.com/papers_#{version.no_dots}.dmg"
   name "Papers"
-  desc "Your personal library of research"
+  desc "Reference manager for researchers"
   homepage "https://support.papersapp.com/support/solutions/articles/30000031865-existing-papers-3-users-accessing-papers-3-program-files-for-additional-device-installs"
 
   app "Papers.app"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [X] `brew cask audit --download papers3` is error-free.
- [X] `brew cask style --fix papers3` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
