### PR TITLE
Update visual-studio-code-insiders from 1.59.0,8f58c1f457bd2ddf6cf81120c450c783b6e8c01b to 1.59.0,379476f0e13988d90fab105c5c19e7abc8b1dea8

### DIFF
--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,13 +1,13 @@
 cask "visual-studio-code-insiders" do
-  version "1.59.0,8f58c1f457bd2ddf6cf81120c450c783b6e8c01b"
+  version "1.59.0,379476f0e13988d90fab105c5c19e7abc8b1dea8"
 
   if Hardware::CPU.intel?
-    sha256 "b9fc7b68261d1c716901c2c613026e7778cb09ffcb689edc53d087166c91ae22"
+    sha256 "260d6da99eeaf43205aa1f3cdb6c7a662fe16d72ac4ef154dc69fbe45b5edc19"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin.zip",
         verified: "az764295.vo.msecnd.net/insider/"
   else
-    sha256 "255fc23016bbf3e84f810dcc3439ee0b858e050d946da28e039393b69f5913b2"
+    sha256 "d91792854e8fa23130ce08907f3a5e01b06537afcf191d14b7949a158f2a9519"
 
     url "https://az764295.vo.msecnd.net/insider/#{version.after_comma}/VSCode-darwin-arm64.zip",
         verified: "az764295.vo.msecnd.net/insider/"


### PR DESCRIPTION
Simple version bump from `1.59.0,8f58c1f457bd2ddf6cf81120c450c783b6e8c01b` to `1.59.0,379476f0e13988d90fab105c5c19e7abc8b1dea8`.