### PR TITLE
Upgrade emacs-pretest to 28.0.90

### DIFF
--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -1,6 +1,6 @@
 cask "emacs-pretest" do
-  version "27.1.90"
-  sha256 "3e456e7dc991d39fb0a1e3d1415914135f7d51a367bee93ad69aae2224c88888"
+  version "28.0.90"
+  sha256 "638050b19c504a086d940804b22ebca084586288357ca9d6670c02799f1a8af0"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
   appcast "https://emacsformacosx.com/atom/pretest"

--- a/Casks/emacs-pretest.rb
+++ b/Casks/emacs-pretest.rb
@@ -3,9 +3,14 @@ cask "emacs-pretest" do
   sha256 "638050b19c504a086d940804b22ebca084586288357ca9d6670c02799f1a8af0"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-pretest-#{version}-universal.dmg"
-  appcast "https://emacsformacosx.com/atom/pretest"
   name "Emacs"
+  desc "Text editor"
   homepage "https://emacsformacosx.com/"
+
+  livecheck do
+    url "https://emacsformacosx.com/atom/pretest"
+    regex(/Emacs[._-]pretest[._-]v?(\d+(?:\.\d+)+)[._-]universal.dmg/i)
+  end
 
   conflicts_with cask:    [
     "emacs",
@@ -15,9 +20,13 @@ cask "emacs-pretest" do
 
   app "Emacs.app"
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: "emacs"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin-x86_64-10_14/ebrowse"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin-x86_64-10_14/emacsclient"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin-x86_64-10_14/etags"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1.gz"
 
   zap trash: [
     "~/Library/Caches/org.gnu.Emacs",


### PR DESCRIPTION
See this page for latest available builds:
https://emacsformacosx.com/builds

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask emacs-pretest` is error-free.
- [ ] `brew style --fix emacs-pretest` reports no offenses.