### PR TITLE
Added arm64 specific version / checksum / url for zulu13

### DIFF
--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -1,19 +1,18 @@
 cask "zulu13" do
-  if Hardware::CPU.arch == :arm64
-    version "13.0.5.1,13.35.1017-ca"
-    sha256 "c930f8475daa9878e627521d21dd7eea541759affde1763bbbb13017c52f4115"
-  else
+  if Hardware::CPU.intel?
     version "13.0.5,13.35.17-ca"
     sha256 "ce0b48f881bcb1d347b1e98a731aea34b843c2e5c9a38a93b14b364a0b10d36c"
-  end
 
-  if Hardware::CPU.arch == :arm64
-    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macos_aarch64.dmg",
-        referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
-  else
     url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
         referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  else
+    version "13.0.5.1,13.35.1017-ca"
+    sha256 "c930f8475daa9878e627521d21dd7eea541759affde1763bbbb13017c52f4115"
+
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macos_aarch64.dmg",
+        referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
   end
+
   name "Azul Zulu Java Standard Edition Development Kit"
   homepage "https://www.azul.com/downloads/zulu/zulu-mac/"
 

--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -1,9 +1,19 @@
 cask "zulu13" do
-  version "13.0.5,13.35.17-ca"
-  sha256 "ce0b48f881bcb1d347b1e98a731aea34b843c2e5c9a38a93b14b364a0b10d36c"
+  if Hardware::CPU.arch == :arm64
+    version "13.0.5.1,13.35.1017-ca"
+    sha256 "c930f8475daa9878e627521d21dd7eea541759affde1763bbbb13017c52f4115"
+  else
+    version "13.0.5,13.35.17-ca"
+    sha256 "ce0b48f881bcb1d347b1e98a731aea34b843c2e5c9a38a93b14b364a0b10d36c"
+  end
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
-      referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  if Hardware::CPU.arch == :arm64
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macos_aarch64.dmg",
+        referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  else
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
+        referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  end
   name "Azul Zulu Java Standard Edition Development Kit"
   homepage "https://www.azul.com/downloads/zulu/zulu-mac/"
 


### PR DESCRIPTION
Recreate PR for https://github.com/Homebrew/homebrew-cask-versions/pull/10101 as https://github.com/Homebrew/brew/issues/7857 is resolved, and homebrew is supporting arm64 devices officially.

Following contents come from original PR.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

~~Additionally, **if adding a new cask**:~~ Not adding a new cask, skipped.

------

I wonder if we should make `zulu13` install arm64 version on apple silicon devices, or we should create a new cask. The former one seems more intuitive for me, so I created this PR.

If this PR is approved and merged, I may create PRs for arm64 versions of `zulu11` and `zulu8` as well. Azul doesn't released arm64 version of `zulu`(15) and `zulu7` right now, so they will remain untouched.