### PR TITLE
Update visual-studio-code-insiders from 1.53.0,2ce26643d85bf985d3d3ce6ce0ff5d78866f9b5f to 1.53.0,5a52bc29d5e9bc419077552d336ea26d904299fa

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.53.0,2ce26643d85bf985d3d3ce6ce0ff5d78866f9b5f"
+  version "1.53.0,5a52bc29d5e9bc419077552d336ea26d904299fa"
 
   if Hardware::CPU.intel?
-    sha256 "44152fbd814ca0629fe40227aca2906620ed2e05a056deab5b28e7ef6397c78a"
+    sha256 "a26c0fb3a166e8b4aff92ac2dc52b1aa4cbf1ec7539217649031ed146389a4f3"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "302cfa28288d1120c8810963e411110d15df087ca546854df305ee42a6501c67"
+    sha256 "7bb5d6ed0a41c6a3ca97f2418e9e99b7da2512c5e13d010cd9c2f9eeeb39b6de"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump.