### PR TITLE
Remove livecheck from discontinued casks

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -8,10 +8,6 @@ cask "docker-edge" do
   desc "App to build and share containerized applications and microservices"
   homepage "https://www.docker.com/products/docker-desktop"
 
-  livecheck do
-    skip "Discontinued"
-  end
-
   auto_updates true
   depends_on macos: ">= :mojave"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR is related to Homebrew/homebrew-cask#107275, which removes `livecheck` blocks from discontinued casks. `brew livecheck` will automatically skip a cask if it's discontinued and a `livecheck` block isn't present in the cask (i.e., having a `livecheck` block in a discontinued cask overrides the automatic skip).

The cask in this PR uses `skip "Discontinued"`, which unnecessarily duplicates the automatic skip for discontinued casks. Without this `livecheck` block, `docker-edge` will continue to be correctly skipped (e.g., `docker-edge : discontinued`).