### PR TITLE
firefox-developer-edition.rb: remove cross-platform from desc

### DIFF
--- a/Casks/firefox-developer-edition.rb
+++ b/Casks/firefox-developer-edition.rb
@@ -47,7 +47,7 @@ cask "firefox-developer-edition" do
 
   url "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=#{language}"
   name "Mozilla Firefox Developer Edition"
-  desc "Cross-platform web browser"
+  desc "Web browser"
   homepage "https://www.mozilla.org/firefox/developer/"
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
It’s irrelevant what platforms it runs on; we only support one.