### PR TITLE
Update chromedriver-beta from 87.0.4280.20 to 91.0.4472.19 and add livecheck

### DIFF
--- a/Casks/chromedriver-beta.rb
+++ b/Casks/chromedriver-beta.rb
@@ -1,12 +1,18 @@
 cask "chromedriver-beta" do
-  version "87.0.4280.20"
-  sha256 "99e98317a5f883d53973a044778f81abe71b42c570fb35f75786f86ea617bd1a"
+  version "91.0.4472.19"
+  sha256 "c23d8244cff767fc1c9bc259fb86fece0124d1eba9645397fe7903100e98651f"
 
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip",
       verified: "chromedriver.storage.googleapis.com/"
   name "ChromeDriver"
   desc "Automated testing of webapps for Google Chrome"
-  homepage "https://sites.google.com/a/chromium.org/chromedriver/home"
+  homepage "https://sites.google.com/chromium.org/driver/"
+
+  livecheck do
+    url :homepage
+    strategy :page_match
+    regex(/Latest\s*beta\s*release:.*?ChromeDriver\s*(\d+(?:\.\d+)*)/i)
+  end
 
   conflicts_with cask: "chromedriver"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Changed homepage based on migration note: https://sites.google.com/a/chromium.org/chromedriver/home
> Please note that we are migrating to a new ChromeDriver site.
> Current site will be deprecated soon.