### PR TITLE
Update android-studio-preview-canary from 4.2.0.16,202.6939830 to 2020.3.1.1,202.6983675

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -10,7 +10,7 @@ cask "android-studio-preview-canary" do
 
   conflicts_with cask: "android-studio-preview-beta"
 
-  app "Android Studio #{version.major_minor} Preview.app"
+  app "Android Studio Preview.app"
 
   zap trash: [
     "~/Library/Android/sdk",

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -1,6 +1,6 @@
 cask "android-studio-preview-canary" do
-  version "4.2.0.16,202.6939830"
-  sha256 "e315f6b98979a5882a64ca8cc979acfd2accbe57b2e6b0ea8ade5cc77587877c"
+  version "2020.3.1.1,202.6983675"
+  sha256 "47b7565136c7378c77da1964a3711ab6d09f5ace3f04bd87a62b13992db5dd9a"
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).