### PR TITLE
Update firefox-esr to 78.12.0

### DIFF
--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -1,68 +1,68 @@
 cask "firefox-esr" do
-  version "78.11.0"
+  version "78.12.0"
 
   language "cs" do
-    sha256 "25b8f1c60b0f8603b923ed57bdfb3b1a3bbd42edc00bf1af7665464bdeb08981"
+    sha256 "7c36aa65e5d7a7ecae6fbc4e1ef58c573d934e7a797af588ab257ed6d6eab2d1"
     "cs"
   end
   language "de" do
-    sha256 "cfda5b70a4e25b40c330f8a7a77fa061b30befbf4a170528445c9ce0f95ea892"
+    sha256 "96f774480dab8517d2f755d1a728b5701c63452d7e9e1ebcb73e0407ccf7dc69"
     "de"
   end
   language "en-CA" do
-    sha256 "b660a67f24058eea5626099eb057a716b3c6cda94855aea7b312f33bcab450dd"
+    sha256 "fc5170fd865d81be86c49050d881ecf1363d074cecefd0e305c41cfbc15e7645"
     "en-CA"
   end
   language "en-GB" do
-    sha256 "b821a55668f9943206aeacca25354652c888eb8c561ea6a36ee2faec68f1a635"
+    sha256 "383dc2cc195c45e1b5e24be6991161cfcf6e6bb3feb586adccc9fa2f8744cb72"
     "en-GB"
   end
   language "en", default: true do
-    sha256 "98d4cba6a673a830b7a8c7e8280320b7515528f024222ac9b185a3db39a6ce72"
+    sha256 "7c460ac899203e49a97523a4ab985e71556a7d7e820ba4cbc1bb9b6144ec0e06"
     "en-US"
   end
   language "fr" do
-    sha256 "080f6bf3e48a0dc21741f7315d24baf90bb1e838cc563944bb94c4ab63bee054"
+    sha256 "25d9909132b61d023d62d35b234c0a127c6138496d3f2d74e60cde1c6022e389"
     "fr"
   end
   language "gl" do
-    sha256 "cd42e09c7807cd8af2adf3f2049aa033ea90a5c8d541ccf40bc5db1a9ff45d9c"
+    sha256 "b944eb5d8d8feb5eccc9e50c31a26b8a70eb1df6e1c663b618c4d4612b78c181"
     "gl"
   end
   language "it" do
-    sha256 "f2a85425084c7c5e1765b7afde105d491f5f78c0a1d031d80466d8d595df5fcd"
+    sha256 "0ba6d11d2f788e464359509b610bd9b15bba0c54256ed2c951f829da41f1f970"
     "it"
   end
   language "ja" do
-    sha256 "5d046f84245261a738e776e334b5129f96149b6e3b6be4af91f409c15826fbfb"
+    sha256 "018a9dc1ba434fa1b56f57636a78aa727d019cbaef1e110be2803c622bcec68d"
     "ja-JP-mac"
   end
   language "nl" do
-    sha256 "d26a4dd8f8056a8abcc222fa7ae5fb6c617b117cf0e9a8fa8bbbab25a40d1940"
+    sha256 "78db717ed04ed994efa3f90eb3e6c2a44f7a8f5800ee0be1a67ba7d0433c7ea2"
     "nl"
   end
   language "pl" do
-    sha256 "1d8731753232bbb65e36308e8d0173460a5c15060e96c327c91a6192e75a811d"
+    sha256 "860bef7434707d2c3f23fdd03b63c28be0c52d35d2479e66a2532f82e756b314"
     "pl"
   end
   language "pt" do
-    sha256 "4188b934bc2acb40f2eb0db4f2009400c3d6fc45e953bb31e5c06528c32b3302"
+    sha256 "1410d8cd5014d03c195044d9a7fe5d83703f1910f75c1da232c5861b87e421ea"
     "pt-PT"
   end
   language "ru" do
-    sha256 "f4f30d7e2d2806ce45d9d8e861e3fad92c0676b99f8c8e5637998b77603391ff"
+    sha256 "0d2198477ba752f33c2cf728a5a35b84284c825fc9d483b945933f29d9754d31"
     "ru"
   end
   language "uk" do
-    sha256 "febdc5e724b1ba0832f2054e21a57e2538e89d15a58a51b22b2c84db6c6cdf03"
+    sha256 "5cd789749e9db9a482fded42f38fc44e3a4a3dd0c9b343d622b4493311c675a2"
     "uk"
   end
   language "zh-TW" do
-    sha256 "2c6973cba801a2e7ed2382a8c56e9afb3df7ae5114f4c0e6236bd38c64d7c058"
+    sha256 "55f5c3bbaf8e813e77bcbaff5e8e9b72462c06d52bc02bd35bbf65f159a908b4"
     "zh-TW"
   end
   language "zh" do
-    sha256 "f836fe84a5cb767bf70a7b11b8fce2b0bff27956608c142e25fc3d5d7b38f40b"
+    sha256 "c00c2ce3e92f69e664f35155ace040cc0aa6d0a9dea986d0656ee52af1812b25"
     "zh-CN"
   end
 


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/78.12.0/releasenotes/

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.