### PR TITLE
Update qgis-ltr from 3.16.4 to 3.16.5,20210319_161904 and add livecheck

### DIFF
--- a/Casks/qgis-ltr.rb
+++ b/Casks/qgis-ltr.rb
@@ -1,13 +1,19 @@
 cask "qgis-ltr" do
-  version "3.16.4"
-  sha256 :no_check
+  version "3.16.5,20210319_161904"
+  sha256 "26faf0b2d0d871a4a5f32fc904e8f7398d9d5eeb0dc7ae596835967f54ecc39f"
 
-  url "https://qgis.org/downloads/macos/qgis-macos-ltr.dmg"
-  appcast "https://qgis.org/downloads/macos/qgis-macos-ltr.sha256sum",
-          must_contain: version.dots_to_underscores
+  url "https://qgis.org/downloads/macos/ltr/qgis_ltr_final-#{version.before_comma.dots_to_underscores}_#{version.after_comma}.dmg"
   name "QGIS LTR"
   desc "Geographic Information System"
   homepage "https://www.qgis.org/"
+
+  livecheck do
+    url "https://qgis.org/downloads/macos/qgis-macos-ltr.sha256sum"
+    strategy :page_match do |page|
+      match = page.match(/qgis_ltr_final-(\d+(?:_\d+)*)_(\d+_\d+)\.dmg/i)
+      "#{match[1].tr("_", ".")},#{match[2]}"
+    end
+  end
 
   app "QGIS-LTR.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

It looks like successful latest DMG built in https://qgis.org/downloads/macos/ltr/ is copied to https://qgis.org/downloads/macos/qgis-macos-ltr.dmg

Based on this, I changed URL to point to versioned DMG to allow checking `sha256`.
Can change back if any issues.