### PR TITLE
Update visual-studio-code-insiders from 1.55.0,4c2a1fa6306c17d0f1affb6759d22fc87f2b6b99 to 1.55.0,c185983a683d14c396952dd432459097bc7f757f

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,14 +1,14 @@
 cask "visual-studio-code-insiders" do
-  version "1.55.0,4c2a1fa6306c17d0f1affb6759d22fc87f2b6b99"
+  version "1.55.0,c185983a683d14c396952dd432459097bc7f757f"
 
   if Hardware::CPU.intel?
-    sha256 "4fe8735b82135e5916cea71514021916255a40a029bb25984d7a3939e199aaa4"
+    sha256 "9f513475598be22b090c5db3c10c14d2a25566c79fadf989888cb7440ebfede9"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
     appcast "https://update.code.visualstudio.com/api/update/darwin/insider/VERSION"
   else
-    sha256 "8dc818fbc05386277337520c20fc8c2a29978642cd71bf4a7b8c42472e556fd0"
+    sha256 "038133f0fd98df8d8205a15d82f15d979e771c3a778746441d5b7e6b23c82b5a"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Bump