### PR TITLE
Update visual-studio-code-insiders from 1.53.0,8d779a4fadaadec06b44b8875a1d3c4adba8e380 to 1.53.0,e1c818a171168eedf78b62fdc7f4e3458d5dea7c

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.53.0,8d779a4fadaadec06b44b8875a1d3c4adba8e380"
+  version "1.53.0,e1c818a171168eedf78b62fdc7f4e3458d5dea7c"
 
   if Hardware::CPU.intel?
-    sha256 "5f061eec33fcb89272741586a81902d18125fd10204beaab6b7f4caae53a3364"
+    sha256 "1c93b300bfb3f640e84c9a70cd648cfe068eb64bcd1d08af7f9149fc2372f3d1"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "2d2ab6923dff917b4ab83f04e6a4938cede4529f3f45b4a06f3dcd4ceffde497"
+    sha256 "0a79031cc8123f93d4711c82b2620651a60398bec15d720c99569ff9e7ac0829"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump