### PR TITLE
Update visual-studio-code-insiders from 1.57.0,a62df5d6c53e844bfdc50694f943c3f34b6ff50e to 1.57.0,fe1eafc80c07608de52a2f9c99fee103dea77f5e

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,13 +1,13 @@
 cask "visual-studio-code-insiders" do
-  version "1.57.0,a62df5d6c53e844bfdc50694f943c3f34b6ff50e"
+  version "1.57.0,fe1eafc80c07608de52a2f9c99fee103dea77f5e"
 
   if Hardware::CPU.intel?
-    sha256 "c0c23b5d5aee2e6a48e43eb0a07e0ed8e6518c25a1c0eea3a59aba0b8a191c21"
+    sha256 "351da0a148512c0a34f51117b230e31da23f3a24f72cbb551fabfe5de7b52149"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
   else
-    sha256 "a39ed2d4eb742b416180903b7152b2d19b4cd0d118064e3e94824e0518eed772"
+    sha256 "c6a465f8b46570e2ffe5a7dd644d4bae5f05c1d338f216f7e2513a8003c469fc"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump from `1.57.0,a62df5d6c53e844bfdc50694f943c3f34b6ff50e` to `1.57.0,fe1eafc80c07608de52a2f9c99fee103dea77f5e`.