### PR TITLE
Add calibre4.rb (Calibre v4)

### DIFF
--- a/Casks/calibre4.rb
+++ b/Casks/calibre4.rb
@@ -1,0 +1,42 @@
+cask "calibre4" do
+  version "4.23.0"
+  sha256 "422b8f452f2d801f612f28f262421a8b18195c5f9473c0997b828d6f4b91b005"
+
+  url "https://download.calibre-ebook.com/#{version}/calibre-#{version}.dmg"
+  name "calibre"
+  desc "E-books management software"
+  homepage "https://calibre-ebook.com/"
+
+  conflicts_with cask: "calibre"
+  depends_on macos: ">= :mojave"
+
+  app "calibre.app"
+  binary "#{appdir}/calibre.app/Contents/MacOS/calibre"
+  binary "#{appdir}/calibre.app/Contents/MacOS/calibre-complete"
+  binary "#{appdir}/calibre.app/Contents/MacOS/calibre-customize"
+  binary "#{appdir}/calibre.app/Contents/MacOS/calibre-debug"
+  binary "#{appdir}/calibre.app/Contents/MacOS/calibre-parallel"
+  binary "#{appdir}/calibre.app/Contents/MacOS/calibre-server"
+  binary "#{appdir}/calibre.app/Contents/MacOS/calibre-smtp"
+  binary "#{appdir}/calibre.app/Contents/MacOS/calibredb"
+  binary "#{appdir}/calibre.app/Contents/MacOS/ebook-convert"
+  binary "#{appdir}/calibre.app/Contents/MacOS/ebook-device"
+  binary "#{appdir}/calibre.app/Contents/MacOS/ebook-edit"
+  binary "#{appdir}/calibre.app/Contents/MacOS/ebook-meta"
+  binary "#{appdir}/calibre.app/Contents/MacOS/ebook-polish"
+  binary "#{appdir}/calibre.app/Contents/MacOS/ebook-viewer"
+  binary "#{appdir}/calibre.app/Contents/MacOS/fetch-ebook-metadata"
+  binary "#{appdir}/calibre.app/Contents/MacOS/lrf2lrs"
+  binary "#{appdir}/calibre.app/Contents/MacOS/lrfviewer"
+  binary "#{appdir}/calibre.app/Contents/MacOS/lrs2lrf"
+  binary "#{appdir}/calibre.app/Contents/MacOS/markdown-calibre"
+  binary "#{appdir}/calibre.app/Contents/MacOS/web2disk"
+
+  zap trash: [
+    "~/Library/Caches/calibre",
+    "~/Library/Preferences/calibre",
+    "~/Library/Preferences/net.kovidgoyal.calibre.plist",
+    "~/Library/Saved Application State/com.calibre-ebook.ebook-viewer.savedState",
+    "~/Library/Saved Application State/net.kovidgoyal.calibre.savedState",
+  ]
+end


### PR DESCRIPTION
The update to v5 removed Python 2 support from Calibre, which [broke several plugins (notably de-drm)](https://blog.the-ebook-reader.com/2020/09/29/how-to-fix-recent-issues-with-calibre-dedrm-plugin/). Until popular plugins are upgraded to support Python 3, it is useful to have an easy way to revert to (and effectively pin) Calibre at version 4.23.0 to maintain plugin compatibility. 

This is based on the [4.23.0 `calibre.rb`](https://github.com/Homebrew/homebrew-cask/blob/c526625eab8dbae601e5c39839e22ac105adaefd/Casks/calibre.rb) from `homebrew-cask`. I replaced the alternative Calibre v3 install for macOS  `<= :high_sierra` with a requirement for `>= :mojave` and added the `desc` stanza from the current version to pass `brew audit`. The url change is necessary because only the most-recent version's dmg is available on the project's GitHub page. Also added `conflicts_with: cask: "calibre"` and removed the `appcast` stanza.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
