### PR TITLE
Update daedalus-flight from 3.0.0-FC1 to 3.0.0-FC2

### DIFF
--- a/Casks/daedalus-flight.rb
+++ b/Casks/daedalus-flight.rb
@@ -1,6 +1,6 @@
 cask "daedalus-flight" do
-  version "3.0.0-FC1,15093"
-  sha256 "61328f6ee5a0653e5e5d7880ba1a706aec603b2f3587f85f83ba2d56e5ce27d6"
+  version "3.0.0-FC2,15337"
+  sha256 "7febd8e4e4d77140e1948945fba7d899f5ae3d8a2e83dc9c578b744893be3833"
 
   # update-cardano-mainnet-flight.iohk.io/ was verified as official when first introduced to the cask
   url "https://update-cardano-mainnet-flight.iohk.io/daedalus-#{version.before_comma}-mainnet_flight-#{version.after_comma}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-versions/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
