### PR TITLE
Add propresenter6 6.5.3_100991749

### DIFF
--- a/Casks/propresenter6.rb
+++ b/Casks/propresenter6.rb
@@ -3,8 +3,8 @@ cask "propresenter6" do
   sha256 "8a822ae5dbf1f4a17008cee66dcf98487b424a3ef01a381de9310eb9bd6ce530"
 
   url "https://renewedvision.com/downloads/ProPresenter%20#{version.major}_#{version}.dmg"
-  appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php"
   name "ProPresenter 6"
+  desc "Presentation and production application for live events"
   homepage "https://www.renewedvision.com/propresenter.php"
 
   depends_on macos: ">= :high_sierra"
@@ -12,13 +12,13 @@ cask "propresenter6" do
   app "ProPresenter #{version.major}.app"
 
   zap trash: [
-    "~/Library/Application Support/RenewedVision/ProPresenter6",
-    "~/Library/Caches/KSCrashReports/ProPresenter 6",
-    "~/Library/Caches/Sessions/ProPresenter 6",
-    "~/Library/Caches/com.renewedvision.ProPresenter6",
-    "~/Library/Preferences/com.renewedvision.ProPresenter6.plist",
+    "~/Library/Application Support/RenewedVision/ProPresenter#{version.major}",
+    "~/Library/Caches/KSCrashReports/ProPresenter #{version.major}",
+    "~/Library/Caches/Sessions/ProPresenter #{version.major}",
+    "~/Library/Caches/com.renewedvision.ProPresenter#{version.major}",
+    "~/Library/Preferences/com.renewedvision.ProPresenter#{version.major}.plist",
     "/Library/Application Support/RenewedVision",
-    "/Library/Caches/com.renewedvision.ProPresenter6",
+    "/Library/Caches/com.renewedvision.ProPresenter#{version.major}",
     "/Users/Shared/Renewed Vision Media",
   ],
       rmdir: [

--- a/Casks/propresenter6.rb
+++ b/Casks/propresenter6.rb
@@ -1,0 +1,29 @@
+cask "propresenter6" do
+  version "6.5.3_100991749"
+  sha256 "8a822ae5dbf1f4a17008cee66dcf98487b424a3ef01a381de9310eb9bd6ce530"
+
+  url "https://renewedvision.com/downloads/ProPresenter%20#{version.major}_#{version}.dmg"
+  appcast "https://www.renewedvision.com/update/ProPresenter#{version.major}.php"
+  name "ProPresenter 6"
+  homepage "https://www.renewedvision.com/propresenter.php"
+
+  depends_on macos: ">= :high_sierra"
+
+  app "ProPresenter #{version.major}.app"
+
+  zap trash: [
+    "~/Library/Application Support/RenewedVision/ProPresenter6",
+    "~/Library/Caches/KSCrashReports/ProPresenter 6",
+    "~/Library/Caches/Sessions/ProPresenter 6",
+    "~/Library/Caches/com.renewedvision.ProPresenter6",
+    "~/Library/Preferences/com.renewedvision.ProPresenter6.plist",
+    "/Library/Application Support/RenewedVision",
+    "/Library/Caches/com.renewedvision.ProPresenter6",
+    "/Users/Shared/Renewed Vision Media",
+  ],
+      rmdir: [
+        "~/Library/Application Support/RenewedVision",
+        "~/Library/Caches/KSCrashReports",
+        "~/Library/Caches/Sessions",
+      ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.
  - Both of these are unmarked because my Ruby installation is currently freaking out, sorry. The cask is just copied straight from [https://github.com/Homebrew/homebrew-cask/pull/76105](https://github.com/Homebrew/homebrew-cask/pull/76105) with modification to only the name, though.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.

Justification for this cask version is because upgrading to ProPresenter 7 (which is still relatively new) requires a paid license, so many users are still using Pro6.