### PR TITLE
Update vmware-fusion11 from 11.5.6-16696540 to 11.5.7-17130923

### DIFF
--- a/Casks/vmware-fusion11.rb
+++ b/Casks/vmware-fusion11.rb
@@ -1,6 +1,6 @@
 cask "vmware-fusion11" do
-  version "11.5.6-16696540"
-  sha256 "f26f8404204af4fcd8932789d849a56e96d0dbeab1a76e35e6a2b42f2f31ffc2"
+  version "11.5.7-17130923"
+  sha256 "c7d58ca44510de6c1ddffe86129ed19982114e742d71e7d81e4a5882036e06e3"
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
   appcast "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).