### PR TITLE
google-chrome-(beta/dev/canary): delete launchctl services only with zap

### DIFF
--- a/Casks/google-chrome-beta.rb
+++ b/Casks/google-chrome-beta.rb
@@ -9,12 +9,7 @@ cask "google-chrome-beta" do
 
   app "Google Chrome Beta.app"
 
-  uninstall launchctl: [
-    "com.google.keystone.agent",
-    "com.google.keystone.daemon",
-  ]
-
-  zap trash: [
+  zap trash:     [
     "/Library/Caches/com.google.SoftwareUpdate.*",
     "/Library/Google/Google Chrome Brand.plist",
     "/Library/Google/GoogleSoftwareUpdate",
@@ -37,10 +32,14 @@ cask "google-chrome-beta" do
     "~/Library/Saved Application State/com.google.Chrome.savedState",
     "~/Library/WebKit/com.google.Chrome",
   ],
-      rmdir: [
+      rmdir:     [
         "/Library/Google",
         "~/Library/Application Support/Google",
         "~/Library/Caches/Google",
         "~/Library/Google",
+      ],
+      launchctl: [
+        "com.google.keystone.agent",
+        "com.google.keystone.daemon",
       ]
 end

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -9,12 +9,7 @@ cask "google-chrome-canary" do
 
   app "Google Chrome Canary.app"
 
-  uninstall launchctl: [
-    "com.google.keystone.agent",
-    "com.google.keystone.daemon",
-  ]
-
-  zap trash: [
+  zap trash:     [
     "/Library/Caches/com.google.SoftwareUpdate.*",
     "/Library/Google/Google Chrome Brand.plist",
     "/Library/Google/GoogleSoftwareUpdate",
@@ -37,10 +32,14 @@ cask "google-chrome-canary" do
     "~/Library/Saved Application State/com.google.Chrome.savedState",
     "~/Library/WebKit/com.google.Chrome",
   ],
-      rmdir: [
+      rmdir:     [
         "/Library/Google",
         "~/Library/Application Support/Google",
         "~/Library/Caches/Google",
         "~/Library/Google",
+      ],
+      launchctl: [
+        "com.google.keystone.agent",
+        "com.google.keystone.daemon",
       ]
 end

--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -9,12 +9,7 @@ cask "google-chrome-dev" do
 
   app "Google Chrome Dev.app"
 
-  uninstall launchctl: [
-    "com.google.keystone.agent",
-    "com.google.keystone.daemon",
-  ]
-
-  zap trash: [
+  zap trash:     [
     "/Library/Caches/com.google.SoftwareUpdate.*",
     "/Library/Google/Google Chrome Brand.plist",
     "/Library/Google/GoogleSoftwareUpdate",
@@ -37,10 +32,14 @@ cask "google-chrome-dev" do
     "~/Library/Saved Application State/com.google.Chrome.savedState",
     "~/Library/WebKit/com.google.Chrome",
   ],
-      rmdir: [
+      rmdir:     [
         "/Library/Google",
         "~/Library/Application Support/Google",
         "~/Library/Caches/Google",
         "~/Library/Google",
+      ],
+      launchctl: [
+        "com.google.keystone.agent",
+        "com.google.keystone.daemon",
       ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
