### PR TITLE
google-chrome-canary.rb: remove cross-platform from desc

### DIFF
--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -4,7 +4,7 @@ cask "google-chrome-canary" do
 
   url "https://dl.google.com/release2/q/canary/googlechrome.dmg"
   name "Google Chrome Canary"
-  desc "Cross-platform web browser"
+  desc "Web browser"
   homepage "https://www.google.com/chrome/canary/"
 
   app "Google Chrome Canary.app"


### PR DESCRIPTION
It’s irrelevant what platforms it runs on; we only support one.