### PR TITLE
Update docker-edge from 2.4.2.0,48975 to 2.5.1.0,49923

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -1,6 +1,6 @@
 cask "docker-edge" do
-  version "2.4.2.0,48975"
-  sha256 "422cc92f8d9eb09f28e9dcc0b213836e70dd225c86206e0e4ff3bc1794946970"
+  version "2.5.1.0,49923"
+  sha256 "9de5a52904c3b774488f400c709b7b8b1f72e89445cc056da9871b1dd38c88ae"
 
   url "https://desktop.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
   appcast "https://desktop.docker.com/mac/edge/appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).