### PR TITLE
add the development snapshot of FreeCAD

### DIFF
--- a/Casks/freecad-pre.rb
+++ b/Casks/freecad-pre.rb
@@ -1,6 +1,6 @@
 cask "freecad-pre" do
   version "0.19_pre,22894"
-  sha256 "bf2195381b58272dac246c7dbbe89fdec7d378f853ed79bc41b3aae4f757fa04"
+  sha256 "a74c87512c845569fd356207be86e71c6691cbe26c7700b792591105c1257586"
 
   # github.com/FreeCAD/FreeCAD/releases/download was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor.delete_suffix("_pre")}-#{version.after_comma}-macOS-x86_64-conda.dmg"

--- a/Casks/freecad-pre.rb
+++ b/Casks/freecad-pre.rb
@@ -1,0 +1,15 @@
+cask "freecad-pre" do
+  version "0.19_pre,22894"
+  sha256 "bf2195381b58272dac246c7dbbe89fdec7d378f853ed79bc41b3aae4f757fa04"
+
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor.delete_suffix("_pre")}-#{version.after_comma}-macOS-x86_64-conda.dmg"
+  appcast "https://github.com/freecad/freecad/releases.atom"
+  name "FreeCAD 0.19_pre"
+  desc "3D parametric modeler"
+  homepage "https://freecadweb.org/"
+
+  depends_on macos: ">= :sierra"
+
+  # Renamed to avoid conflict with other FreeCAD.app
+  app "FreeCAD.app", target: "FreeCAD_pre.app"
+end

--- a/Casks/freecad-pre.rb
+++ b/Casks/freecad-pre.rb
@@ -2,6 +2,7 @@ cask "freecad-pre" do
   version "0.19_pre,22894"
   sha256 "bf2195381b58272dac246c7dbbe89fdec7d378f853ed79bc41b3aae4f757fa04"
 
+  # github.com/FreeCAD/FreeCAD/releases/download was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor.delete_suffix("_pre")}-#{version.after_comma}-macOS-x86_64-conda.dmg"
   appcast "https://github.com/freecad/freecad/releases.atom"
   name "FreeCAD 0.19_pre"

--- a/Casks/freecad-pre.rb
+++ b/Casks/freecad-pre.rb
@@ -2,15 +2,14 @@ cask "freecad-pre" do
   version "0.19_pre,22894"
   sha256 "a74c87512c845569fd356207be86e71c6691cbe26c7700b792591105c1257586"
 
-  # github.com/FreeCAD/FreeCAD/releases/download was verified as official when first introduced to the cask
+  # github.com/FreeCAD/FreeCAD/ was verified as official when first introduced to the cask
   url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.before_comma}/FreeCAD_#{version.major_minor.delete_suffix("_pre")}-#{version.after_comma}-macOS-x86_64-conda.dmg"
   appcast "https://github.com/freecad/freecad/releases.atom"
-  name "FreeCAD 0.19_pre"
+  name "FreeCAD"
   desc "3D parametric modeler"
   homepage "https://freecadweb.org/"
 
   depends_on macos: ">= :sierra"
 
-  # Renamed to avoid conflict with other FreeCAD.app
-  app "FreeCAD.app", target: "FreeCAD_pre.app"
+  app "FreeCAD.app"
 end


### PR DESCRIPTION
the cask contains the conda build of FreeCAD 0.19_pre release

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

	- updated formula with required URL stanza for separate URLs contained within the cask

- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).

- a previous cask was submitted over a year ago, but the 0.18 release of freecad has become quite dated and the 0.19 pre releases are recommended version to use as of November 2020

- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
