### PR TITLE
Add arm64 specific version / checksum / url for zulu8

### DIFF
--- a/Casks/zulu8.rb
+++ b/Casks/zulu8.rb
@@ -1,9 +1,18 @@
 cask "zulu8" do
-  version "8.0.275,8.50.0.51-ca"
-  sha256 "a1a50b751a545da211c6e5546a45518202a4a558e0810341e2f4089eecbb16f4"
+  if Hardware::CPU.intel?
+    version "8.0.275,8.50.0.51-ca"
+    sha256 "a1a50b751a545da211c6e5546a45518202a4a558e0810341e2f4089eecbb16f4"
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
-      referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
+        referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  else
+    version "8.0.275,8.50.0.1017-ca"
+    sha256 "80f1e48d017896e05b5722a3de19f799e5cb9854ec5a1883d0e7a9a9ed4e7b23"
+
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macos_aarch64.dmg",
+        referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  end
+
   name "Azul Zulu Java 8 Standard Edition Development Kit"
   homepage "https://www.azul.com/downloads/zulu/zulu-mac/"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

~~Additionally, **if adding a new cask**:~~ Not adding a new cask.

---

The missing "x" (`macos-aarch64` instead of `macosx-aarch64` is not a typo, or it's a typo from upstream). See [download page](https://www.azul.com/downloads/zulu-community/?version=java-8-lts&os=macos&architecture=arm-64-bit&package=jdk) for reference.