### PR TITLE
google-chrome-*: update livecheck

### DIFF
--- a/Casks/google-chrome-beta.rb
+++ b/Casks/google-chrome-beta.rb
@@ -9,7 +9,7 @@ cask "google-chrome-beta" do
 
   livecheck do
     url "https://chromiumdash.appspot.com/fetch_releases?channel=Beta&platform=Mac"
-    regex(/"version": "(\d+(?:\.\d+)+)"/i)
+    regex(/"version":\s*"v?(\d+(?:\.\d+)+)"/i)
   end
 
   auto_updates true

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -9,7 +9,7 @@ cask "google-chrome-canary" do
 
   livecheck do
     url "https://chromiumdash.appspot.com/fetch_releases?channel=Canary&platform=Mac"
-    regex(/"version": "(\d+(?:\.\d+)+)"/i)
+    regex(/"version":\s*"v?(\d+(?:\.\d+)+)"/i)
   end
 
   auto_updates true

--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -11,7 +11,7 @@ cask "google-chrome-dev" do
 
   livecheck do
     url "https://chromiumdash.appspot.com/fetch_releases?channel=Dev&platform=Mac"
-    regex(/"version": "(\d+(?:\.\d+)+)"/i)
+    regex(/"version":\s*"v?(\d+(?:\.\d+)+)"/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` blocks for `google-chrome-beta`, `google-chrome-canary`, and `google-chrome-dev` are currently giving an `Unable to get versions` error because the regex will only match if there's one space between the `version` key and value. These checks currently fail because the JSON doesn't contain a space between the key and value. This PR updates these regexes to use `\s*`, which will accounts for any spaces while also allowing for no spaces.

For what it's worth, the `google-chrome` cask uses `JSON.parse(page)[0]["version"]` in a `strategy` block instead but that approach assumes that the first entry in the JSON array is the newest version, which is true now but may not always be. Instead, it should match all the available versions (i.e., `.map { |entry| entry["version"] }`) and leave it to livecheck to identify the newest version.

Using a regex is fine for these casks for now, as parsing the JSON involves more overhead and isn't strictly necessary to be able to identify versions. That is to say, there are more error conditions when working with the JSON, so we would have to do some error checking before parsing it (e.g., ensuring the response body isn't blank) and also check the parsed JSON to make sure it's an array before iterating over it. It's more work and potentially less reliable, so it's maybe better left to more complicated situations where a regex isn't sufficient and we have to parse the JSON to be able to accurately identify version information.