### PR TITLE
Add temurin17

### DIFF
--- a/Casks/temurin17.rb
+++ b/Casks/temurin17.rb
@@ -1,0 +1,33 @@
+cask "temurin17" do
+  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+
+  version "17.0.2,8"
+
+  if Hardware::CPU.intel?
+    sha256 "b82d3ba3ff4c453bd954979a20e67754478294da8650e3b9e50f6d1a7cf5c628"
+  else
+    sha256 "0904c11eb5f7b53aac53e6279992ee2a900c9517b26659dee3704b2d11c149cd"
+  end
+
+  url "https://github.com/adoptium/temurin#{version.major}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg",
+      verified: "github.com/adoptium/"
+  name "Eclipse Temurin Java Development Kit"
+  desc "JDK from the Eclipse Foundation (Adoptium)"
+  homepage "https://adoptium.net/"
+
+  livecheck do
+    url "https://api.adoptium.net/v3/info/release_versions?release_type=ga&architecture=#{arch}&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
+    strategy :page_match do |page|
+      JSON.parse(page)["versions"].map do |version|
+        match = version["openjdk_version"].match(/^(\d+(?:\.\d+)*)\+(\d+(?:\.\d+)*)$/i)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end.compact
+    end
+  end
+
+  pkg "OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg"
+
+  uninstall pkgutil: "net.temurin.#{version.major}.jdk"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully. ***(Explanation below)***
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Temurin are builds of OpenJDK provided by Eclipse. (Formerly known as AdoptOpenJDK but forced to rename due to trademarks.) Currently Java 8 and 11 (both LTS) exist in this repository. (`temurin8` and `temurin11`.) `temurin` points to the latest distribution of Temurin. Java 17 is LTS and Java 18 (not LTS) is supposed to release in the next few weeks. Having `temurin17` will allow Brew users to stay on 17 LTS without upgrading to 18. *(I included this because I don't know how well the maintainers of this repository know all of this information.)*

I directly copied the [`temurin.rb` file][1] from `homebrew-cask` to here and everything is working.

[1]: https://github.com/Homebrew/homebrew-cask/blob/4a9b403e71f06a83b158e064709b0bb82780f2a8/Casks/temurin.rb

`brew audit --new-cask` fails with one error that the repository is not significant enough. Please consider waiving this requirement as the repository does not host code, only the binaries. (https://github.com/adoptium/temurin17-binaries) For what it is worth, both 8 and 11 also do not meet this requirement.

```
audit for temurin17: failed
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 cask detected
```