### PR TITLE
Update firefox-esr from 78.10.0 to 78.10.1

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,68 +1,68 @@
 cask "firefox-esr" do
-  version "78.10.0"
+  version "78.10.1"
 
   language "cs" do
-    sha256 "6da4356e2dfc3c069ce5892c7e269c1029fbd6bb11663e4c0cd125c36b62730d"
+    sha256 "afab3243d08b361ede2890ef179ed9f30e0f2be71a3f1833b0159b6c697d56fd"
     "cs"
   end
   language "de" do
-    sha256 "761c6d9559639b669c8a5398d3e776125365a1138d9322103b534c34cabb78b3"
+    sha256 "c28515d41004dcfe6184b7749623dd08ee4d5456400c900278cd80085b2686b7"
     "de"
   end
   language "en-CA" do
-    sha256 "9de3374dbac3b9e2bc8c0f0c8ddba9e74a71a3691804406abb623bbe98ac36c4"
+    sha256 "0c7820df45449e89a6ae55aaa7a826279f089493b192bb3a08372aee3b6cecdf"
     "en-CA"
   end
   language "en-GB" do
-    sha256 "49140d3bef51023e712a2b6c470b40c94d07c1bbc98c4416f608d89eb75cd388"
+    sha256 "5d13ab02acf7d7b3f9138585ab3f0d9b0b327f39cb632e0c88415ca4b5862257"
     "en-GB"
   end
   language "en", default: true do
-    sha256 "8a1e8ad6784296723582dd0f6dc27cde18ee7719ae04d3227a0e86f97a9b1bd9"
+    sha256 "ddded24f345179bda5314ab425cd8309376655a1c6b25ccd02f7116f11722700"
     "en-US"
   end
   language "fr" do
-    sha256 "3d60090bffecf77115de99007340c24dde155db82cb31eaab99465123b347989"
+    sha256 "5d4cae5860965d3ff9f1b2253e4f26127f6c74fbd0db9dd2beb4c21cab24c959"
     "fr"
   end
   language "gl" do
-    sha256 "7405fffd7cdff4cf6f4b8d3abdc75668c81cf596c2c7fe8e5a8254bfe842f0cd"
+    sha256 "4e5113570128928771c2614391a858d2eafe9d7e937406ea7a53958aeac6f856"
     "gl"
   end
   language "it" do
-    sha256 "0b44aeac3eb2358fafd72d0a1b06b9607ada33bbd0f0ff497f32b938316040db"
+    sha256 "27f9416cadf6bb5e8ee341a4beb7cfd60e64637511d19f5bd802c40ac8c05068"
     "it"
   end
   language "ja" do
-    sha256 "873e0d20712c022706c4a72d790f34901c35957ac02b623895145ce3bc9e7459"
+    sha256 "4af3c08b3e05d3ff20a2d7d5174155db10d6dd007d3656fb42945ee401e15bc2"
     "ja-JP-mac"
   end
   language "nl" do
-    sha256 "fd4cb7a55a893a3adb0ad7baacffd7da24ffc09a63aa7d9c393477221508bb42"
+    sha256 "fd21003714c1d053e723693e3be533e3f0f58102bdf114da2b2693e45610c896"
     "nl"
   end
   language "pl" do
-    sha256 "4ea63b10827e0f0ce6d35da34d17cfd02000e4d4dec1c2c7b651884e21e0e02d"
+    sha256 "d7e01a0a4f04f18e9c4e7f2980b8e9896e9ce07aa5d501649b28d6591836003e"
     "pl"
   end
   language "pt" do
-    sha256 "c2ac82a4f47eedd511ef5ba6b216afd7de2ca764f5d1aa40078411a6d35abe4b"
+    sha256 "0f18458094d7611e9020fa8701453209415c6fca67a9c8d5f3c2c003e21ecc60"
     "pt-PT"
   end
   language "ru" do
-    sha256 "6f51b4eaa0817048609a050a756fef13b3d8ea0c41bc366dff839f47f1389049"
+    sha256 "d5cfb7fa77820b6d3500fd9b904b98b37bf9238f3f88d175af066a4c61376321"
     "ru"
   end
   language "uk" do
-    sha256 "b6d964559621a61264eaddef0013f0c3a9eafbdeb8f2869901a0f0da87959518"
+    sha256 "856988efacbfb8711edbc00481fee3fdb6ba9d1b095686d8698f2822612b95a5"
     "uk"
   end
   language "zh-TW" do
-    sha256 "bbaaa622b91ddde18073d9500a9cb02b59a1d9549e6bc1080e457844082d2660"
+    sha256 "ef043077d05f84dc772c4c50cc6469ff3a2075aa3cf632a703b5112685318639"
     "zh-TW"
   end
   language "zh" do
-    sha256 "a27de31e33bfd85267cc6f4c02079f06036fa6757f7d9fa0eacc6046f3808264"
+    sha256 "e74e3e161e3f999d5dfbb645a2667ad71f19d3c333ab365258f02a19fe95204c"
     "zh-CN"
   end
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.