### PR TITLE
docker-edge: mark discontinued as Edge channel has been removed

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -3,7 +3,6 @@ cask "docker-edge" do
   sha256 "5d63435e322494be1113c0e25474fd55db4b06563abc2c0f9697db54584d1595"
 
   url "https://desktop.docker.com/mac/edge/#{version.after_comma}/Docker.dmg"
-  appcast "https://desktop.docker.com/mac/edge/appcast.xml"
   name "Docker Community Edition for Mac (Edge)"
   name "Docker CE for Mac (Edge)"
   desc "App to build and share containerized applications and microservices"
@@ -53,4 +52,12 @@ cask "docker-edge" do
         "~/Library/Caches/KSCrashReports",
         "~/Library/Caches/com.plausiblelabs.crashreporter.data",
       ]
+
+  caveats do
+    discontinued
+    <<~EOS
+      Starting with Docker Desktop 3.0.0, Stable and Edge releases
+      are combined into a single, cumulative release stream.
+    EOS
+  end
 end

--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -8,6 +8,10 @@ cask "docker-edge" do
   desc "App to build and share containerized applications and microservices"
   homepage "https://www.docker.com/products/docker-desktop"
 
+  livecheck do
+    skip "Discontinued"
+  end
+
   auto_updates true
   depends_on macos: ">= :mojave"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Sources

Blog: https://www.docker.com/blog/docker-desktop-3-0-0-smaller-faster-releases/
>  Finally, we are removing the Stable and Edge channels, and moving to a single release stream for all users.

FAQ: https://docs.docker.com/desktop/faqs/#where-can-i-find-information-about-stable-and-edge-releases
> Starting with Docker Desktop 3.0.0, Stable and Edge releases are combined into a single, cumulative release stream for all users.

Appcast: https://desktop.docker.com/mac/edge/appcast.xml
Ends up redirecting to: https://desktop.docker.com/mac/stable/amd64/appcast.xml