### PR TITLE
Add citra-nightly

### DIFF
--- a/Casks/citra-nightly.rb
+++ b/Casks/citra-nightly.rb
@@ -8,6 +8,14 @@ cask "citra-nightly" do
   desc "Nintendo 3DS emulator"
   homepage "https://citra-emu.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest do |page|
+      match = page.match(%r{href=.*?/nightly[._-](\d+)/citra[._-]osx[._-](\d+[._-]\h+)\.tar\.gz}i)
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
   app "citra-osx-#{version.after_comma}/citra-qt.app"
 
   zap trash: [

--- a/Casks/citra-nightly.rb
+++ b/Casks/citra-nightly.rb
@@ -1,0 +1,19 @@
+cask "citra-nightly" do
+  version "1708,20210513-e7671d9"
+  sha256 "3d169e18e40e374d71d76ecfa0c7b856159787e1bed5e23ba252c1e676a925b5"
+
+  url "https://github.com/citra-emu/citra-nightly/releases/download/nightly-#{version.before_comma}/citra-osx-#{version.after_comma}.tar.gz",
+      verified: "github.com/citra-emu/citra-nightly/"
+  name "Citra"
+  desc "Nintendo 3DS emulator"
+  homepage "https://citra-emu.org/"
+
+  app "citra-osx-#{version.after_comma}/citra-qt.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.citra-emu.citra.plist",
+    "~/Library/Saved Application State/com.citra-emu.citra.savedState",
+    "~/.config/citra-emu",
+    "~/.local/share/citra-emu",
+  ]
+end


### PR DESCRIPTION
Nightly version of [citra](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/citra.rb).

---

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
