### PR TITLE
Upgrading keepassxc to 2.6.4

### DIFF
--- a/Casks/keepassxc-beta.rb
+++ b/Casks/keepassxc-beta.rb
@@ -1,23 +1,27 @@
 cask "keepassxc-beta" do
-  version "2.6.3"
+  version "2.6.4"
 
-  if MacOS.version <= :sierra
-    url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-Sierra.dmg",
+  if Hardware::CPU.arm?
+    url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-arm64.dmg",
         verified: "github.com/keepassxreboot/keepassxc/"
-    sha256 "7cd8dc34022091c240e538f7a9889afd7dc8f9f3957a66bca9d70c067045ade4"
+    sha256 "16dcdfae65ad8887b4d9cd86bf56bc7df2dca3e3fedf91b07b42a0f6e1465c48"
   else
-    url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}.dmg",
+    url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-x86_64.dmg",
         verified: "github.com/keepassxreboot/keepassxc/"
-    sha256 "3b2e86aafa6943771f008ec530d0809b12f1a09773838f8e0e79ed71061a3c36"
+    sha256 "639fdfe0379dc3f00f1bd6a72c974cfddae0d4c8ddb66f7297d0b01b1a582ede"
   end
 
-  appcast "https://github.com/keepassxreboot/keepassxc/releases.atom"
   name "KeePassXC"
   desc "Password manager app"
   homepage "https://keepassxc.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   conflicts_with cask: "keepassxc"
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "KeePassXC.app"
   binary "#{appdir}/KeePassXC.app/Contents/MacOS/keepassxc-cli"

--- a/Casks/keepassxc-beta.rb
+++ b/Casks/keepassxc-beta.rb
@@ -1,14 +1,14 @@
 cask "keepassxc-beta" do
   version "2.6.4"
 
-  if Hardware::CPU.arm?
-    url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-arm64.dmg",
-        verified: "github.com/keepassxreboot/keepassxc/"
-    sha256 "16dcdfae65ad8887b4d9cd86bf56bc7df2dca3e3fedf91b07b42a0f6e1465c48"
-  else
+  if Hardware::CPU.intel?
     url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-x86_64.dmg",
         verified: "github.com/keepassxreboot/keepassxc/"
     sha256 "639fdfe0379dc3f00f1bd6a72c974cfddae0d4c8ddb66f7297d0b01b1a582ede"
+  else
+    url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-arm64.dmg",
+        verified: "github.com/keepassxreboot/keepassxc/"
+    sha256 "16dcdfae65ad8887b4d9cd86bf56bc7df2dca3e3fedf91b07b42a0f6e1465c48"
   end
 
   name "KeePassXC"


### PR DESCRIPTION
Removed support for `sierra` since that is not present in the supported versions of the app; added support for ARM architecture.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
