### PR TITLE
Update visual-studio-code-insiders from 1.54.0,192c817fd350bcbf3caecae22a45ec39bae78516 to 1.54.0,11cd76005bc7516dcc726d7389d0bce1744e5c85

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.54.0,192c817fd350bcbf3caecae22a45ec39bae78516"
+  version "1.54.0,11cd76005bc7516dcc726d7389d0bce1744e5c85"
 
   if Hardware::CPU.intel?
-    sha256 "148b841ec38af7a15021dec28dd6d810b575d30031c84d8819b82142d95e7ad6"
+    sha256 "ad4c5c67ccb976a8063c92cf59f72d80ff40fa9d9116251f3bfafbb32db9e17d"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "9b50ae54868a59ddc55c21c9e647b44245850ace1a0695ebd4b9cbe1f43ce082"
+    sha256 "f80090d08d9a8bc65897eeba99439a863b2b94f0cfdfb772626f9ff479bf7ba2"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump.