### PR TITLE
Add ableton-live-*10

### DIFF
--- a/Casks/ableton-live-intro10.rb
+++ b/Casks/ableton-live-intro10.rb
@@ -1,0 +1,27 @@
+cask "ableton-live-intro10" do
+  version "10.1.30"
+  sha256 "cf46fd3c8749e5507adbbafaf6bb2de2b6d62555710596528103deccae1442a8"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_64.dmg"
+  appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
+  name "Ableton Live Intro"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+
+  auto_updates true
+  depends_on macos: ">= :el_capitan"
+
+  app "Ableton Live #{version.major} Intro.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Application Support/Ableton",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end

--- a/Casks/ableton-live-lite10.rb
+++ b/Casks/ableton-live-lite10.rb
@@ -1,0 +1,27 @@
+cask "ableton-live-lite10" do
+  version "10.1.30"
+  sha256 "55b2562b61a30af0a5794f2c3c9f846d0189361688568804490ed696ceeb06e3"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
+  appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
+  name "Ableton Live Lite"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/products/live-lite/"
+
+  auto_updates true
+  depends_on macos: ">= :el_capitan"
+
+  app "Ableton Live #{version.major} Lite.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Application Support/Ableton",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end

--- a/Casks/ableton-live-standard10.rb
+++ b/Casks/ableton-live-standard10.rb
@@ -1,0 +1,27 @@
+cask "ableton-live-standard10" do
+  version "10.1.30"
+  sha256 "736b80d967db98dda5c4a897157f0e96c6d23a9879cae0348e13cab789016a37"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
+  appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
+  name "Ableton Live Standard"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+
+  auto_updates true
+  depends_on macos: ">= :el_capitan"
+
+  app "Ableton Live #{version.major} Standard.app"
+
+  uninstall quit: "com.ableton.Live"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Application Support/Ableton",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end

--- a/Casks/ableton-live-suite10.rb
+++ b/Casks/ableton-live-suite10.rb
@@ -1,0 +1,33 @@
+cask "ableton-live-suite10" do
+  version "10.1.30"
+  sha256 "31a9f793a5aa5aee1258b66c110def3d42317c418e4df5780d15cb383f09c08e"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
+  appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
+  name "Ableton Live Suite"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+
+  auto_updates true
+  depends_on macos: ">= :el_capitan"
+
+  app "Ableton Live #{version.major} Suite.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "/Library/Logs/DiagnosticReports/Max_*.*_resource.diag",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Application Support/CrashReporter/Max_*.plist",
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/Cycling '74",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Library/Preferences/com.cycling74.Max*.plist*",
+    "~/Music/Ableton",
+    "~/Documents/Max [0-9]",
+    "/Users/Shared/Max [0-9]",
+  ]
+end


### PR DESCRIPTION
These four casks have been migrated from `homebrew-cask` after the update to 11.0 (see [#100274](https://github.com/Homebrew/homebrew-cask/pull/100274)). I specifically did not bring `ableton-live` across, since that's the trial version and there seems to be no good reason for maintaining old versions of trial software.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
