### PR TITLE
Provide vagrant 2.2.15

### DIFF
--- a/Casks/vagrant2-2-15.rb
+++ b/Casks/vagrant2-2-15.rb
@@ -1,0 +1,33 @@
+# This is provided because 2.2.16 has a bug where it cannot be used with
+# RSA SHA1 ssh keys which makes it impossible to use with vagrant-aws as
+# well as any other platform that only supports RSA SHA1 keys. There's
+# been no activity from the vagrant maintainers to fix this so until
+# something's done about it it should be easy to install 2.2.15.
+#
+# https://github.com/hashicorp/vagrant/issues/12344
+cask "vagrant2-2-15" do
+  version "2.2.15"
+  sha256 "5c2b290c4fa2371e255c56b1e96ded3d0c838d54cb7f0e8e6cf154e9f206a20e"
+
+  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_x86_64.dmg",
+      verified: "hashicorp.com/vagrant/"
+  name "Vagrant"
+  desc "Development environment"
+  homepage "https://www.vagrantup.com/"
+
+  livecheck do
+    url "https://github.com/hashicorp/vagrant"
+    strategy :git
+  end
+
+  pkg "vagrant.pkg"
+
+  uninstall script:  {
+    executable: "uninstall.tool",
+    input:      ["Yes"],
+    sudo:       true,
+  },
+            pkgutil: "com.vagrant.vagrant"
+
+  zap trash: "~/.vagrant.d"
+end


### PR DESCRIPTION
This is provided because 2.2.16 has a bug where it cannot be used with
RSA SHA1 ssh keys which makes it impossible to use with vagrant-aws as
well as any other platform that only supports RSA SHA1 keys. There's
been no activity from the vagrant maintainers to fix this so until
something's done about it it should be easy to install 2.2.15. I believe
this qualifies as a 'clear demonstrable need'.

https://github.com/hashicorp/vagrant/issues/12344

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [-] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).

  I see some issues regarding older Vagrant versions being refused. At the
  same time I think this submission should at least be considered based on
  the 'clear demonstrable need' of anyone needing to use varant to
  interact with computer providers that require the use of SHA1 RSA keys.

- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.