### PR TITLE
sublime-text-dev: use description as from stable cask

### DIFF
--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -6,6 +6,7 @@ cask "sublime-text-dev" do
   appcast "https://www.sublimetext.com/updates/#{version.major}/dev/appcast_osx.xml",
           must_contain: version.no_dots
   name "Sublime Text"
+  desc "Text editor for code, markup and prose"
   homepage "https://www.sublimetext.com/#{version.major}dev"
 
   auto_updates true


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
