### PR TITLE
Allow .NET Preview 6 to be installed on Apple Silicon

### DIFF
--- a/Casks/dotnet-preview.rb
+++ b/Casks/dotnet-preview.rb
@@ -4,11 +4,13 @@ cask "dotnet-preview" do
     sha256 "286ef6a223d8614df4df45e0e167ad68cd2b69de838b809bc3eb5ce0963e244b"
 
     url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
+    pkg "dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
   else
     version "6.0.0-preview.2.21154.6,3de6add5-a77c-4621-bf77-1722073ac0a7:4535dfffd67bbbf59b06c1b59c0b2f29"
     sha256 "a05e828c99371b137434987ca7ef44a9ff0b36dc390fb5af9754075872b9506e"
 
     url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version.before_comma}-osx-arm64.pkg"
+    pkg "dotnet-runtime-#{version.before_comma}-osx-arm64.pkg"
   end
 
   appcast "https://dotnet.microsoft.com/download/dotnet/#{version.major_minor}"
@@ -23,7 +25,6 @@ cask "dotnet-preview" do
   ]
   depends_on macos: ">= :sierra"
 
-  pkg "dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
   binary "/usr/local/share/dotnet/dotnet"
 
   uninstall pkgutil: "com.microsoft.dotnet.*",

--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -4,11 +4,13 @@ cask "dotnet-sdk-preview" do
     sha256 "626c3c9beed8bf64797838ccebbc05cae5dc7cf28ebc741e444f45d7c0ed03b3"
 
     url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
+    pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
   else
     version "6.0.100-preview.2.21155.3,e5cbc909-e705-4bc1-9327-15c9f905a149:6da57e95a58cef98444698fa72378e23"
     sha256 "9d9c6fc1a829a40222271c8b312368195dd2a771791120b33ab5a03cebdcc843"
 
     url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-sdk-#{version.before_comma}-osx-arm64.pkg"
+    pkg "dotnet-sdk-#{version.before_comma}-osx-arm64.pkg"
   end
 
   appcast "https://dotnet.microsoft.com/download/dotnet/#{version.major_minor}"
@@ -23,7 +25,6 @@ cask "dotnet-sdk-preview" do
   ]
   depends_on macos: ">= :sierra"
 
-  pkg "dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
   binary "/usr/local/share/dotnet/dotnet"
 
   uninstall pkgutil: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Fixes the problem pointed out by [this comment](https://github.com/Homebrew/homebrew-cask-versions/pull/10520#commitcomment-48219856) which was introduced in #10520; this is an alternative to #10526.