### PR TITLE
Add "WPS Office China Edition"

### DIFF
--- a/Casks/wpsoffice-cn.rb
+++ b/Casks/wpsoffice-cn.rb
@@ -1,0 +1,37 @@
+cask "wpsoffice-cn" do
+  version "3.3.1,5149"
+  sha256 :no_check
+
+  url "https://package.mac.wpscdn.cn/mac_wps_pkg/#{version.before_comma}/WPS_Office_#{version.before_comma}(#{version.after_comma}).dmg",
+      verified: "package.mac.wpscdn.cn/"
+  name "WPS Office China Edition"
+  name "WPS Office 中国版"
+  desc "All-in-one office suite"
+  homepage "https://www.wps.cn/product/wpsmac/"
+
+  livecheck do
+    url :homepage
+    strategy :page_match do |page|
+      match = page.match(%r{href=.*?/WPS_Office_(\d+(?:\.\d+)*)\((\d+)\)\.dmg}i)
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: "wpsoffice"
+  depends_on macos: ">= :sierra"
+
+  app "wpsoffice.app"
+
+  uninstall quit: "com.kingsoft.wpsoffice.mac"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.kingsoft.wpsoffice.mac",
+    "~/Library/Saved Application State/com.kingsoft.wpsoffice.mac.savedState",
+    "/private/var/folders/*/*/*/com.kingsoft.wpsoffice.mac",
+    "/private/var/folders/*/*/*/com.apple.WebKit.Networking+com.kingsoft.wpsoffice.mac",
+    "/private/var/folders/*/*/*/com.apple.WebKit.WebContent+com.kingsoft.wpsoffice.mac",
+    "~/Library/Containers/com.kingsoft.wpsoffice.mac",
+    "~/Library/Group Containers/*.wpsoffice",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.

```
 $ brew livecheck --cask --debug wpsoffice-cn

Cask:             wpsoffice-cn
Livecheckable?:   Yes

URL (homepage):   https://www.wps.cn/product/wpsmac/
Strategy:         PageMatch

Matched Versions:
3.3.1,5149
wpsoffice-cn : 3.3.1,5149 ==> 3.3.1,5149
```