### PR TITLE
Update signal-beta to use .dmg instead of .zip

### DIFF
--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -5,6 +5,7 @@ cask "signal-beta" do
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.dmg"
   appcast "https://github.com/signalapp/Signal-Desktop/releases.atom"
   name "Signal Beta"
+  desc "Instant messaging application focusing on security"
   homepage "https://signal.org/"
 
   auto_updates true

--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,8 +1,8 @@
 cask "signal-beta" do
   version "1.39.6-beta.1"
-  sha256 "8782ded1308e21f21417096d76819f777279472502727555f3ae0836d2d4a1c1"
+  sha256 "7bfd120c1456d5f0b1b4d0188d682141e405b5c07bbf76398bf61a50987817d8"
 
-  url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.zip"
+  url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{version}.dmg"
   appcast "https://github.com/signalapp/Signal-Desktop/releases.atom"
   name "Signal Beta"
   homepage "https://signal.org/"


### PR DESCRIPTION
Getting signing issues with the downloaded .zip

As you can see [here](https://github.com/signalapp/Signal-Desktop/issues/3128) it appears that others have, before, experienced issues with the .zip version.

I'm not sure why there are two, but .dmg seems to not have any signing issues. Would appreciate thoughts from others as to why this issue is occurring with the .zip version.

I'm making an assumption that the .zip version is intended for use with the internal update mechanism and, outside of this sphere, something funky occurs? This might be corroborated by [this issue](https://github.com/signalapp/Signal-Desktop/issues/4023) on their GitHub Issues.

Thanks!

Peter

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
