### PR TITLE
handbrake-nightly: fix url block

### DIFF
--- a/Casks/handbrake-nightly.rb
+++ b/Casks/handbrake-nightly.rb
@@ -5,7 +5,12 @@ cask "handbrake-nightly" do
   url do
     require "open-uri"
     base_url = "https://handbrake.fr/nightly.php"
-    URI(base_url).read[/href="([^"]+.dmg)"/, 1]
+    file_path = URI.parse(base_url).open do |f|
+      content = f.read
+      /href=["']?(?<file_path>[^"' >]*Handbrake[._-][^"' >]+\.dmg)["' >]/i =~ content
+      file_path
+    end
+    file_path ? URI.join(base_url, file_path) : nil
   end
   name "HandBrake"
   desc "Open-source video transcoder"

--- a/Casks/handbrake-nightly.rb
+++ b/Casks/handbrake-nightly.rb
@@ -5,8 +5,8 @@ cask "handbrake-nightly" do
   url do
     require "open-uri"
     base_url = "https://handbrake.fr/nightly.php"
-    content = URI(base_url).open(&:read)
-    /href=["']?(?<file_path>[^"' >]*Handbrake[._-][^"' >]+\.dmg)["' >]/i =~ content
+    content = URI(base_url).read
+    file_path = content[/href=["']?([^"' >]*Handbrake[._-][^"' >]+\.dmg)["' >]/i, 1]
     file_path ? URI.join(base_url, file_path) : nil
   end
   name "HandBrake"

--- a/Casks/handbrake-nightly.rb
+++ b/Casks/handbrake-nightly.rb
@@ -5,11 +5,8 @@ cask "handbrake-nightly" do
   url do
     require "open-uri"
     base_url = "https://handbrake.fr/nightly.php"
-    file_path = URI.parse(base_url).open do |f|
-      content = f.read
-      /href=["']?(?<file_path>[^"' >]*Handbrake[._-][^"' >]+\.dmg)["' >]/i =~ content
-      file_path
-    end
+    content = URI(base_url).open(&:read)
+    /href=["']?(?<file_path>[^"' >]*Handbrake[._-][^"' >]+\.dmg)["' >]/i =~ content
     file_path ? URI.join(base_url, file_path) : nil
   end
   name "HandBrake"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

---

`handbrake-nightly` is failing on Homebrew/brew CI in the `brew audit --skip-style` step, with the following error:

```
audit for handbrake-nightly: failed
 - exception while auditing handbrake-nightly: undefined method `split' for nil:NilClass
```

This error is due to the `url` block in `handbrake-nightly` not properly generating a URL as expected. This is occurring because the regex isn't matching and `read[/.../, 1]` gives this error as a result (as it naively assumes there will always be a match).

---

This PR updates the URL-generating code in the following ways:

* Modifies the `#open` call to better align with the example in `CONTRIBUTING.md` and the [homebrew-cask `url` stanza documentation](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md). Namely, I'm using `URI(base_url).open do |f|` and doing the `read` in the block instead of `URI(base_url).read[/.../, 1]`.
* Splits the page content fetching logic from the matching logic. The existing `read[/.../, 1]` approach assumed that the regex would absolutely find a match. The existing regex wasn't finding a match and that's what was giving us the ```undefined method `split'```error here.
* Improves the regex used to identify the URL for the nightly disk image. I've made it a bit more robust (in terms of only matching within the `href` attribute) while also specifically only matching the `HandBrake-...` disk image file (not the `HandBrakeCLI-...` disk image below it). [For what it's worth, this regex borrows a bit from the regex patterns we use in `livecheck` blocks to identify versions from file names in `href` attributes on HTML pages. We have a lot of experience in this particular regard, so if your eyes glaze over looking at this regex you can simply trust that it works (though I'm happy to explain the reasoning behind my choices here).]
* Uses a `file_path` named capture group for the file path part of the regex and uses `/.../ =~ content` to extract it into a local `file_path` variable. When we don't get a match, `file_path` is `nil`.
* Uses `URI#join` to combine the `base_url` with the `file_path`. This correctly joins these two parts, regardless of whether `file_path` is absolute or relative. Following the suggestion in `CONTRIBUTING.md` (e.g., "#{base_url}/#{file_path}") could produce a bad URL under a variety of conditions.
* Handles the situation where matching fails and `file_path` is `nil` in such a way that we'll receive a slightly more understandable error. Namely, returning `nil` when `file_path` is `nil` gives us a `bad argument (expected URI object or URI string)` error (instead of the `undefined method `split' for nil:NilClass` error we were getting). [The ternary condition is necessary as passing `file_path` to `URI#join` when it's `nil` will give us an error.]

---

If this approach is amenable (after we've addressed any feedback), the examples in [`CONTRIBUTING.md`](https://github.com/Homebrew/homebrew-cask-versions/blob/master/CONTRIBUTING.md) and the [homebrew-cask `url` stanza documentation](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md) should probably be improved a bit.

Additionally, the following casks use `open-uri` in a `url` block and we should review those and update them accordingly:

* `keepassxc-snapshot`
* `emacs-nightly`
* `slicer-preview`
* `thunderbird-daily`
* `firefox-nightly`
* `hamsket-nightly`
* `vlc-nightly`
* `tla-plus-toolbox-nightly`
* `sequel-pro-nightly`
* `gpg-suite-nightly`
* `brave-browser-nightly`
* `transmission-nightly`

I'm busy with some other important work at the moment, so I can't take care of this at the moment. However, I'll put it on my to-do list and if no one gets to it before me I'll create PRs to update these areas.

Past that, let me know if any of this could be improved further or needs to change.