### PR TITLE
Update android-studio-preview-canary from 4.2.0.14,202.6907010 to 4.2.0.15,202.6922807

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -6,7 +6,7 @@ cask "android-studio-preview-canary" do
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
   name "Android Studio Preview (Canary)"
   desc "Tools for building Android applications"
-  homepage "https://developer.android.com/studio/preview"
+  homepage "https://developer.android.com/studio/preview/"
 
   conflicts_with cask: "android-studio-preview-beta"
 

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -1,6 +1,6 @@
 cask "android-studio-preview-canary" do
-  version "4.2.0.14,202.6907010"
-  sha256 "d434e58303476844ce9bfaa51c6b449731dd0a19b7c076aec565c048a7b3f5a8"
+  version "4.2.0.15,202.6922807"
+  sha256 "10f304850ef3b62011bb948a82eced223a9f48a461fd547fdc45579d26ec92b9"
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).