### PR TITLE
Update hex-fiend-beta from 2.14.0b1 to 2.14.1b

### DIFF
--- a/Casks/hex-fiend-beta.rb
+++ b/Casks/hex-fiend-beta.rb
@@ -1,9 +1,9 @@
 cask "hex-fiend-beta" do
-  version "2.14.0b1"
-  sha256 "61b264e27089d7b3ac895ad5dc2cf269f66beff38e789aa033f0faf0c0985b0a"
+  version "2.14.1b"
+  sha256 "1bd685a09811bcebf785864e657c36770ba19a8505d4c3bc2eba12314981f510"
 
   # github.com/ridiculousfish/HexFiend/ was verified as official when first introduced to the cask
-  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor}.dmg"
+  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.delete("b")}.dmg"
   appcast "https://github.com/ridiculousfish/HexFiend/releases.atom"
   name "Hex Fiend"
   homepage "https://ridiculousfish.com/hexfiend/"

--- a/Casks/hex-fiend-beta.rb
+++ b/Casks/hex-fiend-beta.rb
@@ -6,6 +6,7 @@ cask "hex-fiend-beta" do
   url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.delete("b")}.dmg"
   appcast "https://github.com/ridiculousfish/HexFiend/releases.atom"
   name "Hex Fiend"
+  desc "Hex editor focussing on speed"
   homepage "https://ridiculousfish.com/hexfiend/"
 
   conflicts_with cask: "hex-fiend"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).