### PR TITLE
Update java-beta to 16,25

### DIFF
--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,6 +1,6 @@
 cask "java-beta" do
-  version "16,20"
-  sha256 "5cc94a6165d433c7070464edebaf971d563f90cda7f59196dffadc03eab40961"
+  version "16,25"
+  sha256 "e08a359771834d0f298f9b08672328758985743d0feefdf4b705a2d6218fecff"
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_osx-x64_bin.tar.gz"
   name "OpenJDK Early Access Java Development Kit"


### PR DESCRIPTION
Update java-beta to 16,25, which fixes the following 404 for 16,20

```log
==> Downloading https://download.java.net/java/early_access/jdk16/20/GPL/openjdk

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'java-beta' with message: Download failed: https://download.java.net/java/early_access/jdk16/20/GPL/openjdk-16-ea+20_osx-x64_bin.tar.gz
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
