### PR TITLE
Update visual-studio-code-insiders from 1.58.0,7dea6d7402b55671410a129661cad24b55aed9f4 to 1.58.0,6afedfdad59d1f1ba4b614341d21c67775e158a9

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,13 +1,13 @@
 cask "visual-studio-code-insiders" do
-  version "1.58.0,7dea6d7402b55671410a129661cad24b55aed9f4"
+  version "1.58.0,6afedfdad59d1f1ba4b614341d21c67775e158a9"
 
   if Hardware::CPU.intel?
-    sha256 "3cf6590623dcc69778ab04ae116720e5bffaa03558611df50f7236cf6536b795"
+    sha256 "86602f1aea0e15e7fb8c6ccb98abe041643cfd2bad0730b12203877ad10af77b"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
   else
-    sha256 "84346ffca6bfeb0fa0030146bed17463d109ceaa9bd5f873d58a54b45816bf2c"
+    sha256 "818751ff687623962a0c0da202f256685725be76d30393f0721976e7b085a0c6"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump from `1.58.0,7dea6d7402b55671410a129661cad24b55aed9f4` to `1.58.0,6afedfdad59d1f1ba4b614341d21c67775e158a9`.