### PR TITLE
Add xampp7 cask with XAMPP 7.4.16 installer

### DIFF
--- a/Casks/xampp7.rb
+++ b/Casks/xampp7.rb
@@ -1,0 +1,30 @@
+cask "xampp7" do
+  version "7.4.16-0"
+  sha256 "be2ae9f742249b4d8f474b5cc320478813a0495b604671fd27d4c6f72963e839"
+
+  url "https://downloadsapachefriends.global.ssl.fastly.net/xampp-files/#{version.split("-").first}/xampp-osx-#{version}-installer.dmg",
+      verified: "downloadsapachefriends.global.ssl.fastly.net/xampp-files/"
+  name "XAMPP"
+  desc "Apache distribution containing MySQL, PHP 7, and Perl"
+  homepage "https://www.apachefriends.org/index.html"
+
+  livecheck do
+    url "https://www.apachefriends.org/download.html"
+    strategy :page_match
+    regex(%r{href=.*?/xampp-osx-(7(?:\.\d+)*-\d+)-installer\.dmg}i)
+  end
+
+  installer script: {
+    executable: "XAMPP.app/Contents/MacOS/osx-x86_64",
+    args:       ["--mode", "unattended"],
+    sudo:       true,
+  }
+
+  uninstall quit:   "com.bitnami.manager",
+            script: {
+              executable: "/Applications/XAMPP/uninstall.app/Contents/MacOS/osx-x86_64",
+              args:       ["--mode", "unattended"],
+              sudo:       true,
+            },
+            delete: "/Applications/XAMPP/"
+end

--- a/Casks/xampp7.rb
+++ b/Casks/xampp7.rb
@@ -14,6 +14,8 @@ cask "xampp7" do
     regex(%r{href=.*?/xampp-osx-(7(?:\.\d+)*-\d+)-installer\.dmg}i)
   end
 
+  conflicts_with cask: "xampp"
+
   installer script: {
     executable: "XAMPP.app/Contents/MacOS/osx-x86_64",
     args:       ["--mode", "unattended"],


### PR DESCRIPTION
### Related https://github.com/Homebrew/homebrew-cask/pull/104095 and https://github.com/Homebrew/homebrew-cask/pull/104777
**This cask depends on whether main `xampp` Cask is updated to 8.0.3**

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

---

Copy https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/xampp.rb for older XAMPP **7.4.16**

```diff
❯ diff xampp7.rb ../../homebrew-cask/Casks/xampp.rb
1,3c1,3
< cask "xampp7" do
<   version "7.4.16-0"
<   sha256 "be2ae9f742249b4d8f474b5cc320478813a0495b604671fd27d4c6f72963e839"
---
> cask "xampp" do
>   version "7.4.15,0"
>   sha256 "f12ef61f550627e4c0b735b69728ac6e7d37dad617f61098f6f541d61a0dd316"
5c5
<   url "https://downloadsapachefriends.global.ssl.fastly.net/xampp-files/#{version.split("-").first}/xampp-osx-#{version}-installer.dmg",
---
>   url "https://downloadsapachefriends.global.ssl.fastly.net/xampp-files/#{version.before_comma}/xampp-osx-#{version.before_comma}-#{version.after_comma}-installer.dmg",
8d7
<   desc "Apache distribution containing MySQL, PHP 7, and Perl"
11,16d9
<   livecheck do
<     url "https://www.apachefriends.org/download.html"
<     strategy :page_match
<     regex(%r{href=.*?/xampp-osx-(7(?:\.\d+)*-\d+)-installer\.dmg}i)
<   end
<
```