### PR TITLE
Add Discord Development

### DIFF
--- a/Casks/discord-development.rb
+++ b/Casks/discord-development.rb
@@ -1,0 +1,29 @@
+cask "discord-development" do
+  version "0.0.8733"
+  sha256 "7b85681454ba9e21ca64755693a3f5d54842fbd2f8c22b470868bebe2e50ff07"
+
+  url "https://dl-development.discordapp.net/apps/osx/#{version}/DiscordDevelopment.dmg",
+      verified: "dl-development.discordapp.net/"
+  name "Discord Development"
+  desc "Voice and text chat software"
+  homepage "https://discord.com/"
+
+  livecheck do
+    url "https://discord.com/api/download/development?platform=osx"
+    strategy :header_match
+  end
+
+  auto_updates true
+
+  app "Discord Development.app"
+
+  zap trash: [
+    "~/Library/Application Support/discorddevelopment",
+    "~/Library/Caches/com.hnc.DiscordDevelopment",
+    "~/Library/Caches/com.hnc.DiscordDevelopment.ShipIt",
+    "~/Library/Cookies/com.hnc.DiscordDevelopment.binarycookies",
+    "~/Library/Preferences/com.hnc.DiscordDevelopment.helper.plist",
+    "~/Library/Preferences/com.hnc.DiscordDevelopment.plist",
+    "~/Library/Saved Application State/com.hnc.DiscordDevelopment.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/issues?q=discord-development).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

I was so happy to check that `brew install` box but then y'all made me uninstall it, what a roller-coaster of emotions :'D

I copied over the `discord-canary` file and replaced case-sensitively `canary` by `development` and checked that stuff worked.

* `~/Library/Preferences/com.hnc.DiscordDevelopment.helper.plist` didn't exist on my machine
* I was unable to access `~/Library/Cookies/`

The "homepage" had to be modified, but other than that, it all checks out.