### PR TITLE
Livecheck graceful regex

### DIFF
--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -12,6 +12,8 @@ cask "adoptopenjdk8" do
     url :url
     strategy :github_latest do |page|
       match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+).+["' >]}i)
+      next if match.blank?
+      
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end

--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -13,7 +13,7 @@ cask "adoptopenjdk8" do
     strategy :github_latest do |page|
       match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+).+["' >]}i)
       next if match.blank?
-      
+
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end

--- a/Casks/arduino-ide-beta.rb
+++ b/Casks/arduino-ide-beta.rb
@@ -11,6 +11,8 @@ cask "arduino-ide-beta" do
     url "https://www.arduino.cc/en/software/"
     strategy :page_match do |page|
       match = page.match(/href=.*?arduino[._-]ide[._-]v?(\d+(?:\.\d+)+)[._-]beta\.(\d+)[._-]macos[._-]64bit\.dmg/i)
+      next if match.blank?
+      
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/arduino-ide-beta.rb
+++ b/Casks/arduino-ide-beta.rb
@@ -12,7 +12,7 @@ cask "arduino-ide-beta" do
     strategy :page_match do |page|
       match = page.match(/href=.*?arduino[._-]ide[._-]v?(\d+(?:\.\d+)+)[._-]beta\.(\d+)[._-]macos[._-]64bit\.dmg/i)
       next if match.blank?
-      
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/azure-data-studio-insiders.rb
+++ b/Casks/azure-data-studio-insiders.rb
@@ -14,7 +14,7 @@ cask "azure-data-studio-insiders" do
       name = page[/"name":"(\d+(?:\.\d+)+)/i, 1]
       version = page[/"version":"(\w+)/i, 1]
       next if name.blank? || version.blank?
-      
+
       "#{name},#{version}"
     end
   end

--- a/Casks/azure-data-studio-insiders.rb
+++ b/Casks/azure-data-studio-insiders.rb
@@ -13,6 +13,8 @@ cask "azure-data-studio-insiders" do
     strategy :page_match do |page|
       name = page[/"name":"(\d+(?:\.\d+)+)/i, 1]
       version = page[/"version":"(\w+)/i, 1]
+      next if name.blank? || version.blank?
+      
       "#{name},#{version}"
     end
   end

--- a/Casks/citra-nightly.rb
+++ b/Casks/citra-nightly.rb
@@ -13,7 +13,7 @@ cask "citra-nightly" do
     strategy :github_latest do |page|
       match = page.match(%r{href=.*?/nightly[._-](\d+)/citra[._-]osx[._-](\d+[._-]\h+)\.tar\.gz}i)
       next if match.blank?
-      
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/citra-nightly.rb
+++ b/Casks/citra-nightly.rb
@@ -12,6 +12,8 @@ cask "citra-nightly" do
     url :url
     strategy :github_latest do |page|
       match = page.match(%r{href=.*?/nightly[._-](\d+)/citra[._-]osx[._-](\d+[._-]\h+)\.tar\.gz}i)
+      next if match.blank?
+      
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/daedalus-flight.rb
+++ b/Casks/daedalus-flight.rb
@@ -13,7 +13,7 @@ cask "daedalus-flight" do
     strategy :page_match do |page|
       match = page.match(%r{/daedalus-(\d+(?:\.\d+)*(?:-FC\d*)?)-mainnet_flight-(\d+)\.pkg}i)
       next if match.blank?
-      
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/daedalus-flight.rb
+++ b/Casks/daedalus-flight.rb
@@ -12,6 +12,8 @@ cask "daedalus-flight" do
     url "https://update-cardano-mainnet-flight.iohk.io/daedalus-latest-version.json"
     strategy :page_match do |page|
       match = page.match(%r{/daedalus-(\d+(?:\.\d+)*(?:-FC\d*)?)-mainnet_flight-(\d+)\.pkg}i)
+      next if match.blank?
+      
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -18,6 +18,8 @@ cask "java-beta" do
     url "https://jdk.java.net/#{version.major}/"
     strategy :page_match do |page|
       match = page.match(/openjdk-(\d+)-ea\+(\d+)_macos-#{arch}_bin\.tar\.gz/i)
+      next if match.blank?
+      
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -19,7 +19,7 @@ cask "java-beta" do
     strategy :page_match do |page|
       match = page.match(/openjdk-(\d+)-ea\+(\d+)_macos-#{arch}_bin\.tar\.gz/i)
       next if match.blank?
-      
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,12 +1,12 @@
 cask "java-beta" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  version "18,20"
+  version "18,21"
 
   if Hardware::CPU.intel?
-    sha256 "93c5b60cf693bf612519fce7c5bf9cae50410ac4338d6a4acb975a192ba0487f"
+    sha256 "fea5879bad743ca94c1860e2568f9058a0edbe8281a9d8aefee85a877bf612ee"
   else
-    sha256 "08f77b56280716074244455d49780c68242c7dab4fd207cac725766323ec711a"
+    sha256 "2fcaa76c0f05f6e1a66c92796b80f31198248e214fc728c9e8c8e1d2eed6590f"
   end
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.after_comma}/GPL/openjdk-#{version.before_comma}-ea+#{version.after_comma}_macos-#{arch}_bin.tar.gz"

--- a/Casks/qgis-ltr.rb
+++ b/Casks/qgis-ltr.rb
@@ -11,6 +11,8 @@ cask "qgis-ltr" do
     url "https://qgis.org/downloads/macos/qgis-macos-ltr.sha256sum"
     strategy :page_match do |page|
       match = page.match(/qgis_ltr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
+      next if match.blank?
+      
       "#{match[1].tr("_", ".")},#{match[2]}"
     end
   end

--- a/Casks/qgis-ltr.rb
+++ b/Casks/qgis-ltr.rb
@@ -12,7 +12,7 @@ cask "qgis-ltr" do
     strategy :page_match do |page|
       match = page.match(/qgis_ltr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
       next if match.blank?
-      
+
       "#{match[1].tr("_", ".")},#{match[2]}"
     end
   end

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -13,7 +13,7 @@ cask "sublime-text-dev" do
     strategy :page_match do |page, regex|
       match = page.match(regex)[1]
       next if match.blank?
-      
+
       "#{match[0]}.#{match[1..]}"
     end
   end

--- a/Casks/sublime-text-dev.rb
+++ b/Casks/sublime-text-dev.rb
@@ -12,6 +12,8 @@ cask "sublime-text-dev" do
     regex(/href=.*?v?(\d+)_mac\.zip/i)
     strategy :page_match do |page, regex|
       match = page.match(regex)[1]
+      next if match.blank?
+      
       "#{match[0]}.#{match[1..]}"
     end
   end

--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -13,7 +13,7 @@ cask "temurin8" do
     strategy :github_latest do |page|
       match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+).+["' >]}i)
       next if match.blank?
-      
+
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end

--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -12,6 +12,8 @@ cask "temurin8" do
     url :url
     strategy :github_latest do |page|
       match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+).+["' >]}i)
+      next if match.blank?
+      
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end

--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -1,6 +1,6 @@
 cask "tunnelblick-beta" do
-  version "3.8.7beta02,5730"
-  sha256 "f5d38cb9608fac0f60df777f3dcfcfc4a33a6a4df04a48d3bef6713160356d5b"
+  version "3.8.7beta03,5740"
+  sha256 "30f7ad636830148e75548db3516bcde00494e7c5a4f21a28e89e618e56a40586"
 
   url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.before_comma}/Tunnelblick_#{version.before_comma}_build_#{version.after_comma}.dmg",
       verified: "github.com/Tunnelblick/Tunnelblick/"

--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -13,6 +13,8 @@ cask "tunnelblick-beta" do
     regex(%r{href=.*?/Tunnelblick_(\d+(?:\.\d+)*beta(?:\d+))_build_(\d+)\.dmg}i)
     strategy :page_match do |page, regex|
       match = page.match(regex)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -21,6 +21,8 @@ cask "visual-studio-code-insiders" do
     strategy :page_match do |page|
       name = page[/"name":"(\d+(?:\.\d+)+)/i, 1]
       version = page[/"version":"(\w+)/i, 1]
+      next if name.blank? || version.blank?
+      
       "#{name},#{version}"
     end
   end

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -22,7 +22,7 @@ cask "visual-studio-code-insiders" do
       name = page[/"name":"(\d+(?:\.\d+)+)/i, 1]
       version = page[/"version":"(\w+)/i, 1]
       next if name.blank? || version.blank?
-      
+
       "#{name},#{version}"
     end
   end


### PR DESCRIPTION
This update causes livecheck to fail gracefully when `page.match` fails inside of the `do` block.
The documentation needs to be updated to match this pattern also.