### PR TITLE
google-chrome-*: alternative download for Intel chips

### DIFF
--- a/Casks/google-chrome-beta.rb
+++ b/Casks/google-chrome-beta.rb
@@ -2,7 +2,12 @@ cask "google-chrome-beta" do
   version "92.0.4515.80"
   sha256 :no_check
 
-  url "https://dl.google.com/chrome/mac/universal/beta/googlechromebeta.dmg"
+  if Hardware::CPU.intel?
+    url "https://dl.google.com/chrome/mac/beta/googlechromebeta.dmg"
+  else
+    url "https://dl.google.com/chrome/mac/universal/beta/googlechromebeta.dmg"
+  end
+
   name "Google Chrome Beta"
   desc "Web browser"
   homepage "https://www.google.com/chrome/beta/"

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -2,7 +2,12 @@ cask "google-chrome-canary" do
   version "93.0.4563.0"
   sha256 :no_check
 
-  url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"
+  if Hardware::CPU.intel?
+    url "https://dl.google.com/chrome/mac/canary/googlechromecanary.dmg"
+  else
+    url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"
+  end
+
   name "Google Chrome Canary"
   desc "Web browser"
   homepage "https://www.google.com/chrome/canary/"

--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -2,7 +2,12 @@ cask "google-chrome-dev" do
   version "93.0.4557.4"
   sha256 :no_check
 
-  url "https://dl.google.com/chrome/mac/universal/dev/googlechromedev.dmg"
+  if Hardware::CPU.intel?
+    url "https://dl.google.com/chrome/mac/dev/googlechromedev.dmg"
+  else
+    url "https://dl.google.com/chrome/mac/universal/dev/googlechromedev.dmg"
+  end
+
   name "Google Chrome Dev"
   desc "Web browser"
   homepage "https://www.google.com/chrome/dev/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Those `google-chrome-*` casks exclusively use universal downloads (https://github.com/Homebrew/homebrew-cask-versions/pull/10232). This PR adds significantly smaller alternative downloads for Intel chips.

Related `google-chrome` (stable) PR: https://github.com/Homebrew/homebrew-cask/pull/108034 