### PR TITLE
Fix checksum in Morpheus.app Cask

### DIFF
--- a/Casks/morpheus-beta.rb
+++ b/Casks/morpheus-beta.rb
@@ -1,6 +1,6 @@
 cask "morpheus-beta" do
   version "2.2.0_rc1"
-  sha256 "a095b04df3cdef5d877371873a8540bca7b13ae068b9ce60b96218c7faffc573"
+  sha256 "3df70eb4eafbfa1a8a95ff1a15676651a1fa2ef10dcc0038655a7bc44eebf72a"
 
   url "https://imc.zih.tu-dresden.de/morpheus/packages/mac/Morpheus-#{version}.dmg",
       verified: "imc.zih.tu-dresden.de/morpheus/"


### PR DESCRIPTION
Adjusted checksum for revision 03.12.2020 of Morpheus.app.

<img width="704" alt="Morpheus-2 2 0_rc1-rev2020-12-03" src="https://user-images.githubusercontent.com/6570972/104365273-1849d500-5518-11eb-8c11-05f26adcfd7c.png">


---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.