### PR TITLE
java6: replace colon in version string with comma

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -1,8 +1,8 @@
 cask "java6" do
-  version "1.6.0_65-b14-468,2019:041-88384-20191011-3d8da658-dca4-4a5b-b67c-26e686876403"
+  version "1.6.0_65-b14-468,2019,041-88384-20191011-3d8da658-dca4-4a5b-b67c-26e686876403"
   sha256 "3a91bd24a0524df4cde9433f2ac56182818f78aacda36c7529b3d548e0c12e63"
 
-  url "https://updates.cdn-apple.com/#{version.after_comma.before_colon}/cert/#{version.after_colon}/JavaForOSX.dmg",
+  url "https://updates.cdn-apple.com/#{version.csv[1]}/cert/#{version.csv[2]}/JavaForOSX.dmg",
       verified: "updates.cdn-apple.com/"
   name "Apple Java 6 Standard Edition Development Kit"
   desc "Legacy runtime for the Java programming language"

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -20,4 +20,8 @@ cask "java6" do
       system_command "pkgutil", chdir: staged_path, args: ["--expand-full", "JavaForOSX.pkg", "JavaForOSX"]
     end
   end
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Homebrew/homebrew-cask#95207