### PR TITLE
Add zulu15

### DIFF
--- a/Casks/zulu15.rb
+++ b/Casks/zulu15.rb
@@ -1,0 +1,32 @@
+cask "zulu15" do
+  version "15.0.2,15.29.15-ca"
+
+  if Hardware::CPU.intel?
+    sha256 "6284c7fb89cbbc8552788a3db522f6226a64d84454d21e075558c050328f6ed7"
+
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_x64.dmg",
+        referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  else
+    sha256 "599c3399eb6edb824f4660ba0a4fbb52118458041700dc71aec891bd383910e5"
+
+    url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.before_comma}-macosx_aarch64.dmg",
+        referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  end
+  name "Azul Zulu Java Standard Edition Development Kit"
+  desc "Zulu OpenJDK 15"
+  homepage "https://www.azul.com/downloads/zulu/zulu-mac/"
+
+  livecheck do
+    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&ext=dmg&os=macos"
+    strategy :page_match do |page|
+      match = page.match(%r{url"\s*:\s*"https:.*?/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)*)-macos}i)
+      "#{match[2]},#{match[1]}"
+    end
+  end
+
+  depends_on macos: ">= :sierra"
+
+  pkg "Double-Click to Install Zulu #{version.major}.pkg"
+
+  uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"
+end


### PR DESCRIPTION
Zulu JDK 16 is now default in the main `zulu` cask recipe repo, see
https://github.com/Homebrew/homebrew-cask/pull/101306 and the recipe was pulled from
https://github.com/Homebrew/homebrew-cask/blob/021a0b9ad82698049b9a3bac7b7718e55eee8f99/Casks/zulu.rb before the main `zulu` recipe was updated to Zulu JDK 16.

This adds a `zulu15` cask representing `Azul Zulu Java Standard Edition Development Kit version 15.0.2+7 15.29.15`

A `zulu15` cask was previously proposed in #9836 and closed out due to:
> The latest **stable** versions are tracked in the main `homebrew-cask` repo, so if version 15 is considered the latest stable one then the `zulu` Cask points to that.
> 
> If version 16 becomes the latest stable version, then a `zulu15` Cask may be added to the `homebrew-cask-versions` repo.
> _Originally posted by @miccal in https://github.com/Homebrew/homebrew-cask-versions/issues/9836#issuecomment-719577572_
> 


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
```
$ brew audit --cask zulu15
audit for zulu15: passed
```

- [x] `brew style --fix {{cask_file}}` reports no offenses.
```
$ brew style --fix zulu15

1 file inspected, no offenses detected
```

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
https://github.com/Homebrew/homebrew-cask-versions/pull/9836
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
```
$ brew audit --new-cask zulu15
==> Downloading https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-macosx_x64.dmg
Already downloaded: /Users/davids/Library/Caches/Homebrew/downloads/b6f458c5a65e692e152dc2800bfd0c51f2241f97e2ed367f301e01f818a34317--zulu15.29.15-ca-jdk15.0.2-macosx_x64.dmg
audit for zulu15: passed
```

- [x] `brew install --cask {{cask_file}}` worked successfully.
```
$ brew install --cask zulu15
==> Downloading https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-macosx_x64.dmg
Already downloaded: /Users/davids/Library/Caches/Homebrew/downloads/b6f458c5a65e692e152dc2800bfd0c51f2241f97e2ed367f301e01f818a34317--zulu15.29.15-ca-jdk15.0.2-macosx_x64.dmg
==> Installing Cask zulu15
==> Running installer for zulu15; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
Password:
installer: Package name is Zulu 15.29+15
installer: Installing at base path /
installer: The install was successful.
🍺  zulu15 was successfully installed!
```

- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
```
$ brew uninstall --cask zulu15
==> Uninstalling Cask zulu15
==> Uninstalling packages:
com.azulsystems.zulu.15
==> Purging files for version 15.0.2,15.29.15-ca of Cask zulu15
```
