### PR TITLE
Add Dash5

### DIFF
--- a/Casks/dash5.rb
+++ b/Casks/dash5.rb
@@ -1,0 +1,30 @@
+cask "dash5" do
+  version "5.5.2,950"
+  sha256 "cd98b4496bfa82ff2cd4c98f7d8a35eb83b909b7da605eb291d12a0c162c24a8"
+
+  url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"
+  name "Dash"
+  desc "API documentation browser and code snippet manager"
+  homepage "https://kapeli.com/dash"
+
+  livecheck do
+    url "https://kapeli.com/Dash#{version.major}.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+
+  app "Dash.app"
+
+  zap trash: [
+    "~/Library/Application Support/Dash",
+    "~/Library/Application Support/com.kapeli.dashdoc",
+    "~/Library/Caches/com.kapeli.dashdoc",
+    "~/Library/Cookies/com.kapeli.dashdoc.binarycookies",
+    "~/Library/HTTPStorages/com.kapeli.dashdoc.binarycookies",
+    "~/Library/Logs/Dash",
+    "~/Library/Preferences/com.kapeli.dashdoc.plist",
+    "~/Library/Saved Application State/com.kapeli.dashdoc.savedState",
+    "~/Library/WebKit/com.kapeli.dashdoc",
+  ]
+end


### PR DESCRIPTION
[This commit](https://github.com/Homebrew/homebrew-cask/commit/16f9bc9655416a7ceef052a05b926cbdd7182e36#diff-88a2c2f9dc7af00a109448a32098f7bd124c5f41eb41ba3ba820d715db5b233b) updated the `Dash` cask, making it impossible for owners of a Dash5 license to install their required version using brew. As `dash2`, `dash3` and `dash4` already exists, I thought it makes sense to add `dash5` too. 😸

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
