### PR TITLE
Update visual-studio-code-insiders from 1.57.0,c7119ae8b6390a5700f6b28f0f1511d676c96562 to 1.57.0,b4c1bd0a9b03c749ea011b06c6d2676c8091a70c

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,13 +1,13 @@
 cask "visual-studio-code-insiders" do
-  version "1.57.0,c7119ae8b6390a5700f6b28f0f1511d676c96562"
+  version "1.57.0,b4c1bd0a9b03c749ea011b06c6d2676c8091a70c"
 
   if Hardware::CPU.intel?
-    sha256 "4b47c868170ebce8b8618eedc49f8153ae67ad80e1ad887e75ee771c7bd4ce15"
+    sha256 "5302f27b67e6833d32f9b8ce8d075d4dcec450d19fccd97fbd038f846eee79d9"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
   else
-    sha256 "9cee0698d971df9e780ba7e17e10e24b0af0b025ef9d6bf9320a2153c0068a0a"
+    sha256 "ce3c0a9f2d88b59f99a6d5dcf6f7828564a37c3fdcf51ba36f7f3d5ac8fd0537"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump from `1.57.0,c7119ae8b6390a5700f6b28f0f1511d676c96562` to `1.57.0,b4c1bd0a9b03c749ea011b06c6d2676c8091a70c`.