### PR TITLE
Update postgres-beta from 2.3beta3 to 2.5beta1

### DIFF
--- a/Casks/postgres-beta.rb
+++ b/Casks/postgres-beta.rb
@@ -1,11 +1,12 @@
 cask "postgres-beta" do
-  version "2.3beta3,2.2.5"
-  sha256 "c63b8bff1e24cdfc8a755ae29a1ff3e17f014cfd2800364df6455357a70c0ea1"
+  version "2.5beta1"
+  sha256 "6fbb47bdbea8e45d24c5d4101f68f58056d1769def771eff00450c5d7b045994"
 
-  url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version.after_comma}/Postgres-#{version.before_comma}.dmg",
+  url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}-13-13-arm.dmg",
       verified: "github.com/PostgresApp/PostgresApp/"
   appcast "https://github.com/PostgresApp/PostgresApp/releases.atom"
   name "Postgres"
+  desc "PostgreSQL installation packaged as a standard app"
   homepage "https://postgresapp.com/"
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Newest pre-release tag from https://github.com/PostgresApp/PostgresApp/tags

Odd file naming, but it seems to be an Intel app with Intel PostgreSQL server (13) and ARM PostgreSQL server (13-arm) binaries 
> The GUI app is still built for Intel, but it runs fine with Rosetta.

---

Default `:git` livecheck thru GitHub URL probably doesn't work.
Functional livecheck may be a bit tricky since repo has legacy app tags (9.x and 10.x):
```console
❯ git ls-remote https://github.com/PostgresApp/PostgresApp | rg beta | awk '{print $2}'
refs/tags/2.1beta1
refs/tags/9.4beta1.0
refs/tags/9.4beta2-1
refs/tags/9.4beta3
refs/tags/9.5beta1.0
refs/tags/9.5beta2.0
refs/tags/9.6beta1
refs/tags/9.6beta4.1
refs/tags/v2.0-beta.1
refs/tags/v2.0-beta.2
refs/tags/v2.0-beta.3
refs/tags/v2.0-beta.4
refs/tags/v2.2beta1
refs/tags/v2.2beta2
refs/tags/v2.2beta3
refs/tags/v2.3beta1
refs/tags/v2.5beta1
```