### PR TITLE
Update visual-studio-code-insiders from 1.54.0,3290f9a73ba6fc3b1063ea32476067434ee91b1d to 1.54.0,e590188f17162393f50feec19263398e6fe02d13

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.54.0,3290f9a73ba6fc3b1063ea32476067434ee91b1d"
+  version "1.54.0,e590188f17162393f50feec19263398e6fe02d13"
 
   if Hardware::CPU.intel?
-    sha256 "cd592d12d3a4199e79414230f27d2ed21cbf5ea55cc863f077e95431fd019c8e"
+    sha256 "f831849060e6aa6bc39dc5715e459f4564a641526338eeb8790bb9ade0adddf7"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "e1cf1171784964b80c51ac3c46a4b85216fa4142c3341889d9142261144a537f"
+    sha256 "c741e1b8d1046b94163d6dd7939601bebee123c540d87de7ef285462d54cad7f"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump.