### PR TITLE
firefox-esr.rb: remove cross-platform from desc

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -71,7 +71,7 @@ cask "firefox-esr" do
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.mozilla.org/%3Fproduct=firefox-esr-latest-ssl%26os=osx"
   name "Mozilla Firefox ESR"
   name "Mozilla Firefox Extended Support Release"
-  desc "Cross-platform web browser"
+  desc "Web browser"
   homepage "https://www.mozilla.org/firefox/organizations/"
 
   conflicts_with cask: [


### PR DESCRIPTION
It’s irrelevant what platforms it runs on; we only support one.