### PR TITLE
Update visual-studio-code-insiders from 1.55.0,e4b1e9ac57ab3cc942ab9bff09967bf3238a7910 to 1.55.0,469e4f6e2755b220dae3eccb04d1ddc587b84a5a

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.55.0,e4b1e9ac57ab3cc942ab9bff09967bf3238a7910"
+  version "1.55.0,469e4f6e2755b220dae3eccb04d1ddc587b84a5a"
 
   if Hardware::CPU.intel?
-    sha256 "fe3807c6e0ae52fffdd8504d7a145a288fc4995184e5b908bf5d03c9ee7f323b"
+    sha256 "aa6c1751b104f2b79126f2615bda92551766644ff510be4a2e110217cdf27ea6"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "7d79cd7ca59fe6cdbf02495c00dba3edd93814e5180c7710d4ff301369cbc1f9"
+    sha256 "e73d2603b7c253d7367136d8a35aaded7b64e87e5d7891dd22c52c748d522c63"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump