### PR TITLE
downgrade hyper-canary, update livecheck

### DIFF
--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -1,12 +1,12 @@
 cask "hyper-canary" do
-  version "3.1.1"
+  version "3.1.0-canary.6"
 
   if Hardware::CPU.intel?
-    sha256 "3d6a3b5b7e95fdacd63cb80973d411b9f5314dd26de2accdd318acecbb53c60d"
+    sha256 "033735bec4cef2796e5c40d84b186843941347a768fdbb3d1323c9bc4379ebd3"
     url "https://github.com/vercel/hyper/releases/download/v#{version}/Hyper-#{version}-mac-x64.zip",
         verified: "github.com/vercel/hyper/"
   else
-    sha256 "1b82a131d27aa77f722d5d4792c03ddb4d50795d7fddc8c367c1cf80e1dd7074"
+    sha256 "d2cd7409dbc1454bc5c67454228572f8c27ef9e5434893f8d1bc81b9613441e0"
     url "https://github.com/vercel/hyper/releases/download/v#{version}/Hyper-#{version}-mac-arm64.zip",
         verified: "github.com/vercel/hyper/"
   end
@@ -16,7 +16,7 @@ cask "hyper-canary" do
   homepage "https://hyper.is/"
 
   livecheck do
-    url "https://github.com/vercel/hyper/releases"
+    url "https://releases-canary.hyper.is/"
     strategy :page_match
     regex(/hyper-(\d+(?:\.\d+)*.+)-mac-x64\.zip/i)
   end


### PR DESCRIPTION
`hyper-canary` should stay on the canary release channel, which does not update to releases newer than the latest canary version. See https://github.com/vercel/hyper/discussions/5753#discussioncomment-1024364

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.