### PR TITLE
adoptopenjdk8: update livecheck

### DIFF
--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -11,7 +11,7 @@ cask "adoptopenjdk8" do
   livecheck do
     url :url
     strategy :github_latest do |page|
-      match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+)["' >]}i)
+      match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+).+["' >]}i)
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.