### PR TITLE
firefox: add en-CA language

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -8,6 +8,9 @@ cask "firefox-beta" do
   language "de" do
     "de"
   end
+  language "en-CA" do
+    "en-CA"
+  end
   language "en-GB" do
     "en-GB"
   end

--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -86,12 +86,16 @@ cask "firefox-beta" do
     "/Library/Logs/DiagnosticReports/firefox_*",
     "~/Library/Application Support/Firefox",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.firefox.sfl*",
+    "~/Library/Application Support/CrashReporter/firefox_*",
     "~/Library/Caches/Firefox",
     "~/Library/Caches/Mozilla/updates/Applications/Firefox",
+    "~/Library/Caches/org.mozilla.firefox",
     "~/Library/Preferences/org.mozilla.firefox.plist",
+    "~/Library/Saved Application State/org.mozilla.firefox.savedState",
+    "~/Library/WebKit/org.mozilla.firefox",
   ],
       rmdir: [
-        "~/Library/Application Support/Mozilla", # May also contain non-Firefox data
+        "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
         "~/Library/Caches/Mozilla/updates/Applications",
         "~/Library/Caches/Mozilla/updates",
         "~/Library/Caches/Mozilla",

--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -78,6 +78,7 @@ cask "firefox-beta" do
     "firefox",
     "firefox-esr",
   ]
+  depends_on macos: ">= :sierra"
 
   app "Firefox.app"
 

--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -71,6 +71,7 @@ cask "firefox-beta" do
 
   url "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=#{language}"
   name "Mozilla Firefox"
+  desc "Cross-platform web browser"
   homepage "https://www.mozilla.org/firefox/channel/desktop/#beta"
 
   conflicts_with cask: [

--- a/Casks/firefox-developer-edition.rb
+++ b/Casks/firefox-developer-edition.rb
@@ -47,6 +47,7 @@ cask "firefox-developer-edition" do
 
   url "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=#{language}"
   name "Mozilla Firefox Developer Edition"
+  desc "Cross-platform web browser"
   homepage "https://www.mozilla.org/firefox/developer/"
 
   app "Firefox Developer Edition.app"

--- a/Casks/firefox-developer-edition.rb
+++ b/Casks/firefox-developer-edition.rb
@@ -8,6 +8,9 @@ cask "firefox-developer-edition" do
   language "de" do
     "de"
   end
+  language "en-CA" do
+    "en-CA"
+  end
   language "en-GB" do
     "en-GB"
   end

--- a/Casks/firefox-developer-edition.rb
+++ b/Casks/firefox-developer-edition.rb
@@ -50,5 +50,7 @@ cask "firefox-developer-edition" do
   desc "Cross-platform web browser"
   homepage "https://www.mozilla.org/firefox/developer/"
 
+  depends_on macos: ">= :sierra"
+
   app "Firefox Developer Edition.app"
 end

--- a/Casks/firefox-developer-edition.rb
+++ b/Casks/firefox-developer-edition.rb
@@ -53,4 +53,23 @@ cask "firefox-developer-edition" do
   depends_on macos: ">= :sierra"
 
   app "Firefox Developer Edition.app"
+
+  zap trash: [
+    "/Library/Logs/DiagnosticReports/firefox_*",
+    "~/Library/Application Support/Firefox",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.firefox.sfl*",
+    "~/Library/Application Support/CrashReporter/firefox_*",
+    "~/Library/Caches/Firefox",
+    "~/Library/Caches/Mozilla/updates/Applications/Firefox",
+    "~/Library/Caches/org.mozilla.firefox",
+    "~/Library/Preferences/org.mozilla.firefox.plist",
+    "~/Library/Saved Application State/org.mozilla.firefox.savedState",
+    "~/Library/WebKit/org.mozilla.firefox",
+  ],
+      rmdir: [
+        "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
+        "~/Library/Caches/Mozilla/updates/Applications",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla",
+      ]
 end

--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -83,7 +83,21 @@ cask "firefox-esr" do
   app "Firefox.app"
 
   zap trash: [
+    "/Library/Logs/DiagnosticReports/firefox_*",
     "~/Library/Application Support/Firefox",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.firefox.sfl*",
+    "~/Library/Application Support/CrashReporter/firefox_*",
     "~/Library/Caches/Firefox",
-  ]
+    "~/Library/Caches/Mozilla/updates/Applications/Firefox",
+    "~/Library/Caches/org.mozilla.firefox",
+    "~/Library/Preferences/org.mozilla.firefox.plist",
+    "~/Library/Saved Application State/org.mozilla.firefox.savedState",
+    "~/Library/WebKit/org.mozilla.firefox",
+  ],
+      rmdir: [
+        "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
+        "~/Library/Caches/Mozilla/updates/Applications",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla",
+      ]
 end

--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -78,6 +78,7 @@ cask "firefox-esr" do
     "firefox",
     "firefox-beta",
   ]
+  depends_on macos: ">= :sierra"
 
   app "Firefox.app"
 

--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -9,6 +9,10 @@ cask "firefox-esr" do
     sha256 "4bf69cec269ce229447f8f7733b2e5163550ac150a3f9c7d7e1018263385c2de"
     "de"
   end
+  language "en-CA" do
+    sha256 "c59d589d79ee817f219a27bcb1b8cea15f2cc51bd3fa9d721717741100d73fcf"
+    "en-CA"
+  end
   language "en-GB" do
     sha256 "a559e934d9586b8e24eeb3a3a0ca97b65bdd623ce3abb07fd177bcd31ade8930"
     "en-GB"

--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -87,6 +87,7 @@ cask "firefox-nightly" do
     "#{base_url}/#{latest_build_filename}"
   end
   name "Mozilla Firefox"
+  desc "Cross-platform web browser"
   homepage "https://www.mozilla.org/firefox/channel/desktop/#nightly"
 
   app "Firefox Nightly.app"

--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -90,6 +90,8 @@ cask "firefox-nightly" do
   desc "Cross-platform web browser"
   homepage "https://www.mozilla.org/firefox/channel/desktop/#nightly"
 
+  depends_on macos: ">= :sierra"
+
   app "Firefox Nightly.app"
 
   zap trash: [

--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -95,7 +95,21 @@ cask "firefox-nightly" do
   app "Firefox Nightly.app"
 
   zap trash: [
+    "/Library/Logs/DiagnosticReports/firefox_*",
     "~/Library/Application Support/Firefox",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.firefox.sfl*",
+    "~/Library/Application Support/CrashReporter/firefox_*",
     "~/Library/Caches/Firefox",
-  ]
+    "~/Library/Caches/Mozilla/updates/Applications/Firefox",
+    "~/Library/Caches/org.mozilla.firefox",
+    "~/Library/Preferences/org.mozilla.firefox.plist",
+    "~/Library/Saved Application State/org.mozilla.firefox.savedState",
+    "~/Library/WebKit/org.mozilla.firefox",
+  ],
+      rmdir: [
+        "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
+        "~/Library/Caches/Mozilla/updates/Applications",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla",
+      ]
 end

--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -8,6 +8,9 @@ cask "firefox-nightly" do
   language "de" do
     "de"
   end
+  language "en-CA" do
+    "en-CA"
+  end
   language "en-GB" do
     "en-GB"
   end

--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -86,7 +86,7 @@ cask "firefox-nightly" do
     latest_build_filename = URI(builds_url).open.read.scan(%r{<td><a href="/pub/firefox/nightly/([^"]+\.mac\.dmg)">}).flatten.grep(/\.#{language}\.mac\.dmg/).max
     "#{base_url}/#{latest_build_filename}"
   end
-  name "Mozilla Firefox"
+  name "Mozilla Firefox Nightly"
   desc "Cross-platform web browser"
   homepage "https://www.mozilla.org/firefox/channel/desktop/#nightly"
 


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-cask/pull/91804. The additional commits are to satisfy `brew cask audit`, add a distinguishing "Nightly" to `firefox-nightly`'s name (since it can be installed simultaneously with `firefox`), and synchronize the `zap` stanzas with the stable cask.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
