### PR TITLE
Update google-chrome livecheck

### DIFF
--- a/Casks/google-chrome-beta.rb
+++ b/Casks/google-chrome-beta.rb
@@ -8,9 +8,9 @@ cask "google-chrome-beta" do
   homepage "https://www.google.com/chrome/beta/"
 
   livecheck do
-    url "https://omahaproxy.appspot.com/history?os=mac;channel=beta"
+    url "https://chromiumdash.appspot.com/fetch_releases?channel=Beta&platform=Mac"
     strategy :page_match
-    regex(/mac,beta,(\d+(?:\.\d+)*)/i)
+    regex(/"version": "(\d+(?:\.\d+)*)"/i)
   end
 
   auto_updates true

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -1,5 +1,5 @@
 cask "google-chrome-canary" do
-  version "93.0.4524.0"
+  version "93.0.4525.0"
   sha256 :no_check
 
   url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -1,5 +1,5 @@
 cask "google-chrome-canary" do
-  version "93.0.4523.0"
+  version "93.0.4524.0"
   sha256 :no_check
 
   url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -1,5 +1,5 @@
 cask "google-chrome-canary" do
-  version "93.0.4523.3"
+  version "93.0.4523.0"
   sha256 :no_check
 
   url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -8,9 +8,9 @@ cask "google-chrome-canary" do
   homepage "https://www.google.com/chrome/canary/"
 
   livecheck do
-    url "https://omahaproxy.appspot.com/history?os=mac;channel=canary"
+    url "https://chromiumdash.appspot.com/fetch_releases?channel=Canary&platform=Mac"
     strategy :page_match
-    regex(/mac,canary,(\d+(?:\.\d+)*)/i)
+    regex(/"version": "(\d+(?:\.\d+)*)"/i)
   end
 
   auto_updates true

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -1,5 +1,5 @@
 cask "google-chrome-canary" do
-  version "93.0.4523.0"
+  version "93.0.4523.3"
   sha256 :no_check
 
   url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"

--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -8,9 +8,9 @@ cask "google-chrome-dev" do
   homepage "https://www.google.com/chrome/dev/"
 
   livecheck do
-    url "https://omahaproxy.appspot.com/history?os=mac;channel=dev"
+    url "https://chromiumdash.appspot.com/fetch_releases?channel=Dev&platform=Mac"
     strategy :page_match
-    regex(/mac,dev,(\d+(?:\.\d+)*)/i)
+    regex(/"version": "(\d+(?:\.\d+)*)"/i)
   end
 
   auto_updates true


### PR DESCRIPTION
Changed `livecheck` to a more frequently updated version of the api.

The original api prevented the livecheck for 93.0.4523.3 on `google-chrome-canary` from passing even though it was the version that was downloaded when going to the download link and the version listed on all official websites. The new api is the same one used by the [official chromium releases page](https://chromiumdash.appspot.com/releases?platform=Mac).