### PR TITLE
Update background-music-pre to 0.4.0-SNAPSHOT-b38f6dd and add livecheck

### DIFF
--- a/Casks/background-music-pre.rb
+++ b/Casks/background-music-pre.rb
@@ -1,11 +1,18 @@
 cask "background-music-pre" do
-  version "0.4.0-SNAPSHOT-c0ab98b"
-  sha256 "7fdbcab0542c496cb37f3f958b63d4ec2cd2fe1ce1debbcdf0cf6cb5f1226384"
+  version "0.4.0-SNAPSHOT-b38f6dd"
+  sha256 "7a62b0f505a3695e6e2d6055c363f6f018fcefb2bdf5054e8a0463d744ac9886"
 
   url "https://github.com/kyleneideck/BackgroundMusic/releases/download/#{version}/BackgroundMusic-#{version}.pkg"
-  appcast "https://github.com/kyleneideck/BackgroundMusic/releases.atom"
   name "Background Music"
+  desc "Audio utility"
   homepage "https://github.com/kyleneideck/BackgroundMusic"
+
+  livecheck do
+    url "https://github.com/kyleneideck/BackgroundMusic/releases.atom"
+    strategy :page_match do |page|
+      page[%r{href=.*?/tag/(\d+(?:\.\d+)*-SNAPSHOT-[0-9a-f]+)}i, 1]
+    end
+  end
 
   conflicts_with cask: "background-music"
   depends_on macos: ">= :yosemite"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Notes
- Update to latest pre-release shown at https://github.com/kyleneideck/BackgroundMusic/releases
- For `livecheck`:
  - Version numbers aren't incremental due to using commit IDs for snapshots `c0ab98b -> b38f6dd`
  - Due to above, couldn't use `regex(...)` or `:git` strategy as they try to order results.
  - Currently used workaround was the `do |page| ... end` section to just return 1st match
  - Another alternative would be to include timestamps in version so that version numbers are ordered.