### PR TITLE
Update visual-studio-code-insiders from 1.53.0,1a4b35c2023a41efae1af2661026d57cea90ef5c to 1.53.0,4f2341834e646360e603953b62bf6c6020b07a29

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.53.0,1a4b35c2023a41efae1af2661026d57cea90ef5c"
+  version "1.53.0,4f2341834e646360e603953b62bf6c6020b07a29"
 
   if Hardware::CPU.intel?
-    sha256 "9a6c78362b67a645a7414b08045873b94f6d75a7864d7310257512a5cefa1bfd"
+    sha256 "cb0934afa2f26d9dbcffc8a81355e2833550540a92b1bc80e9515664ea62a598"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "600888057b553aef1502545ffe59ef31c91e7c1be6148826d73d64ba19a650c8"
+    sha256 "3243faad535decb28848b9b723e8e0cdb1231a5821283452b053ce4b33847870"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump.