### PR TITLE
Update visual-studio-code-insiders from 1.54.0,93f705ab40b37aade9d3b5165ed09114a8c87ac9 to 1.54.0,6ac9a3ecb3698e82bf901f11bbb5940f6bc3c197

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.54.0,93f705ab40b37aade9d3b5165ed09114a8c87ac9"
+  version "1.54.0,6ac9a3ecb3698e82bf901f11bbb5940f6bc3c197"
 
   if Hardware::CPU.intel?
-    sha256 "8fc3682ff0000aab7ce68a8b2ec82d11fd59ae09b1ab384b4b72c57d06b70b30"
+    sha256 "b8c08a0cbda57eebc8e618b0d3a5939198e582064c8f82f9c5d0f326fbe42ec9"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "fee1e0e05990ed74c619250c2198c8ec94fa943e73b9c55a1eb4d3006210ebb1"
+    sha256 "4d0a57a35c698b056ca35556d7d0db7fb9b9fa31268a7ca93dc508c36a233bf5"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump from `1.54.0,93f705ab40b37aade9d3b5165ed09114a8c87ac9` to `1.54.0,6ac9a3ecb3698e82bf901f11bbb5940f6bc3c197`.