### PR TITLE
Update visual-studio-code-insiders from 1.55.0,06b54543d660353a04cdab6554d1f27266a537fd to 1.55.0,892a1083cb2b9b3987ff7edc85376b5d9764433d

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.55.0,06b54543d660353a04cdab6554d1f27266a537fd"
+  version "1.55.0,892a1083cb2b9b3987ff7edc85376b5d9764433d"
 
   if Hardware::CPU.intel?
-    sha256 "542db871ea58b161ffab1c34c2cdd8cdb181e183cc0045a3fe9f3dc541ffef47"
+    sha256 "80acf4955381a716418c92819a56aeccb686c8b5241e428884a7beb838c795a0"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "74b75c488bc2863de1199c2e27ed90826ba0aa3727849809830128009917524e"
+    sha256 "9d99216de22c8f360da50410c08a1d5f94c90a75fbaf50f42da99e40409af476"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump