### PR TITLE
google-chrome-canary: use latest version

### DIFF
--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -1,5 +1,5 @@
 cask "google-chrome-canary" do
-  version "101.0.4900.0"
+  version :latest
   sha256 :no_check
 
   url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"
@@ -7,12 +7,6 @@ cask "google-chrome-canary" do
   desc "Web browser"
   homepage "https://www.google.com/chrome/canary/"
 
-  livecheck do
-    url "https://chromiumdash.appspot.com/fetch_releases?channel=Canary&platform=Mac"
-    regex(/"version": "(\d+(?:\.\d+)+)"/i)
-  end
-
-  auto_updates true
   depends_on macos: ">= :el_capitan"
 
   app "Google Chrome Canary.app"


### PR DESCRIPTION
I think we can switch to `:latest` for the version here since the exact version number isn't required for the cask to work. Since there are sometimes multiple updates on a single day, this should contribute to lower the maintenance work for the repository.

If this get's merged, I'd update `google-chrome-beta` and `google-chrome-dev` in the same way.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.