### PR TITLE
telegram-desktop-beta: depend on macos >= sierra

### DIFF
--- a/Casks/telegram-desktop-beta.rb
+++ b/Casks/telegram-desktop-beta.rb
@@ -16,6 +16,7 @@ cask "telegram-desktop-beta" do
 
   auto_updates true
   conflicts_with cask: "telegram-desktop"
+  depends_on macos: ">= :sierra"
 
   # Renamed to avoid conflict with telegram
   app "Telegram.app", target: "Telegram Desktop.app"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask telegram-desktop-beta` is error-free.
- [X] `brew style --fix telegram-desktop-beta` reports no offenses.

See also homebrew/homebrew-cask#110188.
