### PR TITLE
Update sublime-merge-dev from 2006 to 2051 and add livecheck

### DIFF
--- a/Casks/sublime-merge-dev.rb
+++ b/Casks/sublime-merge-dev.rb
@@ -1,12 +1,18 @@
 cask "sublime-merge-dev" do
-  version "2006"
-  sha256 "75f38772afb42cccb66b23acdaf08232b2ea340322085e7105236a5d4fe943f5"
+  version "2051"
+  sha256 "e1853776f790bab8e44a52b6f0b0993213c3fb53b260da6fa6766d0c9698d0f2"
 
   url "https://download.sublimetext.com/sublime_merge_build_#{version}_mac.zip",
       verified: "download.sublimetext.com/"
-  appcast "https://www.sublimemerge.com/updates/dev_update_check"
   name "Sublime Merge"
+  desc "Git client"
   homepage "https://www.sublimemerge.com/dev"
+
+  livecheck do
+    url "https://www.sublimemerge.com/updates/dev_update_check"
+    strategy :page_match
+    regex(/"latest_version":\s*(\d+)/i)
+  end
 
   auto_updates true
   conflicts_with cask: "sublime-merge"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
