### PR TITLE
Update temurin8 sha256 value

### DIFF
--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -1,6 +1,6 @@
 cask "temurin8" do
   version "8,312,07"
-  sha256 "231cb0450c603cc861ade707b1deb01a8cbe2efd6c93e49c1707f3d899f92a93"
+  sha256 "468bd64621e7fb2e1d80becfd8d53127a41182e283f94cb75a204ef00976adfb"
 
   url "https://github.com/adoptium/temurin8-binaries/releases/download/jdk#{version.csv[0]}u#{version.csv[1]}-b#{version.csv[2]}/OpenJDK#{version.csv[0]}U-jdk_x64_mac_hotspot_#{version.csv[0]}u#{version.csv[1]}b#{version.csv[2]}.pkg",
       verified: "github.com/adoptium/temurin8-binaries/"


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


Commit fix sha256 value error