### PR TITLE
Remove livecheck from discontinued casks

### DIFF
--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -8,16 +8,6 @@ cask "adoptopenjdk8" do
   desc "Prebuilt OpenJDK binaries"
   homepage "https://adoptopenjdk.net/"
 
-  livecheck do
-    url :url
-    strategy :github_latest do |page|
-      match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+).+["' >]}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}:#{match[3]}"
-    end
-  end
-
   pkg "OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}u#{version.after_comma.before_colon}#{version.after_comma.after_colon}.pkg"
 
   uninstall pkgutil: "net.adoptopenjdk.#{version.before_comma}.jdk"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes `livecheck` blocks from discontinued casks, so they will be automatically skipped as discontinued instead of continuing to be checked. This is necessary since we technically allow a `livecheck` block to override an automatic skip, as there are sometimes rare instances where we want to continue checking a formula/cask despite matching one of the built-in `SkipCondition`s. That isn't the case for these discontinued casks, so removing the `livecheck` block is appropriate.