### PR TITLE
Update daedalus-flight from 2.4.1 to 3.0.0-FC1

### DIFF
--- a/Casks/daedalus-flight.rb
+++ b/Casks/daedalus-flight.rb
@@ -1,6 +1,6 @@
 cask "daedalus-flight" do
-  version "2.4.1,15062"
-  sha256 "c97520d22ebbc0df4b857101c96dc9a016613756991827d1f4d57599313d87e0"
+  version "3.0.0-FC1,15093"
+  sha256 "61328f6ee5a0653e5e5d7880ba1a706aec603b2f3587f85f83ba2d56e5ce27d6"
 
   # update-cardano-mainnet-flight.iohk.io/ was verified as official when first introduced to the cask
   url "https://update-cardano-mainnet-flight.iohk.io/daedalus-#{version.before_comma}-mainnet_flight-#{version.after_comma}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
