### PR TITLE
firefox-nightly.rb: remove cross-platform from desc

### DIFF
--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -87,7 +87,7 @@ cask "firefox-nightly" do
     "#{base_url}/#{latest_build_filename}"
   end
   name "Mozilla Firefox Nightly"
-  desc "Cross-platform web browser"
+  desc "Web browser"
   homepage "https://www.mozilla.org/firefox/channel/desktop/#nightly"
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
It’s irrelevant what platforms it runs on; we only support one.