### PR TITLE
Add versioned cask gcc-adm-embedded10 to easily switch...

### DIFF
--- a/Casks/gcc-arm-embedded10.rb
+++ b/Casks/gcc-arm-embedded10.rb
@@ -1,0 +1,54 @@
+cask "gcc-arm-embedded10" do
+  # Exists as a cask because it is impractical as a formula:
+  # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
+  version "10.3-2021.10"
+  gcc_version = "10.3.1"
+  sha256 "e3888a1d0af798be7f98d67a3e6dc4fc96d92d5b57fc635e0c021a4a36087b5d"
+
+  url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/#{version}/gcc-arm-none-eabi-#{version}-mac.pkg"
+  name "GCC ARM Embedded"
+  desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
+  homepage "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm"
+
+  livecheck do
+    url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads"
+    regex(/href=.*?gcc-arm-none-eabi-(\d+\.\d+-\d+\.\d+)-mac.pkg/i)
+  end
+
+  pkg "gcc-arm-none-eabi-#{version}-mac.pkg"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-addr2line"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-ar"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-as"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-c++"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-c++filt"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-cpp"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-elfedit"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-g++"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-#{gcc_version}"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ar"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-nm"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ranlib"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-dump"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-tool"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-add-index"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-add-index-py"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-py"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gprof"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-ld"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-ld.bfd"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-lto-dump"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-nm"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-objcopy"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-objdump"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-ranlib"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-readelf"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-size"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-strings"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-strip"
+
+  uninstall pkgutil: "gcc.arm-none-eabi-#{version[/^(\d{2})/]}",
+            delete:  "/Applications/ARM"
+end


### PR DESCRIPTION
…to previous version due to incompatibility with x86 and Apple Silicon on current version 11.2.1.

The bug is reported here: https://community.arm.com/support-forums/f/compilers-and-libraries-forum/52377/internal-compiler-errors-with-arm-none-eabi-gcc-11-2-2022-02-on-macs-with-apple-silicon

Any fix is pending. In the meanwhile, affected users should be able to easily go back to previous stable build 10.3.1.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
