### PR TITLE
temurin8: replace colon in version string with comma

### DIFF
--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -1,24 +1,24 @@
 cask "temurin8" do
-  version "8,312,b07"
+  version "8,312,07"
   sha256 "231cb0450c603cc861ade707b1deb01a8cbe2efd6c93e49c1707f3d899f92a93"
 
-  url "https://github.com/adoptium/temurin8-binaries/releases/download/jdk#{version.csv[0]}u#{version.csv[1]}-#{version.csv[2]}/OpenJDK#{version.csv[0]}U-jdk_x64_mac_hotspot_#{version.csv[0]}u#{version.csv[1]}#{version.csv[2]}.pkg",
+  url "https://github.com/adoptium/temurin8-binaries/releases/download/jdk#{version.csv[0]}u#{version.csv[1]}-b#{version.csv[2]}/OpenJDK#{version.csv[0]}U-jdk_x64_mac_hotspot_#{version.csv[0]}u#{version.csv[1]}b#{version.csv[2]}.pkg",
       verified: "github.com/adoptium/temurin8-binaries/"
   name "Eclipse Temurin 8"
   desc "JDK from the Eclipse Foundation (Adoptium)"
   homepage "https://adoptium.net/"
 
   livecheck do
-    url :url
-    strategy :github_latest do |page|
-      match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+).+["' >]}i)
+    url "https://github.com/adoptium/temurin8-binaries/releases/"
+    strategy :page_match do |page|
+      match = page.match(/jdk_x64_mac_hotspot_(\d+)u(\d+)b(\d+)\.pkg/i)
       next if match.blank?
 
       "#{match[1]},#{match[2]},#{match[3]}"
     end
   end
 
-  pkg "OpenJDK#{version.csv[0]}U-jdk_x64_mac_hotspot_#{version.csv[0]}u#{version.csv[1]}#{version.csv[2]}.pkg"
+  pkg "OpenJDK#{version.csv[0]}U-jdk_x64_mac_hotspot_#{version.csv[0]}u#{version.csv[1]}b#{version.csv[2]}.pkg"
 
   uninstall pkgutil: "net.temurin.#{version.csv[0]}.jdk"
 end

--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -16,7 +16,7 @@ cask "temurin8" do
         next if match.blank?
 
         "#{match[1]},#{match[2]},#{match[3]}"
-      end
+      end.compact
     end
   end
 

--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -1,8 +1,8 @@
 cask "temurin8" do
-  version "8,312:b07"
+  version "8,312,b07"
   sha256 "231cb0450c603cc861ade707b1deb01a8cbe2efd6c93e49c1707f3d899f92a93"
 
-  url "https://github.com/adoptium/temurin8-binaries/releases/download/jdk#{version.before_comma}u#{version.after_comma.before_colon}-#{version.after_colon}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}u#{version.after_comma.before_colon}#{version.after_comma.after_colon}.pkg",
+  url "https://github.com/adoptium/temurin8-binaries/releases/download/jdk#{version.csv[0]}u#{version.csv[1]}-#{version.csv[2]}/OpenJDK#{version.csv[0]}U-jdk_x64_mac_hotspot_#{version.csv[0]}u#{version.csv[1]}#{version.csv[2]}.pkg",
       verified: "github.com/adoptium/temurin8-binaries/"
   name "Eclipse Temurin 8"
   desc "JDK from the Eclipse Foundation (Adoptium)"
@@ -14,11 +14,11 @@ cask "temurin8" do
       match = page.match(%r{href=.*/jdk(\d+)u(\d+)-(b\d+).+["' >]}i)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}:#{match[3]}"
+      "#{match[1]},#{match[2]},#{match[3]}"
     end
   end
 
-  pkg "OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}u#{version.after_comma.before_colon}#{version.after_comma.after_colon}.pkg"
+  pkg "OpenJDK#{version.csv[0]}U-jdk_x64_mac_hotspot_#{version.csv[0]}u#{version.csv[1]}#{version.csv[2]}.pkg"
 
-  uninstall pkgutil: "net.temurin.#{version.before_comma}.jdk"
+  uninstall pkgutil: "net.temurin.#{version.csv[0]}.jdk"
 end

--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -9,12 +9,14 @@ cask "temurin8" do
   homepage "https://adoptium.net/"
 
   livecheck do
-    url "https://github.com/adoptium/temurin8-binaries/releases/"
+    url "https://api.adoptium.net/v3/assets/feature_releases/8/ga?architecture=x64&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
     strategy :page_match do |page|
-      match = page.match(/jdk_x64_mac_hotspot_(\d+)u(\d+)b(\d+)\.pkg/i)
-      next if match.blank?
+      JSON.parse(page).map do |release|
+        match = release["release_name"].match(/^jdk(\d+)u(\d+)-b(\d+)$/)
+        next if match.blank?
 
-      "#{match[1]},#{match[2]},#{match[3]}"
+        "#{match[1]},#{match[2]},#{match[3]}"
+      end
     end
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Homebrew/homebrew-cask#95207

Livecheck reports `8,302,b08` because the [latest release](https://github.com/adoptium/temurin8-binaries/releases/latest) on GitHub is `jdk8u302-b08.1`, but the latest release for macOS is `jdk8u312-b07`. (The `:github_releases` strategy can't be used because it's possible for [one page to only have pre-releases](https://github.com/adoptium/temurin8-binaries/releases?page=2))