### PR TITLE
powershell6: mark discontinued as end-of-life

### DIFF
--- a/Casks/powershell6.rb
+++ b/Casks/powershell6.rb
@@ -3,8 +3,8 @@ cask "powershell6" do
   sha256 "d968da998b00178f666f342c9823c7df5038947a46d153892b1b20580be8d6d4"
 
   url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-x64.pkg"
-  appcast "https://github.com/PowerShell/PowerShell/releases.atom"
   name "PowerShell"
+  desc "Command-line shell and scripting language"
   homepage "https://github.com/PowerShell/PowerShell"
 
   conflicts_with cask: "powershell"
@@ -25,4 +25,8 @@ cask "powershell6" do
         "~/.local/share",
         "~/.local",
       ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

https://docs.microsoft.com/en-us/powershell/scripting/powershell-support-lifecycle?view=powershell-7.1#powershell-releases-end-of-life

Version | End-of-life
-- | --
7.1 | mid-February 2022 (projected)
7.0 | December 3, 2022
**6.2** | **September 4, 2020**



https://docs.microsoft.com/en-us/previous-versions/powershell/scripting/overview?view=powershell-6

> PowerShell 3.0
> PowerShell 4.0
> PowerShell 5.0
> **PowerShell 6 (out of support)**