### PR TITLE
Update firefox-esr to 78.11.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,68 +1,68 @@
 cask "firefox-esr" do
-  version "78.10.1"
+  version "78.11.0"
 
   language "cs" do
-    sha256 "afab3243d08b361ede2890ef179ed9f30e0f2be71a3f1833b0159b6c697d56fd"
+    sha256 "25b8f1c60b0f8603b923ed57bdfb3b1a3bbd42edc00bf1af7665464bdeb08981"
     "cs"
   end
   language "de" do
-    sha256 "c28515d41004dcfe6184b7749623dd08ee4d5456400c900278cd80085b2686b7"
+    sha256 "cfda5b70a4e25b40c330f8a7a77fa061b30befbf4a170528445c9ce0f95ea892"
     "de"
   end
   language "en-CA" do
-    sha256 "0c7820df45449e89a6ae55aaa7a826279f089493b192bb3a08372aee3b6cecdf"
+    sha256 "b660a67f24058eea5626099eb057a716b3c6cda94855aea7b312f33bcab450dd"
     "en-CA"
   end
   language "en-GB" do
-    sha256 "5d13ab02acf7d7b3f9138585ab3f0d9b0b327f39cb632e0c88415ca4b5862257"
+    sha256 "b821a55668f9943206aeacca25354652c888eb8c561ea6a36ee2faec68f1a635"
     "en-GB"
   end
   language "en", default: true do
-    sha256 "ddded24f345179bda5314ab425cd8309376655a1c6b25ccd02f7116f11722700"
+    sha256 "98d4cba6a673a830b7a8c7e8280320b7515528f024222ac9b185a3db39a6ce72"
     "en-US"
   end
   language "fr" do
-    sha256 "5d4cae5860965d3ff9f1b2253e4f26127f6c74fbd0db9dd2beb4c21cab24c959"
+    sha256 "080f6bf3e48a0dc21741f7315d24baf90bb1e838cc563944bb94c4ab63bee054"
     "fr"
   end
   language "gl" do
-    sha256 "4e5113570128928771c2614391a858d2eafe9d7e937406ea7a53958aeac6f856"
+    sha256 "cd42e09c7807cd8af2adf3f2049aa033ea90a5c8d541ccf40bc5db1a9ff45d9c"
     "gl"
   end
   language "it" do
-    sha256 "27f9416cadf6bb5e8ee341a4beb7cfd60e64637511d19f5bd802c40ac8c05068"
+    sha256 "f2a85425084c7c5e1765b7afde105d491f5f78c0a1d031d80466d8d595df5fcd"
     "it"
   end
   language "ja" do
-    sha256 "4af3c08b3e05d3ff20a2d7d5174155db10d6dd007d3656fb42945ee401e15bc2"
+    sha256 "5d046f84245261a738e776e334b5129f96149b6e3b6be4af91f409c15826fbfb"
     "ja-JP-mac"
   end
   language "nl" do
-    sha256 "fd21003714c1d053e723693e3be533e3f0f58102bdf114da2b2693e45610c896"
+    sha256 "d26a4dd8f8056a8abcc222fa7ae5fb6c617b117cf0e9a8fa8bbbab25a40d1940"
     "nl"
   end
   language "pl" do
-    sha256 "d7e01a0a4f04f18e9c4e7f2980b8e9896e9ce07aa5d501649b28d6591836003e"
+    sha256 "1d8731753232bbb65e36308e8d0173460a5c15060e96c327c91a6192e75a811d"
     "pl"
   end
   language "pt" do
-    sha256 "0f18458094d7611e9020fa8701453209415c6fca67a9c8d5f3c2c003e21ecc60"
+    sha256 "4188b934bc2acb40f2eb0db4f2009400c3d6fc45e953bb31e5c06528c32b3302"
     "pt-PT"
   end
   language "ru" do
-    sha256 "d5cfb7fa77820b6d3500fd9b904b98b37bf9238f3f88d175af066a4c61376321"
+    sha256 "f4f30d7e2d2806ce45d9d8e861e3fad92c0676b99f8c8e5637998b77603391ff"
     "ru"
   end
   language "uk" do
-    sha256 "856988efacbfb8711edbc00481fee3fdb6ba9d1b095686d8698f2822612b95a5"
+    sha256 "febdc5e724b1ba0832f2054e21a57e2538e89d15a58a51b22b2c84db6c6cdf03"
     "uk"
   end
   language "zh-TW" do
-    sha256 "ef043077d05f84dc772c4c50cc6469ff3a2075aa3cf632a703b5112685318639"
+    sha256 "2c6973cba801a2e7ed2382a8c56e9afb3df7ae5114f4c0e6236bd38c64d7c058"
     "zh-TW"
   end
   language "zh" do
-    sha256 "e74e3e161e3f999d5dfbb645a2667ad71f19d3c333ab365258f02a19fe95204c"
+    sha256 "f836fe84a5cb767bf70a7b11b8fce2b0bff27956608c142e25fc3d5d7b38f40b"
     "zh-CN"
   end
 


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/78.11.0/releasenotes/

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

