### PR TITLE
Add 1password-cli1

### DIFF
--- a/Casks/1password-cli1.rb
+++ b/Casks/1password-cli1.rb
@@ -1,0 +1,23 @@
+cask "1password-cli1" do
+  version "1.12.4"
+  sha256 "a484de66fa64252c51f3a90d6b8a1dad70bd4537b786466f897b99badb51a1ee"
+
+  url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_apple_universal_v#{version}.pkg",
+      verified: "cache.agilebits.com/dist/1P/op/pkg/"
+  name "1Password CLI"
+  desc "Command-line helper for the 1Password password manager"
+  homepage "https://developer.1password.com/docs/cli/v1/usage/"
+
+  livecheck do
+    url "https://app-updates.agilebits.com/product_history/CLI"
+    regex(%r{href=.*?/op_apple_universal[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
+  end
+
+  conflicts_with cask: "1password-cli"
+
+  pkg "op_apple_universal_v#{version}.pkg"
+
+  uninstall pkgutil: "com.1password.op"
+
+  zap trash: "~/.op"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

# Additional notes

[1Password CLI 2.0](https://1password.community/discussion/127897/weve-launched-cli-2-0) has been released and updated in _homebrew-cask_ (Homebrew/homebrew-cask#120540).

It comes with breaking changes (see [upgrade notes](https://developer.1password.com/docs/cli/upgrade/)) leading to incompatibilities where scripts are relying on the CLI 1.X interface.