### PR TITLE
google-chrome-dev.rb: remove cross-platform from desc

### DIFF
--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -4,7 +4,7 @@ cask "google-chrome-dev" do
 
   url "https://dl.google.com/chrome/mac/dev/googlechromedev.dmg"
   name "Google Chrome Dev"
-  desc "Cross-platform web browser"
+  desc "Web browser"
   homepage "https://www.google.com/chrome/dev/"
 
   app "Google Chrome Dev.app"


### PR DESCRIPTION
It’s irrelevant what platforms it runs on; we only support one.