### PR TITLE
Unify zulu13 x86_64 and arm64 version

### DIFF
--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -1,15 +1,15 @@
 cask "zulu13" do
+  version "13.0.6,13.37.21-ca"
+
   if Hardware::CPU.intel?
-    version "13.0.6,13.37.21-ca"
     sha256 "c9de14e85b882fdcb65deef263ea43cfb8c3eb603b7f5a7c51214c7e4e16674b"
 
     url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
         referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
   else
-    version "13.0.5.1,13.35.1017-ca"
-    sha256 "c930f8475daa9878e627521d21dd7eea541759affde1763bbbb13017c52f4115"
+    sha256 "5831abf3669642fdb2f841f4034fe7f2cde7e7c85a04e93a44e49c17e5f5dc7b"
 
-    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macos_aarch64.dmg",
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_aarch64.dmg",
         referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

~~Additionally, **if adding a new cask**:~~

---

`x86_64` and `arm64` versions of `zulu13` are the same now, makes `brew bump-cask-pr` fail when `brew style --fix`-ing. Doing manual version bump here.

`url` change is expected as upstream fixed missing `x` in download url for the previous version.