### PR TITLE
Update julia-nightly from 1.6 to 1.7

### DIFF
--- a/Casks/julia-nightly.rb
+++ b/Casks/julia-nightly.rb
@@ -1,5 +1,5 @@
 cask "julia-nightly" do
-  version "1.6"
+  version "1.7"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://julialangnightlies-s3.julialang.org/bin/mac/x64/julia-latest-mac64.dmg"


### PR DESCRIPTION
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version). -- nightly version
- [ ] `brew audit --cask {{cask_file}}` is error-free. -- "Error: Your CLT does not support macOS 11."
- [ ] `brew style --fix {{cask_file}}` reports no offenses. -- "An error occurred while installing hpricot (0.8.6), and Bundler cannot continue."
