### PR TITLE
Update opera-developer from 75.0.3925.0 to 75.0.3932.0

### DIFF
--- a/Casks/opera-developer.rb
+++ b/Casks/opera-developer.rb
@@ -1,6 +1,6 @@
 cask "opera-developer" do
-  version "75.0.3925.0"
-  sha256 "8bf584f67aaaab891d707d1dc0c94218bf33c70eea1cfa3db9aa78e0689ab0fc"
+  version "75.0.3932.0"
+  sha256 "79ede2ec2ac9d4a0c7fb8cae081c3453d034641e6f243a4dce6ea1aa0cc3a601"
 
   url "https://get.geo.opera.com/pub/opera-developer/#{version}/mac/Opera_Developer_#{version}_Setup.dmg"
   name "Opera Developer"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.