### PR TITLE
Add Arduino 2.0 beta nightly

### DIFF
--- a/Casks/arduino-beta-nightly.rb
+++ b/Casks/arduino-beta-nightly.rb
@@ -1,0 +1,11 @@
+cask "arduino-beta-nightly" do
+  version :latest
+  sha256 :no_check
+
+  url "https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_macOS_64bit.dmg"
+  name "Arduino Beta Nightly"
+  desc "Open-source electronics prototyping platform"
+  homepage "https://www.arduino.cc/"
+
+  app "Arduino IDE.app"
+end


### PR DESCRIPTION
The nightly version of the Arduino 2.0 beta. 

The *duel wielding* suffix '-beta-nighlty' is used to prevent conflicts until either the Arduino 1.x no longer has a nightly version, or 2.0 come out of beta, which would then allow it to take over `arduino-nightly.rb`

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
