### PR TITLE
Fix URL for "inso-beta" formula

### DIFF
--- a/Casks/inso-beta.rb
+++ b/Casks/inso-beta.rb
@@ -9,7 +9,7 @@ cask "inso-beta" do
   homepage "https://insomnia.rest/products/inso"
 
   livecheck do
-    url "https://github.com/Kong/insomnia/releases"
+    url "https://github.com/Kong/insomnia/releases?q=Inso+CLI"
     strategy :page_match
     regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+)+[._-](?:beta)[._-]\d*)\.zip/i)
   end

--- a/Casks/inso-beta.rb
+++ b/Casks/inso-beta.rb
@@ -9,7 +9,7 @@ cask "inso-beta" do
   homepage "https://insomnia.rest/products/inso"
 
   livecheck do
-    url "https://github.com/Kong/insomnia/releases?q=Inso+CLI"
+    url "https://github.com/Kong/insomnia/releases?q=prerelease%3Atrue+Inso+CLI"
     strategy :page_match
     regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+)+[._-](?:beta)[._-]\d*)\.zip/i)
   end


### PR DESCRIPTION
Since the Insomnia repo effectively contains 2 pieces of software, a CLI and a GUI, the "latest" github release is not always guaranteed to be either type of release.
It can also transpire that the "latest" beta CLI release can occur far enough back that it would appear on "page 2" of the releases page. In which case `livecheck` will fail to find it.

Using the query parameter "q" to emulate a user searching provides a better opportunity for `livecheck` to find older releases of a certain variety.

I'm working on a similar change for the `insomnia` and `inso` formulae:
  - https://github.com/Homebrew/homebrew-cask/pull/119280
  - https://github.com/Homebrew/homebrew-cask/pull/119281

Any feedback on the Github Actions automation for this would be appreciated as well: https://github.com/Kong/insomnia/blob/develop/.github/workflows/homebrew.yml