### PR TITLE
Add caveat for PowerShell-preview setup

### DIFF
--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -30,4 +30,10 @@ cask "powershell-preview" do
         "~/.local",
         "~/.local/share",
       ]
+
+   caveats "If PowerShell is used as a login shell, an entry must be added to the" \
+           "PowerShell profile file to use Homebrew. The easiest way to do this is to run" \
+           "the following command once within a PowerShell session:" \
+           "" \
+           "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue'"
 end

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -34,7 +34,7 @@ cask "powershell-preview" do
   caveats "If PowerShell is used as a login shell, an entry must be added to the " \
           "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
           "the following command once within a PowerShell session:" \
-          "" \
+          "\n\n" \
           "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf " \
           "/opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path " \
           "-PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | " \

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -33,6 +33,6 @@ cask "powershell-preview" do
 
   caveats <<~EOS
     To use Homebrew in PowerShell, set:
-      Add-Content -Path $PROFILE -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'
+      Add-Content -Path $PROFILE.CurrentUserAllHosts -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'
   EOS
 end

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -31,8 +31,8 @@ cask "powershell-preview" do
         "~/.local/share",
       ]
 
-   caveats "If PowerShell is used as a login shell, an entry must be added to the" \
-           "PowerShell profile file to use Homebrew. The easiest way to do this is to run" \
+   caveats "If PowerShell is used as a login shell, an entry must be added to the " \
+           "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
            "the following command once within a PowerShell session:" \
            "" \
            "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue'"

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -31,12 +31,8 @@ cask "powershell-preview" do
         "~/.local/share",
       ]
 
-  caveats "If PowerShell is used as a login shell, an entry must be added to the " \
-          "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
-          "the following command once within a PowerShell session:" \
-          "\n\n" \
-          "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf " \
-          "/opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path " \
-          "-PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | " \
-          "Invoke-Expression -ErrorAction SilentlyContinue'"
+  caveats <<~EOS
+    To use Homebrew in PowerShell, set:
+      Add-Content -Path $PROFILE -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'
+  EOS
 end

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -31,9 +31,12 @@ cask "powershell-preview" do
         "~/.local/share",
       ]
 
-   caveats "If PowerShell is used as a login shell, an entry must be added to the " \
-           "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
-           "the following command once within a PowerShell session:" \
-           "" \
-           "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue'"
+  caveats "If PowerShell is used as a login shell, an entry must be added to the " \
+          "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
+          "the following command once within a PowerShell session:" \
+          "" \
+          "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf " \
+          "/opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path " \
+          "-PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | " \
+          "Invoke-Expression -ErrorAction SilentlyContinue'"
 end


### PR DESCRIPTION
Add caveat about enabling Homebrew for PowerShell sessions where environment variables are not inherited from zsh.

This requires pull request https://github.com/Homebrew/brew/pull/12494 to be approved and merged before the caveat becomes useful.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
