### PR TITLE
Update corretto version to 8.275.01.1

### DIFF
--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,6 +1,6 @@
 cask "corretto8" do
-  version "8.272.10.3"
-  sha256 "307d27c21f155021facd9c4791cf9df55f157e296ea10a6609a390495d606ba7"
+  version "8.275.01.1"
+  sha256 "d136db770d98725910535b95ca934157e2af6f9f2be0a13ec7834a6aa25028af"
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-macos-jdk.pkg"


### PR DESCRIPTION
Update amazon-corretto version from 8.272.10.3 to 8.275.01.1

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.
