### PR TITLE
Update rstudio-preview from 1.4.1114 to 1.4.1118

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,10 +1,11 @@
 cask "rstudio-preview" do
-  version "1.4.1114"
-  sha256 "2b87318dd608086b806aec31371852ac7dccc271732df7d0e915e091af7d531e"
+  version "1.4.1118"
+  sha256 "6ac3e278ff1533612a1153cbe08d0b2effb0993319b081a556a8b0f6a31da7c4"
 
   url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version}.dmg",
       verified: "s3.amazonaws.com/rstudio-ide-build/"
   name "RStudio"
+  desc "Data science software focusing on R and Python"
   homepage "https://www.rstudio.com/products/rstudio/download/preview/"
 
   livecheck do
@@ -12,6 +13,9 @@ cask "rstudio-preview" do
     strategy :page_match
     regex(/RStudio-(\d+(?:\.\d+)*)\.dmg/i)
   end
+
+  conflicts_with cask: "rstudio"
+  depends_on macos: ">= :high_sierra"
 
   app "RStudio.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/rstudio.rb
> conflicts_with cask: "homebrew/cask-versions/rstudio-preview"