### PR TITLE
Update lando-edge from 3.0.19 to 3.0.20

### DIFF
--- a/Casks/lando-edge.rb
+++ b/Casks/lando-edge.rb
@@ -1,6 +1,6 @@
 cask "lando-edge" do
-  version "3.0.19"
-  sha256 "613182c6e58c77a30ad94b976c58cb566c48ed8d56ee9bdfc5118c2e768f2157"
+  version "3.0.20"
+  sha256 "708da1db00c42af9f1c4dcc89129198b3d02483ec0bf99aa2f5279e4738af3a7"
 
   # github.com/lando/lando/ was verified as official when first introduced to the cask
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-v#{version}.dmg"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.