### PR TITLE
Update firefox-esr from 78.6.1 to 78.7.1

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,68 +1,68 @@
 cask "firefox-esr" do
-  version "78.6.1"
+  version "78.7.1"
 
   language "cs" do
-    sha256 "07e2f33c26b3846dee574b15c850a10f51e0900a4243b6d26d81e087e8e3874c"
+    sha256 "27e5a9abdedf7e2cf1881d869b1244ba6ef0802869f23e1047b10300f01ee906"
     "cs"
   end
   language "de" do
-    sha256 "ba6b0aa139728d7111cc5998b49c8a4fb83d9424774db2870acd9f9b76dd588c"
+    sha256 "26061618b9186b37d2745e8b27ebe3af32d48e14501ec41473bfbfdcf9bbd2f1"
     "de"
   end
   language "en-CA" do
-    sha256 "2d1f8c381ecc5d0539546454a4804f1a5e654b844fddee98244aed37143bf9cf"
+    sha256 "17f17477c0d3db98306b1603af550cf04a18262497fa7ea4b0a6526af3ac291e"
     "en-CA"
   end
   language "en-GB" do
-    sha256 "0c1ae91c6c044dfca2e35e0692a01a901fd52cbcdc359042a1b48e3b17dcc6ef"
+    sha256 "6014ed74228b0b0d1937ce1920ce9f2bcd58a8f58a489b236a256ee280583d3c"
     "en-GB"
   end
   language "en", default: true do
-    sha256 "f0ef96e267bafaff278770f4c6734980b626ec9bfe009dfe74b4caeb4cc37271"
+    sha256 "8c0f081d14e1cd8a73bd296468b4fbbf1092fbcac4adab4b34969a04b4f155b5"
     "en-US"
   end
   language "fr" do
-    sha256 "32106808ec2ee5445ee4bbc7017fe4b97fd17b06c8768a9a0368d585d69e28e5"
+    sha256 "ddd1d9cbd83781d27377b8cc4d3acca63a3a53b54f1e3d123aadb8ba474eb865"
     "fr"
   end
   language "gl" do
-    sha256 "adb8aa6c41fd35837afc2277eddc60f5f34ad0ce77cacb753dcfd7cb25a98aa5"
+    sha256 "adb6da6d546c71cad97ea90691ce59c879f8783bbd85f290f186ba31f6ac7697"
     "gl"
   end
   language "it" do
-    sha256 "20229f14b6893154bbb279bb42e2ed3d600460a780ac823fb0b8f9f9085e5414"
+    sha256 "720248306b58b16c7351127d73963775cf71ce22bdbff7e751fdd3f7238491cc"
     "it"
   end
   language "ja" do
-    sha256 "2c76e65f4e4c476ecd6a4f12c2b8247893e5002bd3b864d8d55525a786670c6c"
+    sha256 "ed701e1489eda705f6e970d504c72a3748c7e1f16525fa01c56970844890d3d7"
     "ja-JP-mac"
   end
   language "nl" do
-    sha256 "6bbad9a8eb5063622a002d3697705dc64ffce2c9b23236bb9ffe9c0c267d3d54"
+    sha256 "126a11e3dda5c85c09cc58efef10cb9e7b8de4b2f1912170b156ca308bf219df"
     "nl"
   end
   language "pl" do
-    sha256 "e29434c3c387954ad84dffdcfba1ae8b6fac28e49c1a4f19b82a92f8cd1c05eb"
+    sha256 "40056744105f493bd418f505c54a397c27669728fe2cb2a2580a23a8ea8f0b42"
     "pl"
   end
   language "pt" do
-    sha256 "cd24d8c863d82b317b18fb917852f605bd1aeb842bb3b8b3c7abb53ba52e5c48"
+    sha256 "f6d03b03607f1c3d1b08bc4655b65df23093691c89552a95e2ae5555227e3a68"
     "pt-PT"
   end
   language "ru" do
-    sha256 "7b3dd72166addb81934e429af2730c97ef773d1033a873384a748808cdf3fc4e"
+    sha256 "d535c6d19621ec7e12958b6ce33106697e7ee1e2ad2ef4ca9e22d645c26e3d6b"
     "ru"
   end
   language "uk" do
-    sha256 "6167f4f2756ccf64d38940042232b4eaf6f78eac68985a4e090b21bc3dd14e0d"
+    sha256 "3a77608767343f41e2b799bb061319d97ab421b17f2ccae88a2e29a2d83cf5d1"
     "uk"
   end
   language "zh-TW" do
-    sha256 "fff80d3d5be7ea3e5c4b98ce2d846950d205bd288858d678eeb50543a7378abc"
+    sha256 "d60c9d7396660a9c63c96d277ca5468d3209c43135ecc2e6f944d3211ee7b26d"
     "zh-TW"
   end
   language "zh" do
-    sha256 "e38c65cc29f2dbf3cb06171abb585579021eeb0b3da23772fc490fcb6caf40e5"
+    sha256 "8026b5566cade981d91a137a441c92b699e912d6fb14a1792efeab8f366cc3ad"
     "zh-CN"
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.