### PR TITLE
Update visual-studio-code-insiders from 1.55.0,9b2ee7fb7d970b9a628fdb3545bdd01d67078d16 to 1.55.0,06b54543d660353a04cdab6554d1f27266a537fd

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.55.0,9b2ee7fb7d970b9a628fdb3545bdd01d67078d16"
+  version "1.55.0,06b54543d660353a04cdab6554d1f27266a537fd"
 
   if Hardware::CPU.intel?
-    sha256 "dc4706db0eb7c8f878d441f5f8582e80413a8c1a07da67baf456de4613a2e8ba"
+    sha256 "542db871ea58b161ffab1c34c2cdd8cdb181e183cc0045a3fe9f3dc541ffef47"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "4cddb052f19eddca108dcbe3dcd2b3443c72519b21b9216af90c85041958f35b"
+    sha256 "74b75c488bc2863de1199c2e27ed90826ba0aa3727849809830128009917524e"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump.