### PR TITLE
chrome beta and dev can be installed side-by-side

### DIFF
--- a/Casks/google-chrome-beta.rb
+++ b/Casks/google-chrome-beta.rb
@@ -2,17 +2,12 @@ cask "google-chrome-beta" do
   version :latest
   sha256 :no_check
 
-  url "https://dl.google.com/chrome/mac/beta/googlechrome.dmg"
-  name "Google Chrome"
+  url "https://dl.google.com/chrome/mac/beta/googlechromebeta.dmg"
+  name "Google Chrome Beta"
   desc "Cross-platform web browser"
   homepage "https://www.google.com/chrome/beta/"
 
-  conflicts_with cask: [
-    "google-chrome",
-    "google-chrome-dev",
-  ]
-
-  app "Google Chrome.app"
+  app "Google Chrome Beta.app"
 
   uninstall launchctl: [
     "com.google.keystone.agent",
@@ -23,10 +18,10 @@ cask "google-chrome-beta" do
     "/Library/Caches/com.google.SoftwareUpdate.*",
     "/Library/Google/Google Chrome Brand.plist",
     "/Library/Google/GoogleSoftwareUpdate",
-    "~/Library/Application Support/Google/Chrome",
+    "~/Library/Application Support/Google/Chrome Beta",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.chrome.app.*.sfl*",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.chrome.sfl*",
-    "~/Library/Caches/Google/Chrome",
+    "~/Library/Caches/Google/Chrome Beta",
     "~/Library/Caches/com.google.Chrome",
     "~/Library/Caches/com.google.Chrome.helper.*",
     "~/Library/Caches/com.google.Keystone",

--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -2,17 +2,12 @@ cask "google-chrome-dev" do
   version :latest
   sha256 :no_check
 
-  url "https://dl.google.com/chrome/mac/dev/googlechrome.dmg"
-  name "Google Chrome"
+  url "https://dl.google.com/chrome/mac/dev/googlechromedev.dmg"
+  name "Google Chrome Dev"
   desc "Cross-platform web browser"
   homepage "https://www.google.com/chrome/dev/"
 
-  conflicts_with cask: [
-    "google-chrome",
-    "google-chrome-beta",
-  ]
-
-  app "Google Chrome.app"
+  app "Google Chrome Dev.app"
 
   uninstall launchctl: [
     "com.google.keystone.agent",
@@ -23,10 +18,10 @@ cask "google-chrome-dev" do
     "/Library/Caches/com.google.SoftwareUpdate.*",
     "/Library/Google/Google Chrome Brand.plist",
     "/Library/Google/GoogleSoftwareUpdate",
-    "~/Library/Application Support/Google/Chrome",
+    "~/Library/Application Support/Google/Chrome Dev",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.chrome.app.*.sfl*",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.chrome.sfl*",
-    "~/Library/Caches/Google/Chrome",
+    "~/Library/Caches/Google/Chrome Dev",
     "~/Library/Caches/com.google.Chrome",
     "~/Library/Caches/com.google.Chrome.helper.*",
     "~/Library/Caches/com.google.Keystone",


### PR DESCRIPTION
Chrome Beta and Chrome Dev can now be installed side-by-side on macOS **since October 13, 2020**.

Sources:
- [Update on Chromium Blog](https://blog.chromium.org/2017/08/run-multiple-versions-of-chrome-side-by.html)
- [Chromium Dev Channel](https://www.chromium.org/getting-involved/dev-channel)

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
