### PR TITLE
Add IBM Semeru OpenJDK 8 & 11 (LTS)

### DIFF
--- a/Casks/semeru-jdk11-open.rb
+++ b/Casks/semeru-jdk11-open.rb
@@ -10,9 +10,11 @@ cask "semeru-jdk11-open" do
 
   livecheck do
     url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases"
-    regex(/["'][^"']*ibm-semeru-open-jdk_x64_mac[._-](\d+(?:[._]\d+)+)[._-](.+)\.pkg["']/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0].tr("_", "+")},#{match[1]}" }
+    strategy :github_latest do |page|
+      match = page.match(%r{href=.*?/tag/jdk[._-](\d+(?:[._+]\d+)+)[._-]([^&]+)&quot;}i)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
     end
   end
 

--- a/Casks/semeru-jdk11-open.rb
+++ b/Casks/semeru-jdk11-open.rb
@@ -1,0 +1,22 @@
+cask "semeru-jdk11-open" do
+  version "11.0.13+8,openj9-0.29.0"
+  sha256 "19787a8728a2cb2d264c7656a5f494be0874046157610b6b248f6d46cc12a592"
+
+  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version.before_comma}_#{version.after_comma}/ibm-semeru-open-jdk_x64_mac_#{version.before_comma.tr("+", "_")}_#{version.after_comma}.pkg",
+      verified: "github.com/ibmruntimes/semeru#{version.major}-binaries/"
+  name "IBM Semeru Runtime (JDK 11) Open Edition"
+  desc "Production-ready JDK with the OpenJDK class libraries and the Eclipse OpenJ9 JVM"
+  homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
+
+  livecheck do
+    url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases"
+    regex(/["'][^"']*ibm-semeru-open-jdk_x64_mac[._-](\d+(?:[._]\d+)+)[._-](.+)\.pkg["']/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0].tr("_", "+")},#{match[1]}" }
+    end
+  end
+
+  pkg "ibm-semeru-open-jdk_x64_mac_#{version.before_comma.tr("+", "_")}_#{version.after_comma}.pkg"
+
+  uninstall pkgutil: "net.ibm-semeru-open.#{version.major}.jdk"
+end

--- a/Casks/semeru-jdk8-open.rb
+++ b/Casks/semeru-jdk8-open.rb
@@ -10,9 +10,11 @@ cask "semeru-jdk8-open" do
 
   livecheck do
     url "https://github.com/ibmruntimes/semeru8-binaries/releases"
-    regex(/["'][^"']*ibm-semeru-open-jdk_x64_mac[._-](\d+u\d+)(b\d+)[._-](.+)\.pkg["']/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}-#{match[1]},#{match[2]}" }
+    strategy :github_latest do |page|
+      match = page.match(%r{href=.*?/tag/jdk(\d+u\d+)[._-](b\d+)[._-]([^&]+)&quot;}i)
+      next if match.blank?
+
+      "#{match[1]}-#{match[2]},#{match[3]}"
     end
   end
 

--- a/Casks/semeru-jdk8-open.rb
+++ b/Casks/semeru-jdk8-open.rb
@@ -1,0 +1,22 @@
+cask "semeru-jdk8-open" do
+  version "8u312-b07,openj9-0.29.0"
+  sha256 "f3ce369d3627bce344c9c5d2d76af3ae5b8c8f59c642f04c669d1e4269c29bba"
+
+  url "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk#{version.before_comma}_#{version.after_comma}/ibm-semeru-open-jdk_x64_mac_#{version.before_comma.tr("-", "")}_#{version.after_comma}.pkg",
+      verified: "github.com/ibmruntimes/semeru8-binaries/"
+  name "IBM Semeru Runtime (JDK 8) Open Edition"
+  desc "Production-ready JDK with the OpenJDK class libraries and the Eclipse OpenJ9 JVM"
+  homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
+
+  livecheck do
+    url "https://github.com/ibmruntimes/semeru8-binaries/releases"
+    regex(/["'][^"']*ibm-semeru-open-jdk_x64_mac[._-](\d+u\d+)(b\d+)[._-](.+)\.pkg["']/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]}-#{match[1]},#{match[2]}" }
+    end
+  end
+
+  pkg "ibm-semeru-open-jdk_x64_mac_#{version.before_comma.tr("-", "")}_#{version.after_comma}.pkg"
+
+  uninstall pkgutil: "net.ibm-semeru-open.8.jdk"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

This PR proposes to add the cask `semeru-jdk{8,11}-open`.

# Status Quo
See the PR for main cask (`semeru-jdk-open`) for its full history: [homebrew/homebrew-cask#112084](https://github.com/Homebrew/homebrew-cask/pull/112084), [homebrew/homebrew-cask#112101](https://github.com/Homebrew/homebrew-cask/pull/112101).

Basically, the original main distribution channel of JDK, AdoptOpenJDK, had been adopted by Eclipse Foundation and then change its name to [Adoptium](https://adoptium.net/) (with the actual JDK release called Temurin). However, previously AdoptOpenJDK had been distributing with two versions of VM available: HotSpot and OpenJ9. In the contract with Eclipse, the team is required to no longer provide OpenJ9 VM version of JDK/JRE binaries on their [release page](https://adoptium.net/index.html). Instead, in the FAQ the team [documented](https://adoptium.net/faq.html#semeru) that [IBM Semeru OpenJDK](https://developer.ibm.com/languages/java/semeru-runtimes/downloads/) will be providing the OpenJ9 VM version of JDK/JRE binaries. Since OpenJ9 VM has its own advantages when compared to HotSpot, many of us had relied on this flavor, and thus this PR proposes the inclusion of JDK 8 & 11 (both are LTS, so is used by a lot of people and will not end support until several years later) version of OpenJ9 VM from IBM Semeru.

# Why seek approval with audit error?
The only `brew audit` error for the following cask is
```
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```
However, this is normal since the GitHub repository the cask is downloading binaries from is [ibmruntimes/semeru8-binaries](https://github.com/ibmruntimes/semeru8-binaries) and [ibmruntimes/semeru11-binaries](ibmruntimes/semeru11-binaries). These two repos are used by IBM only for distributing binaries, and do not handle the code and/or homepage for the Semeru project. Therefore it is normal that these repositories are not notable enough.

# Things changed from main cask ([semeru-jdk-open](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/semeru-jdk-open.rb))
Following the step of two other JDK vendor, `zulu` and `temurin`, the JRE binaries are not added and only `semeru-jdk8-open` and `semeru-jdk11-open` is proposed.

The first change is that the `livecheck` URL is no longer the homepage (download page), since the download URL will only leads to Java 16 download, and change Java version ~~can only be handled via a dropdown selection (no stable URL)~~ can be done but the final source file will still contain all the versions, and thus all the version will still be matched. Therefore, I changed the URL to GitHub release page, which should have the same result since the download page links to GitHub release downloads anyway.

Other than this, the `semeru-jdk11-open` cask contains minimal changes, since JDK 11 distribution is basically the same as JDK 16 distribution, and only things that are changed is `version`, `sha256` and `name`. JDK 8, however, is trickier since its version number is no longer `major.minor.third+patch` but something like `8u312-b07`, which means that we cannot use `version.major` directly. Since the cask is called `semeru-jdk8-open`, I think that it is bundled with major version number 8 and thus I simply changed all use of `#{version.major}` to `8`. (If this is not acceptable, then I can perform the step of finding the first `u` and treat everything before it as major version number). Also, the `livecheck` regex is changed to recognize `uXX` and `bXX` and insert a hyphen between them, since the original binary name is like `ibm-semeru-open-jdk_x64_mac_8u312b07_openj9-0.29.0.pkg`.