### PR TITLE
Update dotnet-sdk-preview and dotnet-preview for arm64

### DIFF
--- a/Casks/dotnet-preview.rb
+++ b/Casks/dotnet-preview.rb
@@ -15,8 +15,8 @@ cask "dotnet-preview" do
       end
     end
   else
-    version "6.0.0-preview.5.21301.5,59b1d539-c76f-493c-9f6e-18c953429084:4c7fafc6ab3f5f4927929b543d62bc81"
-    sha256 "a9a510a957c1b219c9c5b499a05317a45f33c0346d5f44bfcde25e63a6356da8"
+    version "6.0.0-preview.7.21377.19,291e415b-c521-45b9-b817-710c342d2eb8:d05ca09bec35d4fbb31a07d700e9f416"
+    sha256 "014bfbbd8e93516ee6bb75aed532ce7f9e6d5673beac66444ae3c71e6fb562c7"
 
     url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version.before_comma}-osx-arm64.pkg"
     pkg "dotnet-runtime-#{version.before_comma}-osx-arm64.pkg"

--- a/Casks/dotnet-sdk-preview.rb
+++ b/Casks/dotnet-sdk-preview.rb
@@ -15,8 +15,8 @@ cask "dotnet-sdk-preview" do
       end
     end
   else
-    version "6.0.100-preview.5.21302.13,b1b77ccc-7428-4ab6-9bd5-dbde5e5fdb56:5a33c488a8bb58eaf1982a2edd2af2a2"
-    sha256 "2295dbc157def86b6d3543dcc49ea691d3386bfd47d5b3e7ddef6525381199cc"
+    version "6.0.100-preview.7.21379.14,01d92318-8db9-40f2-b9b8-20586d7e8f40:37d13083ff512e2b10bc2fd0fdbb9358"
+    sha256 "85f45dee8644e7cea3cb683925bc3374afb763443f3801697f8f58fc47f66016"
 
     url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-sdk-#{version.before_comma}-osx-arm64.pkg"
     pkg "dotnet-sdk-#{version.before_comma}-osx-arm64.pkg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
