### PR TITLE
Add prerelease cask for LibreOffice.app

### DIFF
--- a/Casks/libreoffice-prerelease.rb
+++ b/Casks/libreoffice-prerelease.rb
@@ -1,27 +1,24 @@
-cask "libreoffice-still" do
-  version "7.0.6"
-  sha256 "cd99c75b4becb853dbd37a501300b07f1f39b33dc0c1e418c346744829fc7738"
+cask "libreoffice-prerelease" do
+  version "7.2.0.2"
+  sha256 "9f91efd227bf650231ea7f4851a05c976e89bea23358f050c79cfef833837f1d"
 
-  url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg",
-      verified: "download.documentfoundation.org/"
-  name "LibreOffice Still"
+  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg",
+      verified: "documentfoundation.org/"
+  name "LibreOffice"
   desc "Free cross-platform office suite"
   homepage "https://www.libreoffice.org/"
 
   livecheck do
-    url "https://www.libreoffice.org/download/release-notes/"
-    strategy :page_match do |page|
-      match = page.match(
-        /LibreOffice\s*(\d+(?:\.\d+)*)\s*\((\d+(?:-\d+)*)\)\s*-\s*Still\s*Branch/i,
-      )
-      (match[1]).to_s
-    end
+    url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/"
+    strategy :page_match
+    regex(/href="LibreOffice_(\d+(?:\.\d+)*)_MacOS_x86-64.dmg"/i)
   end
 
   conflicts_with cask: [
     "libreoffice",
-    "homebrew/cask-versions/libreoffice-prerelease",
+    "homebrew/cask-versions/libreoffice-still",
   ]
+  depends_on macos: ">= :yosemite"
 
   app "LibreOffice.app"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"


### PR DESCRIPTION
`homebrew-cask` includes the primary stable [`libreoffice`](https://github.com/Homebrew/homebrew-cask/blob/ef85fb108065ee36e0f8b4d0da9745c9ed5bde6b/Casks/libreoffice.rb) release, and this repo includes [`libreoffice-still`](https://github.com/Homebrew/homebrew-cask-versions/blob/744413d474f99279a74f09dd72d3b6f96a5ae106/Casks/libreoffice-still.rb), which LibreOffice [calls](https://www.libreoffice.org/download/release-notes/) "the mature 'still' version", but the [LibreOffice download page](https://www.libreoffice.org/download/download/) also includes a third branch, which they describe as "prerelease".

The full version number (currently 7.2.0.2) contains four numbers, but for the `livecheck` stanza, I couldn't find any web pages that list the full version number but don't already contain the `major_minor_patch` version number in the URL. So what I settled on, with URL `https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/x86_64/`, will continue to return for the correct latest prerelease version for as long as the 7.2.0 series is in prerelease, but as soon as the prerelease branch moves on to a new `major_minor_patch` series, it will start erroring. But once the cask file is updated to the newest prerelease version at that point, the `livecheck` will go back to returning the correct latest prerelease version for the rest of that series's life.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
  - _I think so, at least. Naming details at the top of this PR description._
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
  - _It has not been refused before, but an essentially identical cask called `libreoffice-rc` was deleted in 2019 (#8283). The reasoning wasn't terribly clear, though; I don't see why the reasons for wanting to use "release candidates" are any worse than the reasons for wanting to use beta versions of software, which this Tap does accept (and there is no `libreoffice-beta` in this repo)._
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.