### PR TITLE
discord-ptb and discord-canary livecheck

### DIFF
--- a/Casks/discord-canary.rb
+++ b/Casks/discord-canary.rb
@@ -2,11 +2,16 @@ cask "discord-canary" do
   version "0.0.267"
   sha256 "1ac8acc1f400b9d7ec47e4ba3e8fedf776fafbae62398cd7b1b514f12729abae"
 
-  url "https://cdn-canary.discordapp.com/apps/osx/#{version}/DiscordCanary.dmg",
-      verified: "cdn-canary.discordapp.com/apps/osx/"
-  appcast "https://canary.discord.com/api/canary/updates?platform=osx"
+  url "https://dl-canary.discordapp.net/apps/osx/#{version}/DiscordCanary.dmg",
+      verified: "dl-canary.discordapp.net/"
   name "Discord Canary"
+  desc "Voice and text chat software"
   homepage "https://canary.discord.com/"
+
+  livecheck do
+    url "https://discord.com/api/download/canary?platform=osx"
+    strategy :header_match
+  end
 
   auto_updates true
 

--- a/Casks/discord-ptb.rb
+++ b/Casks/discord-ptb.rb
@@ -1,11 +1,17 @@
 cask "discord-ptb" do
-  version "0.0.53"
-  sha256 "3b755ddfa65c680d6c91ab5edb445c51c2a4102860faaea0ee78ce13984c3223"
+  version "0.0.54"
+  sha256 "fb877a47ea74b6ef5b0e75dc160440aa574992540e6d53b456d617d068925114"
 
-  url "https://cdn-ptb.discordapp.com/apps/osx/#{version}/DiscordPTB.dmg"
-  appcast "https://discordapp.com/api/ptb/updates?platform=osx"
+  url "https://dl-ptb.discordapp.net/apps/osx/#{version}/DiscordPTB.dmg",
+      verified: "dl-ptb.discordapp.net/"
   name "Discord PTB"
-  homepage "https://discordapp.com/"
+  desc "Voice and text chat software"
+  homepage "https://discord.com/"
+
+  livecheck do
+    url "https://discord.com/api/download/ptb?platform=osx"
+    strategy :header_match
+  end
 
   app "Discord PTB.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Notes
- https://discordapp.com/ --> https://discord.com/
- PTB install link from https://discord.com/download:
  - URL is https://discord.com/api/download/ptb?platform=osx
  - Redirects to https://dl-ptb.discordapp.net/apps/osx/0.0.54/DiscordPTB.dmg
- Canary install link from https://support.discord.com/hc/en-us/articles/360035675191-Desktop-PTB-and-Canary-Clients:
  - URL is https://discord.com/api/download/canary?platform=osx
  - Redirects to https://dl-canary.discordapp.net/apps/osx/0.0.267/DiscordCanary.dmg