### PR TITLE
temurin11: use Adoptium API in livecheck

### DIFF
--- a/Casks/temurin11.rb
+++ b/Casks/temurin11.rb
@@ -9,11 +9,13 @@ cask "temurin11" do
   homepage "https://adoptium.net/"
 
   livecheck do
-    url :url
-    strategy :git do |tags|
-      tags.map do |tag|
-        match = tag.match(/^jdk-(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)$/i)
-        "#{match[1]},#{match[2]}" if match
+    url "https://api.adoptium.net/v3/assets/feature_releases/11/ga?architecture=x64&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
+    strategy :page_match do |page|
+      JSON.parse(page).map do |release|
+        match = release["release_name"].match(/^jdk-(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)$/i)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
       end.compact
     end
   end


### PR DESCRIPTION
- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

https://github.com/Homebrew/homebrew-cask-versions/pull/12617#issuecomment-976297942