### PR TITLE
add bitbar beta version

### DIFF
--- a/Casks/bitbar.rb
+++ b/Casks/bitbar.rb
@@ -1,6 +1,6 @@
 cask "bitbar" do
   version "2.0.0-beta10"
-  sha256 "29e535649b03fbb5bb43fac37bfa62a3074259ab31339e66e534ad938816ae01"
+  sha256 "69731c6686e0f2ccc2a3f19dd4e98cca7244e5a859d5326c627875a20220cea5"
 
   url "https://github.com/matryer/bitbar/releases/download/v#{version}/BitBar-v#{version}.zip"
   appcast "https://github.com/matryer/bitbar/releases.atom"

--- a/Casks/bitbar.rb
+++ b/Casks/bitbar.rb
@@ -1,0 +1,18 @@
+cask "bitbar" do
+  version "2.0.0-beta10"
+  sha256 "29e535649b03fbb5bb43fac37bfa62a3074259ab31339e66e534ad938816ae01"
+
+  url "https://github.com/matryer/bitbar/releases/download/v#{version}/BitBar-v#{version}.zip"
+  appcast "https://github.com/matryer/bitbar/releases.atom"
+  name "BitBar"
+  desc "Utility to display the output from any script or program in the menu bar"
+  homepage "https://github.com/matryer/bitbar/"
+
+  app "BitBar.app"
+
+  zap trash: [
+    "~/Library/BitBar Plugins",
+    "~/Library/Caches/com.matryer.BitBar",
+    "~/Library/Preferences/com.matryer.BitBar.plist",
+  ]
+end


### PR DESCRIPTION
Cask was deleted at 2015 but since then there's a beta version for it

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
