### PR TITLE
Update adguard-nightly.rb

### DIFF
--- a/Casks/adguard-nightly.rb
+++ b/Casks/adguard-nightly.rb
@@ -4,21 +4,49 @@ cask "adguard-nightly" do
 
   url "https://static.adguard.com/mac/nightly/AdGuard.dmg"
   name "Adguard"
+  desc "Stand alone ad blocker"
   homepage "https://adguard.com/"
+
+  conflicts_with cask: "adguard"
+  depends_on macos: ">= :sierra"
 
   pkg "AdGuard.pkg"
 
-  uninstall pkgutil: "com.adguard.mac.adguard-pkg"
+  uninstall quit:      "com.adguard.mac.adguard",
+            pkgutil:   "com.adguard.mac.adguard-pkg",
+            launchctl: [
+              "com.adguard.mac.adguard.pac",
+              "com.adguard.mac.adguard.tun-helper",
+            ],
+            delete:    [
+              "/Library/com.adguard.mac.adguard.pac",
+              "/Library/Application Support/AdGuard Software/com.adguard.mac.adguard",
+              "/Library/Application Support/com.adguard.Adguard",
+            ],
+            rmdir:     [
+              "/Library/Application Support/AdGuard Software",
+              "/Library/Application Support/AdGuard Software/com.adguard.mac",
+            ]
 
   zap trash: [
-    "/Library/Application Support/com.adguard.mac.adguard",
-    "~/Library/Application Support/com.adguard.mac.adguard-loginhelper",
-    "~/Library/Application Support/com.adguard.mac.adguard",
-    "~/Library/Caches/KSCrash/Adguard",
+    "/Library/Logs/com.adguard.mac.adguard",
+    "~/Library/Application Scripts/*.com.adguard.mac",
+    "~/Library/Application Scripts/com.adguard.mac.adguard.loginhelper",
+    "~/Library/Application Scripts/com.adguard.mac.adguard.safari-assistant",
+    "~/Library/Application Support/Adguard",
+    "~/Library/Application Support/com.adguard.Adguard",
+    "~/Library/Application Support/com.adguard.mac.adguard.pac",
+    "~/Library/Application Support/com.adguard.mac.adguard.tun-helper",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.adguard.mac.adguard.loginhelper.sfl*",
+    "~/Library/Caches/com.adguard.Adguard",
     "~/Library/Caches/com.adguard.mac.adguard",
+    "~/Library/Containers/com.adguard.mac.adguard.loginhelper",
+    "~/Library/Containers/com.adguard.mac.adguard.safari-assistant",
     "~/Library/Cookies/com.adguard.Adguard.binarycookies",
-    "~/Library/Containers/com.adguard.mac.adguard-loginhelper",
-    "~/Library/Logs/com.adguard.mac.adguard",
+    "~/Library/Group Containers/*.com.adguard.mac",
+    "~/Library/HTTPStorages/com.adguard.mac.adguard",
+    "~/Library/Logs/Adguard",
+    "~/Library/Preferences/com.adguard.Adguard.plist",
     "~/Library/Preferences/com.adguard.mac.adguard.plist",
     "~/Library/Saved Application State/com.adguard.mac.adguard.savedState",
   ]


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
