### PR TITLE
Update visual-studio-code-insiders from 1.56.0,94d369e27d19f598228961e9feb0413f2edabe5d to 1.56.0,25785b97e533b15ae3b12e48aaf4187416437e62

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,13 +1,13 @@
 cask "visual-studio-code-insiders" do
-  version "1.56.0,94d369e27d19f598228961e9feb0413f2edabe5d"
+  version "1.56.0,25785b97e533b15ae3b12e48aaf4187416437e62"
 
   if Hardware::CPU.intel?
-    sha256 "627489095a6f0d2779dfcac91d7837fe199addcbceedc5d9409129bae9d41e54"
+    sha256 "495208e8ecb05577c02d8facb1c0583f55a250a03c4900d2bc41323159c335c0"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
   else
-    sha256 "e382f6fdce459d310d92ab917b93d70a22e14392e90a1accbb5e262973360a7e"
+    sha256 "b089fa2f0b527685b85fca63b33a33a0a4bcc67eb985b17b35313853c8c283b7"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump from `1.56.0,94d369e27d19f598228961e9feb0413f2edabe5d` to `1.56.0,25785b97e533b15ae3b12e48aaf4187416437e62`.