### PR TITLE
Updates hyper-canary

### DIFF
--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -1,16 +1,18 @@
 cask "hyper-canary" do
-  version "3.0.1-canary.4"
-  sha256 "d6c9d1d78769772f6afc431747c29488b9d4657fb1f892fef87f5d5040aa69ee"
+  version "3.1.0-canary.4"
+  sha256 "6585914c59fa71142154340d20e641e725d17bf25b58b7b43ecdf5362d0ff837"
 
-  url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip",
-      verified: "github.com/zeit/hyper/"
-  appcast "https://github.com/zeit/hyper/releases.atom"
+  url "https://github.com/vercel/hyper/releases/download/v#{version}/Hyper-#{version}-mac.zip",
+      verified: "github.com/vercel/hyper/"
+  appcast "https://github.com/vercel/hyper/releases.atom"
   name "Hyper"
+  desc "Terminal built on web technologies"
   homepage "https://hyper.is/"
 
   auto_updates true
 
   app "Hyper.app"
+  binary "#{appdir}/Hyper.app/Contents/Resources/bin/hyper"
 
   zap trash: [
     "~/.hyper.js",
@@ -19,6 +21,9 @@ cask "hyper-canary" do
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.zeit.hyper.sfl*",
     "~/Library/Caches/co.zeit.hyper",
     "~/Library/Caches/co.zeit.hyper.ShipIt",
+    "~/Library/Cookies/co.zeit.hyper.binarycookies",
+    "~/Library/Logs/Hyper",
+    "~/Library/Preferences/ByHost/co.zeit.hyper.ShipIt.*.plist",
     "~/Library/Preferences/co.zeit.hyper.plist",
     "~/Library/Preferences/co.zeit.hyper.helper.plist",
     "~/Library/Saved Application State/co.zeit.hyper.savedState",

--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -4,12 +4,18 @@ cask "hyper-canary" do
 
   url "https://github.com/vercel/hyper/releases/download/v#{version}/Hyper-#{version}-mac.zip",
       verified: "github.com/vercel/hyper/"
-  appcast "https://github.com/vercel/hyper/releases.atom"
   name "Hyper"
   desc "Terminal built on web technologies"
   homepage "https://hyper.is/"
 
+  livecheck do
+    url "https://github.com/vercel/hyper/releases"
+    strategy :page_match
+    regex(/hyper-(\d+(?:\.\d+)*+.+)-mac\.zip/i)
+  end
+
   auto_updates true
+  conflicts_with cask: "hyper"
 
   app "Hyper.app"
   binary "#{appdir}/Hyper.app/Contents/Resources/bin/hyper"

--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -11,7 +11,7 @@ cask "hyper-canary" do
   livecheck do
     url "https://github.com/vercel/hyper/releases"
     strategy :page_match
-    regex(/hyper-(\d+(?:\.\d+)*+.+)-mac\.zip/i)
+    regex(/hyper-(\d+(?:\.\d+)*.+)-mac\.zip/i)
   end
 
   auto_updates true


### PR DESCRIPTION
This PR updates Hyper Canary with new Github repo ownership and aligns some strategy with the main Hyper cask.

Does it need a livecheck stanza instead of appcast? If so I can look into it.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.