### PR TITLE
safari-technology-preview: add livecheck

### DIFF
--- a/Casks/safari-technology-preview.rb
+++ b/Casks/safari-technology-preview.rb
@@ -8,10 +8,19 @@ cask "safari-technology-preview" do
   end
 
   url "https://secure-appldnld.apple.com/STP/#{version.after_comma}/SafariTechnologyPreview.dmg"
-  appcast "https://developer.apple.com/safari/download/"
   name "Safari Technology Preview"
   desc "Web browser"
   homepage "https://developer.apple.com/safari/download/"
+
+  livecheck do
+    url :homepage
+    strategy :page_match do |page|
+      macos_version = MacOS.version.to_s.gsub(".", "\\.")
+      release = page[%r{Release</p>\s*<p.*?>(\d+)</p>}i, 1]
+      id = page[%r{href=.*?/([0-9a-f]+(?:-[0-9a-f]+)*)/SafariTechnologyPreview\.dmg.*?macOS\s*#{macos_version}\.}i, 1]
+      "#{release},#{id}"
+    end
+  end
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Release HTML
```html
<div class="column large-2 small-12 gutter padding-bottom-small text-right">
	<p class="sosumi no-margin-bottom margin-top-small">Release</p>
	<p class="smaller lighter no-margin">123</p>
```

### URL HTML
```html
<li class="dmg"><a class="inline" href="https://secure-appldnld.apple.com/STP/071-23628-20210330-8224de12-9cd5-4c33-b944-149b5f4cd543/SafariTechnologyPreview.dmg">Safari Technology Preview for macOS Big Sur</a><br><span class="smaller lighter nowrap nowrap-small">Requires macOS 11.</span></li>
<li class="dmg"><a class="inline" href="https://secure-appldnld.apple.com/STP/071-23564-20210330-f6b89a7f-4800-4af7-93cb-0dbb005db0e8/SafariTechnologyPreview.dmg">Safari Technology Preview for macOS Catalina</a><br><span class="smaller lighter nowrap nowrap-small">Requires macOS 10.15.</span></li>
```

### Archive.org copy (2018) of URL HTML
```html
<li class="dmg"><a class="inline" href="https://web.archive.org/web/20180105003152/https://secure-appldnld.apple.com/STP/091-56396-20171220-165D5240-E4E0-11E7-BC97-BB5AB072E13B/SafariTechnologyPreview.dmg">Safari Technology Preview for macOS High Sierra</a><br><span class="smaller nowrap nowrap-small">Requires macOS 10.13.</span></li>
<li class="dmg"><a class="inline" href="https://web.archive.org/web/20180105003152/https://secure-appldnld.apple.com/STP/091-56401-20171220-165D5556-E4E0-11E7-BAF0-D5AB2772752F/SafariTechnologyPreview.dmg">Safari Technology Preview for macOS Sierra</a><br><span class="smaller nowrap nowrap-small">Requires macOS 10.12.6 or later.</span></li>
```