### PR TITLE
Update visual-studio-code-insiders from 1.55.0,6ebe2a14f3722bc2582ecd8108d0a71dfdd46036 to 1.55.0,d06d2f1d6245ce00b1c36a9cd81a9087d225173e

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.55.0,6ebe2a14f3722bc2582ecd8108d0a71dfdd46036"
+  version "1.55.0,d06d2f1d6245ce00b1c36a9cd81a9087d225173e"
 
   if Hardware::CPU.intel?
-    sha256 "cee76083132ef349df5a3475890e87ba4980d956c8656b914189ea488be8bb39"
+    sha256 "b2f6df8ced8f8447f1d1daf238312ef93d1a0275f768748336fe0d8318d00a9a"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "2ed0443a95f502bb81c483742d3932e4c290d1da3cd16e43c00da52a12a3b680"
+    sha256 "797156731cb6193aa6d1f166a107bc61959f421a162cce5744b3ef58241235d6"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump