### PR TITLE
corretto8 8.322.06.4 for aarch64

### DIFF
--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,20 +1,27 @@
 cask "corretto8" do
-  version "8.322.06.1"
-  sha256 "c20d7454fc0b461d3d354b6d4eed2665fa056d74ef438ef51c26f140203b4386"
+  if Hardware::CPU.intel?
+    arch_string = "x64"
+    version "8.322.06.1"
+    sha256 "c20d7454fc0b461d3d354b6d4eed2665fa056d74ef438ef51c26f140203b4386"
+  else
+    arch_string = "aarch64"
+    version "8.322.06.4"
+    sha256 "bbca6e00d81070f7c633fbede651ae6bfa71cbc563d250ee2e0c439e69a3e193"
+  end
 
-  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
+  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-#{arch_string}.pkg"
   name "Amazon Corretto JDK"
   desc "OpenJDK distribution from Amazon"
   homepage "https://corretto.aws/"
 
   livecheck do
-    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-x64-macos-jdk.pkg"
+    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch_string}-macos-jdk.pkg"
     strategy :header_match do |headers|
-      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-x64\.pkg}i, 1]
+      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch_string}\.pkg}i, 1]
     end
   end
 
-  pkg "amazon-corretto-#{version}-macosx-x64.pkg"
+  pkg "amazon-corretto-#{version}-macosx-#{arch_string}.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
 end

--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,27 +1,27 @@
 cask "corretto8" do
+  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+
   if Hardware::CPU.intel?
-    arch_string = "x64"
     version "8.322.06.1"
     sha256 "c20d7454fc0b461d3d354b6d4eed2665fa056d74ef438ef51c26f140203b4386"
   else
-    arch_string = "aarch64"
     version "8.322.06.4"
     sha256 "bbca6e00d81070f7c633fbede651ae6bfa71cbc563d250ee2e0c439e69a3e193"
   end
 
-  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-#{arch_string}.pkg"
+  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "Amazon Corretto JDK"
   desc "OpenJDK distribution from Amazon"
   homepage "https://corretto.aws/"
 
   livecheck do
-    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch_string}-macos-jdk.pkg"
+    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch}-macos-jdk.pkg"
     strategy :header_match do |headers|
-      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch_string}\.pkg}i, 1]
+      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i, 1]
     end
   end
 
-  pkg "amazon-corretto-#{version}-macosx-#{arch_string}.pkg"
+  pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
 end


### PR DESCRIPTION
Adds aarch64 support for Corretto8. The divergence in version numbers between x64 and aarch64 is temporary, and will be resolved in an upcoming release.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
