### PR TITLE
kaleidoscope2: replace colon in version string with comma

### DIFF
--- a/Casks/kaleidoscope2.rb
+++ b/Casks/kaleidoscope2.rb
@@ -1,8 +1,8 @@
 cask "kaleidoscope2" do
-  version "2.4.2,1455:sep-7-2021"
+  version "2.4.2,1455,sep-7-2021"
   sha256 "d2ccd4c63781f836f2b5018ba51c286829929d43d74ea6300144e7c7a50f911a"
 
-  url "https://updates.kaleidoscope.app/v#{version.major}/prod/Kaleidoscope-#{version.before_comma}-#{version.after_comma.before_colon}-#{version.after_colon}.app.zip"
+  url "https://updates.kaleidoscope.app/v#{version.major}/prod/Kaleidoscope-#{version.tr(",", "-")}.app.zip"
   name "Kaleidoscope v2"
   desc "Spot and merge differences in text and image files or folders"
   homepage "https://www.kaleidoscope.app/"
@@ -11,7 +11,7 @@ cask "kaleidoscope2" do
     url "https://updates.kaleidoscope.app/v#{version.major}/prod/appcast"
     regex(/Kaleidoscope-(\d+(?:\.\d+)+)-(\d+)-(\w+(?:-\d+)*)\.app\.zip/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}:#{match[2]}" }
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
     end
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Homebrew/homebrew-cask#95207

Which one of these is preferred?

1. `#{version.csv[0]}-#{version.csv[1]}-#{version.csv[2]}`
2. `#{version.csv.join("-")`
3. `#{version.tr(",", "-")}`