### PR TITLE
Update visual-studio-code-insiders from 1.53.0,e1c818a171168eedf78b62fdc7f4e3458d5dea7c to 1.53.0,8490d3dde47c57ba65ec40dd192d014fd2113496

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.53.0,e1c818a171168eedf78b62fdc7f4e3458d5dea7c"
+  version "1.53.0,8490d3dde47c57ba65ec40dd192d014fd2113496"
 
   if Hardware::CPU.intel?
-    sha256 "1c93b300bfb3f640e84c9a70cd648cfe068eb64bcd1d08af7f9149fc2372f3d1"
+    sha256 "ec58eb65edd308c2b209b533344dab4790ac7c74e68c5815d7db13c4e8ca3a03"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "0a79031cc8123f93d4711c82b2620651a60398bec15d720c99569ff9e7ac0829"
+    sha256 "94675b11f0cf386d4fea842b43c6554406f31b24148c80b476a8eaa60bdab6ac"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump