### PR TITLE
Update sketch-beta to 72-123734 and add livecheck

### DIFF
--- a/Casks/sketch-beta.rb
+++ b/Casks/sketch-beta.rb
@@ -1,14 +1,20 @@
 cask "sketch-beta" do
-  version "71.0-112664"
-  sha256 :no_check
+  version "72-123734"
+  sha256 "c4fd1f3be51a195a48d80442263bbc5f4ec249e2ad79866ea39b4a0bdf9d447a"
 
-  url "https://beta-download.sketch.com/sketch.zip"
+  url "https://beta-download.sketch.com/sketch-#{version}.zip"
   name "Sketch"
   desc "Digital design and prototyping platform"
   homepage "https://www.sketch.com/beta"
 
+  livecheck do
+    url "https://beta-download.sketch.com/sketch-versions.xml"
+    strategy :page_match
+    regex(%r{url=.*?/sketch-(\d+(?:\.\d+)*-\d+)\.zip}i)
+  end
+
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :catalina"
 
   app "Sketch Beta.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Casks.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

### Notes:
- Issue using `:sparkle` due to some empty `<pubDate/>`
- New min version from https://www.sketch.com/beta/:
   > Requires macOS Catalina (10.15.0) or newer
- Switched to versioned URL.