### PR TITLE
Add Aerial-beta 2.3.4beta8

### DIFF
--- a/Casks/aerial-beta.rb
+++ b/Casks/aerial-beta.rb
@@ -1,0 +1,30 @@
+cask "aerial-beta" do
+  version "2.3.4beta8"
+  sha256 "59140497c9b74dd30176974babdf2a1d750d414336fb18219b8727e6c6fc99ec"
+
+  url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip",
+      verified: "github.com/JohnCoates/Aerial/"
+  name "Aerial Screensaver"
+  desc "Apple TV Aerial screensaver"
+  homepage "https://aerialscreensaver.github.io/"
+
+  conflicts_with cask: "aerial"
+  depends_on macos: ">= :sierra"
+
+  screen_saver "Aerial.saver"
+
+  zap trash: [
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/Aerial",
+    "~/Library/Screen Savers/Aerial.saver",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Preferences/"\
+    "ByHost/com.JohnCoates.Aerial*.plist",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Caches/Aerial",
+    "/Library/Screen Savers/Aerial.saver",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Caches/Aerial",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Application Support/"\
+    "Aerial",
+    "~/Library/Preferences/ByHost/com.JohnCoates.Aerial*",
+    "~/Library/Application Support/Aerial",
+    "~/Library/Caches/Aerial",
+  ]
+end

--- a/Casks/aerial-beta.rb
+++ b/Casks/aerial-beta.rb
@@ -11,7 +11,7 @@ cask "aerial-beta" do
   livecheck do
     url :url
     strategy :git
-    regex(/^(\d+(?:\.\d+)*beta\d+)$/i)
+    regex(/^v?(\d+(?:\.\d+)*beta\d+)$/i)
   end
 
   conflicts_with cask: "aerial"

--- a/Casks/aerial-beta.rb
+++ b/Casks/aerial-beta.rb
@@ -8,23 +8,24 @@ cask "aerial-beta" do
   desc "Apple TV Aerial screensaver"
   homepage "https://aerialscreensaver.github.io/"
 
+  livecheck do
+    url :url
+    strategy :git
+    regex(/^(\d+(?:\.\d+)*beta\d+)$/i)
+  end
+
   conflicts_with cask: "aerial"
   depends_on macos: ">= :sierra"
 
   screen_saver "Aerial.saver"
 
   zap trash: [
-    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/Aerial",
-    "~/Library/Screen Savers/Aerial.saver",
-    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Preferences/"\
-    "ByHost/com.JohnCoates.Aerial*.plist",
-    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Caches/Aerial",
-    "/Library/Screen Savers/Aerial.saver",
-    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Caches/Aerial",
-    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Application Support/"\
-    "Aerial",
-    "~/Library/Preferences/ByHost/com.JohnCoates.Aerial*",
     "~/Library/Application Support/Aerial",
     "~/Library/Caches/Aerial",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver.x86-64/Data/Library/Caches/Aerial",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/Aerial",
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Caches/Aerial",
+    "~/Library/Preferences/ByHost/com.JohnCoates.Aerial*",
+    "~/Library/Screen Savers/Aerial.saver",
   ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Hi there, so `brew audit --new-cask` gives me this error, but i don't understand why... can you advise if / how to solve this?
Thank you!

```
❯ brew audit --new-cask aerial-beta
==> Downloading https://github.com/JohnCoates/Aerial/releases/download/v2.3.4beta8/Aerial.saver.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/44998092/ae528e0b-ccc3-4391-810e-b546c
######################################################################## 100.0%
audit for aerial-beta: failed
 - Version '2.3.4beta8' differs from '2.3.3' retrieved by livecheck.
Error: 1 problem in 1 cask detected
```