### PR TITLE
Unify zulu11 x86_64 and arm64 version

### DIFF
--- a/Casks/zulu11.rb
+++ b/Casks/zulu11.rb
@@ -1,13 +1,13 @@
 cask "zulu11" do
+  version "11.0.10,11.45.27-ca"
+
   if Hardware::CPU.intel?
-    version "11.0.10,11.45.27-ca"
     sha256 "1c59885634ad438c9b198d31b9dd2aa310922484b3a0ffec603eec1b02eb898e"
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
         referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
   else
-    version "11.0.9.1,11.43.1021-ca"
-    sha256 "260a9d1bd3acda5b82bd3d61096fb3eec9985e5c37817ee2d3bb21f1134f0b36"
+    sha256 "dd7f76d637fcf692081ae29af8f694d95e82cf30a9aa9ddea26d8e062c65e4f5"
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_aarch64.dmg",
         referer: "https://www.azul.com/downloads/zulu/zulu-mac/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

~~Additionally, **if adding a new cask**:~~

---

`x86_64` and `arm64` versions of `zulu11` are the same now, makes `brew bump-cask-pr` fail when `brew style --fix`-ing. Doing manual version bump here.