### PR TITLE
Replace open-uri with curl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,16 +30,14 @@ For Casks of [nightlies](https://en.wikipedia.org/wiki/Daily_build), `version`, 
 
 See [this pull request for exist-db-nightly](https://github.com/Homebrew/homebrew-cask-versions/pull/3067) for an example of the procedure.
 
-Example ([exist-db-nightly.rb](https://github.com/Homebrew/homebrew-cask-versions/blob/16b3bab91ab5b9a69ef7c456441b0e0fced56516/Casks/exist-db-nightly.rb#L6#L14)):
+Example ([transmission-nightly.rb](https://github.com/Homebrew/homebrew-cask-versions/blob/9d85295723eaccb8cb0ead855c6e80d142f7ad32/Casks/transmission-nightly.rb#L5#L11)):
 
 ```ruby
   url do
-    require "open-uri"
-    base_url = "http://static.adamretter.org.uk/exist-nightly"
-    builds_url = "#{base_url}/table.html"
-    latest_build_filename = URI(builds_url).open do |io|
-      io.read.scan(%r{<tr>.*?<td>(.*?)</td>.*?<a href="([^\"]+)">dmg}m).max[1]
-    end
-    "#{base_url}/#{latest_build_filename}"
+    base_url = "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/"
+    result = curl_output("--fail", "--silent", base_url)
+    result.assert_success!
+    file = result.stdout[/href="([^"]+.dmg)"/, 1]
+    "#{base_url}#{file}"
   end
 ```

--- a/Casks/brave-browser-nightly.rb
+++ b/Casks/brave-browser-nightly.rb
@@ -3,9 +3,10 @@ cask "brave-browser-nightly" do
   sha256 :no_check
 
   url do
-    require "open-uri"
     appcast = "https://updates.bravesoftware.com/sparkle/Brave-Browser/nightly/appcast.xml"
-    URI(appcast).read[/enclosure url="([^"]+.dmg)"/, 1]
+    result = curl_output("--fail", "--silent", appcast)
+    result.assert_success!
+    result.stdout[/enclosure url="([^"]+.dmg)"/, 1]
   end
   name "Brave Nightly"
   desc "Web browser focusing on privacy"

--- a/Casks/emacs-nightly.rb
+++ b/Casks/emacs-nightly.rb
@@ -3,8 +3,9 @@ cask "emacs-nightly" do
   sha256 :no_check
 
   url do
-    require "open-uri"
-    URI("https://emacsformacosx.com/atom/daily").read[/href="([^"]+.dmg)"/, 1]
+    result = curl_output("--fail", "--silent", "https://emacsformacosx.com/atom/daily")
+    result.assert_success!
+    result.stdout[/href="([^"]+.dmg)"/, 1]
   end
   name "Emacs"
   desc "GNU Emacs text editor"

--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -79,10 +79,11 @@ cask "firefox-nightly" do
   end
 
   url do
-    require "open-uri"
     base_url = "https://download-installer.cdn.mozilla.net/pub/firefox/nightly"
     builds_url = "#{base_url}/latest-mozilla-central#{language == "en-US" ? "" : "-l10n"}/"
-    latest_build_filename = URI(builds_url).open.read.scan(%r{<td><a href="/pub/firefox/nightly/([^"]+\.mac\.dmg)">}).flatten.grep(/\.#{language}\.mac\.dmg/).max
+    result = curl_output("--fail", "--silent", builds_url)
+    result.assert_success!
+    latest_build_filename = result.stdout.scan(%r{<td><a href="/pub/firefox/nightly/([^"]+\.mac\.dmg)">}).flatten.grep(/\.#{language}\.mac\.dmg/).max
     "#{base_url}/#{latest_build_filename}"
   end
   name "Mozilla Firefox Nightly"

--- a/Casks/gpg-suite-nightly.rb
+++ b/Casks/gpg-suite-nightly.rb
@@ -3,9 +3,9 @@ cask "gpg-suite-nightly" do
   sha256 :no_check
 
   url do
-    require "open-uri"
-    html = URI("https://releases.gpgtools.org/nightlies/").open.read
-    html.match(/<td class='filename'><a href='(.*)'>/)[1]
+    result = curl_output("--fail", "--silent", "https://releases.gpgtools.org/nightlies/")
+    result.assert_success!
+    result.stdout.match(/<td class='filename'><a href='(.*)'>/)[1]
   end
   name "GPG Suite Nightly"
   desc "Tools to protect your emails and files"

--- a/Casks/hamsket-nightly.rb
+++ b/Casks/hamsket-nightly.rb
@@ -3,9 +3,10 @@ cask "hamsket-nightly" do
   sha256 :no_check
 
   url do
-    require "open-uri"
     base_url = "https://github.com/TheGoddessInari/hamsket/releases"
-    "https://github.com#{URI(base_url).read[%r{href="([^"]+nightly/Hamsket-.*.dmg)"}, 1]}"
+    result = curl_output("--fail", "--silent", base_url)
+    result.assert_success!
+    "https://github.com#{result.stdout[%r{href="([^"]+nightly/Hamsket-.*.dmg)"}, 1]}"
   end
   name "Hamsket"
   desc "Free and Open Source messaging and emailing app"

--- a/Casks/handbrake-nightly.rb
+++ b/Casks/handbrake-nightly.rb
@@ -3,10 +3,10 @@ cask "handbrake-nightly" do
   sha256 :no_check
 
   url do
-    require "open-uri"
     base_url = "https://handbrake.fr/nightly.php"
-    content = URI(base_url).read
-    file_path = content[/href=["']?([^"' >]*Handbrake[._-][^"' >]+\.dmg)["' >]/i, 1]
+    result = curl_output("--fail", "--silent", base_url)
+    result.assert_success!
+    file_path = result.stdout[/href=["']?([^"' >]*Handbrake[._-][^"' >]+\.dmg)["' >]/i, 1]
     file_path ? URI.join(base_url, file_path) : nil
   end
   name "HandBrake"

--- a/Casks/keepassxc-snapshot.rb
+++ b/Casks/keepassxc-snapshot.rb
@@ -3,9 +3,10 @@ cask "keepassxc-snapshot" do
   sha256 :no_check
 
   url do
-    require "open-uri"
     base_url = "https://snapshot.keepassxc.org/latest/"
-    path = URI(base_url).read[/href="([^"]+-snapshot\.dmg)"/, 1]
+    result = curl_output("--fail", "--silent", base_url)
+    result.assert_success!
+    path = result.stdout[/href="([^"]+-snapshot\.dmg)"/, 1]
     "#{base_url}#{path}"
   end
   name "KeePassXC"

--- a/Casks/sequel-pro-nightly.rb
+++ b/Casks/sequel-pro-nightly.rb
@@ -3,11 +3,9 @@ cask "sequel-pro-nightly" do
   sha256 :no_check
 
   url do
-    require "resolv-replace"
-    require "open-uri"
-    URI("https://sequelpro.com/builds/latest-test-build.xml").open do |page|
-      page.read[%r{https://sequelpro.com/builds/Sequel-Pro-Build-\w+.zip}]
-    end
+    result = curl_output("--fail", "--silent", "https://sequelpro.com/builds/latest-test-build.xml")
+    result.assert_success!
+    result.stdout[%r{https://sequelpro.com/builds/Sequel-Pro-Build-\w+.zip}]
   end
   name "Sequel Pro"
   homepage "https://sequelpro.com/test-builds"

--- a/Casks/slicer-preview.rb
+++ b/Casks/slicer-preview.rb
@@ -3,10 +3,11 @@ cask "slicer-preview" do
   sha256 :no_check
 
   url do
-    require "open-uri"
     require "json"
     base_url = "https://download.slicer.org"
-    "#{base_url}/#{JSON.parse(URI("#{base_url}/find?os=macosx&stability=nightly").read)["download_url"]}"
+    result = curl_output("--fail", "--silent", "#{base_url}/find?os=macosx&stability=nightly")
+    result.assert_success!
+    "#{base_url}/#{JSON.parse(result.stdout)["download_url"]}"
   end
   name "3D Slicer"
   desc "Medical image processing and visualization system"

--- a/Casks/thunderbird-daily.rb
+++ b/Casks/thunderbird-daily.rb
@@ -19,10 +19,11 @@ cask "thunderbird-daily" do
   end
 
   url do
-    require "open-uri"
     base_url = "https://download-installer.cdn.mozilla.net/pub/thunderbird/nightly"
     builds_url = "#{base_url}/latest-comm-central#{language == "en-US" ? "" : "-l10n"}/"
-    latest_build_filename = URI(builds_url).open.read.scan(%r{<td><a href="/pub/thunderbird/nightly/([^"]+\.mac\.dmg)">}).flatten.grep(/\.#{language}\.mac\.dmg/).last
+    result = curl_output("--fail", "--silent", builds_url)
+    result.assert_success!
+    latest_build_filename = result.stdout.scan(%r{<td><a href="/pub/thunderbird/nightly/([^"]+\.mac\.dmg)">}).flatten.grep(/\.#{language}\.mac\.dmg/).last
     "#{base_url}/#{latest_build_filename}"
   end
   name "Earlybird"

--- a/Casks/tla-plus-toolbox-nightly.rb
+++ b/Casks/tla-plus-toolbox-nightly.rb
@@ -3,9 +3,10 @@ cask "tla-plus-toolbox-nightly" do
   sha256 :no_check
 
   url do
-    require "open-uri"
     base_url = "https://tla.msr-inria.inria.fr/tlatoolbox/ci/products/"
-    file = URI(base_url).read[/href="([^"]+-macosx.cocoa.x86_64.zip)"/, 1]
+    result = curl_output("--fail", "--silent", base_url)
+    result.assert_success!
+    file = result.stdout[/href="([^"]+-macosx.cocoa.x86_64.zip)"/, 1]
     "#{base_url}#{file}"
   end
   name "TLA+ Toolbox"

--- a/Casks/transmission-nightly.rb
+++ b/Casks/transmission-nightly.rb
@@ -3,9 +3,10 @@ cask "transmission-nightly" do
   sha256 :no_check
 
   url do
-    require "open-uri"
     base_url = "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/"
-    file = URI(base_url).read[/href="([^"]+.dmg)"/, 1]
+    result = curl_output("--fail", "--silent", base_url)
+    result.assert_success!
+    file = result.stdout[/href="([^"]+.dmg)"/, 1]
     "#{base_url}#{file}"
   end
   name "Transmission"

--- a/Casks/vlc-nightly.rb
+++ b/Casks/vlc-nightly.rb
@@ -3,11 +3,14 @@ cask "vlc-nightly" do
   sha256 :no_check
 
   url do
-    require "open-uri"
     base_url = "https://artifacts.videolan.org/vlc/nightly-macos/"
-    folder = URI(base_url).read[/\d+-\d+/]
+    result = curl_output("--fail", "--silent", base_url)
+    result.assert_success!
+    folder = result.stdout[/\d+-\d+/]
     updated_url = "#{base_url}#{folder}/"
-    file = URI.join(updated_url).read[/href="([^"]+.dmg)"/, 1]
+    result = curl_output("--fail", "--silent", updated_url)
+    result.assert_success!
+    file = result.stdout[/href="([^"]+.dmg)"/, 1]
     "#{updated_url}#{file}"
   end
   name "VLC media player"


### PR DESCRIPTION
The Homebrew/brew CI is constantly seeing flaky audit failures for `gpg-suite-nightly`. Upon further investigation, it appears that the DNS for releases.gpgtools.org contains multiple IPs, and some don't respond.

open-uri does not try another IP when one fails, but curl does. Curl also has better proxy and HTTPS support (there are known issues with open-uri certificate handling under portable-ruby). Moving to curl also aligns these network requests with what the rest of Homebrew does.