### PR TITLE
Add Royal-TSX v5 Beta

### DIFF
--- a/Casks/royal-tsx-beta.rb
+++ b/Casks/royal-tsx-beta.rb
@@ -4,7 +4,7 @@ cask "royal-tsx-beta" do
 
   url "https://royaltsx-v5.royalapps.com/updates/royaltsx_#{version}.dmg"
   name "Royal TSX"
-  desc "Powerful Connection Management"
+  desc "Remote management solution"
   homepage "https://www.royalapps.com/ts/mac/features"
 
   livecheck do
@@ -13,6 +13,7 @@ cask "royal-tsx-beta" do
   end
 
   auto_updates true
+  depends_on macos: ">= :sierra"
 
   app "Royal TSX.app"
 end

--- a/Casks/royal-tsx-beta.rb
+++ b/Casks/royal-tsx-beta.rb
@@ -16,4 +16,11 @@ cask "royal-tsx-beta" do
   depends_on macos: ">= :sierra"
 
   app "Royal TSX.app"
+
+  zap trash: [
+    "~/Library/Application Support/Royal TSX",
+    "~/Library/Application Support/com.lemonmojo.RoyalTSX.App",
+    "~/Library/Caches/com.lemonmojo.RoyalTSX.App",
+    "~/Library/Preferences/com.lemonmojo.RoyalTSX.App.plist",
+  ]
 end

--- a/Casks/royal-tsx-beta.rb
+++ b/Casks/royal-tsx-beta.rb
@@ -1,0 +1,18 @@
+cask "royal-tsx-beta" do
+  version "5.0.0.18"
+  sha256 "8c2aad10ff166e8f2962d0b8e62ec38a39176ce5cbf0d9733c6aaa023c23d34d"
+
+  url "https://royaltsx-v5.royalapps.com/updates/royaltsx_#{version}.dmg"
+  name "Royal TSX"
+  desc "Powerful Connection Management"
+  homepage "https://www.royalapps.com/ts/mac/features"
+
+  livecheck do
+    url "https://royaltsx-v#{version.major}.royalapps.com/updates_beta.php"
+    strategy :sparkle
+  end
+
+  auto_updates true
+
+  app "Royal TSX.app"
+end


### PR DESCRIPTION
Add Royal TSX v5 Beta. 
p.s. beta is created from a [stable versioned cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/royal-tsx.rb).

- [x] Beta-Version
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
