### PR TITLE
Update corretto8 from 8.265.01.1 to 8.272.10.3

### DIFF
--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,6 +1,6 @@
 cask "corretto8" do
-  version "8.265.01.1"
-  sha256 "2244f6f5603a08257d57e25dddc17eceb33aa948d34d82be4ea22c34cba1004f"
+  version "8.272.10.1"
+  sha256 "0ad0e916b5636cbda2e7b0f9ef69bab0d32f33e95b92f734341d5d28ae23fa20"
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg"

--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,6 +1,6 @@
 cask "corretto8" do
-  version "8.272.10.1"
-  sha256 "0ad0e916b5636cbda2e7b0f9ef69bab0d32f33e95b92f734341d5d28ae23fa20"
+  version "8.272.10.3"
+  sha256 "307d27c21f155021facd9c4791cf9df55f157e296ea10a6609a390495d606ba7"
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.