### PR TITLE
Update visual-studio-code-insiders from 1.53.0,565dc9704f27619ad73867fddde6bbca88110c18 to 1.53.0,8d779a4fadaadec06b44b8875a1d3c4adba8e380

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.53.0,565dc9704f27619ad73867fddde6bbca88110c18"
+  version "1.53.0,8d779a4fadaadec06b44b8875a1d3c4adba8e380"
 
   if Hardware::CPU.intel?
-    sha256 "16380e0797a7a07c73f93e13adcd6ffbb689041e73763c0e79ce4acf859712a9"
+    sha256 "5f061eec33fcb89272741586a81902d18125fd10204beaab6b7f4caae53a3364"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "9a12833c5a8681fb151103ca704e0491817b2947db4eda3ca808e0610d5cc524"
+    sha256 "2d2ab6923dff917b4ab83f04e6a4938cede4529f3f45b4a06f3dcd4ceffde497"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump.