### PR TITLE
Unify zulu8 x86_64 and arm64 version

### DIFF
--- a/Casks/zulu8.rb
+++ b/Casks/zulu8.rb
@@ -1,15 +1,15 @@
 cask "zulu8" do
+  version "8.0.282,8.52.0.23-ca"
+
   if Hardware::CPU.intel?
-    version "8.0.282,8.52.0.23-ca"
     sha256 "4eaf47acd097ad3102f55ddc586f4e1fbb3b8b8115d5cb2c455a54b0d84ee1bc"
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
         referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
   else
-    version "8.0.275,8.50.0.1017-ca"
-    sha256 "80f1e48d017896e05b5722a3de19f799e5cb9854ec5a1883d0e7a9a9ed4e7b23"
+    sha256 "c6d1795d535cb448de567faf1449610fce69e5fe2e8a443a3f96f4036319f809"
 
-    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macos_aarch64.dmg",
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_aarch64.dmg",
         referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

~~Additionally, **if adding a new cask**:~~

---

`x86_64` and `arm64` versions of `zulu8` are the same now, makes `brew bump-cask-pr` fail when `brew style --fix`-ing. Doing manual version bump here.

`url` change is expected as upstream fixed missing `x` in download url for the previous version.