### PR TITLE
Update android-studio-preview-canary from 2020.3.1.1,202.6983675 to 2020.3.1.2,202.7006259

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -2,8 +2,8 @@ cask "android-studio-preview-canary" do
   version "2020.3.1.2,202.7006259"
   sha256 "e767bba3b9ed88e922d6a1dcce64900237c65045e43d30de6ce29c5f90f1b5f7"
 
-  # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
-  url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"
+  url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip",
+      verified: "dl.google.com/dl/android/studio/"
   name "Android Studio Preview (Canary)"
   desc "Tools for building Android applications"
   homepage "https://developer.android.com/studio/preview/"

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -1,6 +1,6 @@
 cask "android-studio-preview-canary" do
-  version "2020.3.1.1,202.6983675"
-  sha256 "47b7565136c7378c77da1964a3711ab6d09f5ace3f04bd87a62b13992db5dd9a"
+  version "2020.3.1.2,202.7006259"
+  sha256 "e767bba3b9ed88e922d6a1dcce64900237c65045e43d30de6ce29c5f90f1b5f7"
 
   # dl.google.com/dl/android/studio/ was verified as official when first introduced to the cask
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version.before_comma}/android-studio-ide-#{version.after_comma}-mac.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).