### PR TITLE
Add Carbon Copy Cloner v5

### DIFF
--- a/Casks/carbon-copy-cloner-5.rb
+++ b/Casks/carbon-copy-cloner-5.rb
@@ -1,0 +1,36 @@
+cask "carbon-copy-cloner-5" do
+  version "5.1.27.6196"
+  sha256 "b2edc2798f3e7497c3b2f624517909a8876b89026d181ac0c321447a6d47849f"
+
+  url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip",
+      verified: "bombich.scdn1.secure.raxcdn.com/software/files/"
+  name "Carbon Copy Cloner 5"
+  desc "Hard disk backup and cloning utility"
+  homepage "https://bombich.com/"
+
+  livecheck do
+    url "https://bombich.com/download"
+    strategy :page_match
+    regex(/href=.*?v=(5+(?:\.\d+)+)/i)
+  end
+
+  auto_updates true
+  conflicts_with cask: "carbon-copy-cloner"
+
+  app "Carbon Copy Cloner.app"
+
+  uninstall login_item: "CCC User Agent",
+            quit:       [
+              "com.bombich.ccc",
+              "com.bombich.cccuseragent",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/com.bombich.ccc",
+    "~/Library/Caches/com.bombich.ccc",
+    "~/Library/Preferences/com.bombich.ccc.plist",
+    "~/Library/Preferences/com.bombich.cccuseragent.plist",
+    "~/Library/Saved Application State/com.bombich.ccc.savedState",
+    "/Library/LaunchDaemons/com.bombich.ccchelper.plist",
+  ]
+end


### PR DESCRIPTION
The latest version (v6) of Carbon Copy Cloner requires Catalina or newer. This version supports older version of Mac OS.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
