### PR TITLE
firefox-beta: remove cross-platform from desc

### DIFF
--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -71,7 +71,7 @@ cask "firefox-beta" do
 
   url "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=#{language}"
   name "Mozilla Firefox"
-  desc "Cross-platform web browser"
+  desc "Web browser"
   homepage "https://www.mozilla.org/firefox/channel/desktop/#beta"
 
   conflicts_with cask: [


### PR DESCRIPTION
It’s irrelevant what platforms it runs on; we only support one.