### PR TITLE
java6.rb: use colon

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -1,8 +1,8 @@
 cask "java6" do
-  version "1.6.0_65-b14-468,2019,041-88384-20191011-3d8da658-dca4-4a5b-b67c-26e686876403"
+  version "1.6.0_65-b14-468,2019:041-88384-20191011-3d8da658-dca4-4a5b-b67c-26e686876403"
   sha256 "3a91bd24a0524df4cde9433f2ac56182818f78aacda36c7529b3d548e0c12e63"
 
-  url "https://updates.cdn-apple.com/#{version.after_comma.before_comma}/cert/#{version.after_comma.after_comma}/JavaForOSX.dmg",
+  url "https://updates.cdn-apple.com/#{version.after_comma.before_colon}/cert/#{version.after_colon}/JavaForOSX.dmg",
       verified: "updates.cdn-apple.com/"
   name "Apple Java 6 Standard Edition Development Kit"
   desc "Legacy runtime for the Java programming language"


### PR DESCRIPTION
@reitermarkus Changing this to use `colon`, until we decide on [a proper solution](https://github.com/Homebrew/homebrew-cask/issues/95207). `after_comma.after_comma` reads bizarre, and:

* If we do use something better (like `parts[0]`), it will be easier to find casks to correct if they already use `colon`.
* If we decide to keep the current methodology, this is how it would look anyway.