### PR TITLE
wine-devel: remove conflicts_with formula

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -7,8 +7,7 @@ cask "wine-devel" do
   name "WineHQ-devel"
   homepage "https://wiki.winehq.org/MacOS"
 
-  conflicts_with formula: "wine",
-                 cask:    [
+  conflicts_with cask:    [
                    "wine-stable",
                    "wine-staging",
                  ]

--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -7,7 +7,7 @@ cask "wine-devel" do
   name "WineHQ-devel"
   homepage "https://wiki.winehq.org/MacOS"
 
-  conflicts_with cask:    [
+  conflicts_with cask: [
                    "wine-stable",
                    "wine-staging",
                  ]

--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -5,13 +5,14 @@ cask "wine-devel" do
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-devel-#{version}.pkg"
   appcast "https://dl.winehq.org/wine-builds/macosx/download.html"
   name "WineHQ-devel"
+  desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
 
   conflicts_with cask: [
                    "wine-stable",
                    "wine-staging",
                  ]
-  depends_on x11: true
+  depends_on cask: xquartz
 
   pkg "winehq-devel-#{version}.pkg",
       choices: [

--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -12,7 +12,7 @@ cask "wine-devel" do
     "wine-stable",
     "wine-staging",
   ]
-  depends_on cask: xquartz
+  depends_on cask: "xquartz"
 
   pkg "winehq-devel-#{version}.pkg",
       choices: [

--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -9,9 +9,9 @@ cask "wine-devel" do
   homepage "https://wiki.winehq.org/MacOS"
 
   conflicts_with cask: [
-                   "wine-stable",
-                   "wine-staging",
-                 ]
+    "wine-stable",
+    "wine-staging",
+  ]
   depends_on cask: xquartz
 
   pkg "winehq-devel-#{version}.pkg",


### PR DESCRIPTION
There is no longer a `wine` formula.