### PR TITLE
Update visual-studio-code-insiders from 1.55.0,469e4f6e2755b220dae3eccb04d1ddc587b84a5a to 1.55.0,a6f6b4aa8e3a688d9a5cbcd5df14af511ce2bd8e

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.55.0,469e4f6e2755b220dae3eccb04d1ddc587b84a5a"
+  version "1.55.0,a6f6b4aa8e3a688d9a5cbcd5df14af511ce2bd8e"
 
   if Hardware::CPU.intel?
-    sha256 "aa6c1751b104f2b79126f2615bda92551766644ff510be4a2e110217cdf27ea6"
+    sha256 "9aec29de9ecfdfeedec1e9a06afc1021c8c8c1f8015258a9d9e0c849a103b432"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "e73d2603b7c253d7367136d8a35aaded7b64e87e5d7891dd22c52c748d522c63"
+    sha256 "be1596114d0d2f3a0c40366b8a5daed5f01c51c166070990fb5e003843960a3b"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump.