### PR TITLE
Revert "Update VMware Fusion Technology Preview for ARM to 19431034"

### DIFF
--- a/Casks/vmware-fusion-tech-preview.rb
+++ b/Casks/vmware-fusion-tech-preview.rb
@@ -10,8 +10,8 @@ cask "vmware-fusion-tech-preview" do
       strategy :header_match
     end
   else
-    version "19431034"
-    sha256 "493fda53120050f85836032324409be6c6484f90a0755ae0c6a673ba7626818b"
+    version "18656771"
+    sha256 "c8511bbb829d60f95f94599392bef8058b36cd94f103fb264a57cacdc5f55325"
 
     livecheck do
       skip "No version information available"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask-versions#13551

I have just realized that my pull request was not properly tested and that this actually doesn't work.

sha256 returned is actually shasum of the 404 error page, not of the dmg:

```
❯ curl https://download3.vmware.com/software/fusion/file/VMware-Fusion-e.x.p-19431034_arm64.dmg | shasum -a 256
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0      4      0  0:00:02  0:00:02 --:--:--     4
493fda53120050f85836032324409be6c6484f90a0755ae0c6a673ba7626818b  -
```

```
❯ curl -I https://download3.vmware.com/software/fusion/file/VMware-Fusion-e.x.p-19431034_arm64.dmg
HTTP/1.1 404 Not Found
Accept-Ranges: bytes
Content-Length: 10
Server: AkamaiNetStorage
Date: Fri, 25 Mar 2022 10:33:25 GMT
Connection: keep-alive
content-disposition: attachment; filename="VMware-Fusion-e.x.p-19431034_arm64.dmg"
Content-Type: application/x-octet-stream
```

New link that works can only be accessed with authorization:

```
❯ curl -I https://download2.vmware.com/software/FUS-PUBTP-2021H1-TEST1/VMware-Fusion-e.x.p-19431034_arm64.dmg
HTTP/1.1 403 Forbidden
Server: AkamaiGHost
Mime-Version: 1.0
Content-Type: text/html
Content-Length: 176
Expires: Fri, 25 Mar 2022 10:34:06 GMT
Date: Fri, 25 Mar 2022 10:34:06 GMT
Connection: keep-alive
content-disposition: attachment; filename="VMware-Fusion-e.x.p-19431034_arm64.dmg"
```

Old version can still be dowloaded, but license doesn't work anymore:

```
❯ curl -I https://download3.vmware.com/software/fusion/file/VMware-Fusion-e.x.p-18656771_arm64.dmg
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 87158453
Content-MD5: s82k4GOcaPQ3TFU2iM7XXw==
ETag: "b3cda4e0639c68f4374c553688ced75f:1632309896.704751"
Last-Modified: Wed, 22 Sep 2021 11:25:00 GMT
Server: AkamaiNetStorage
Date: Fri, 25 Mar 2022 10:45:56 GMT
Connection: keep-alive
content-disposition: attachment; filename="VMware-Fusion-e.x.p-18656771_arm64.dmg"
Content-Type: application/x-octet-stream
```

More details about license problem in [this](https://communities.vmware.com/t5/Fusion-for-Apple-Silicon-Tech/M1-Fusion-tech-preview-30-days-license-expiry/td-p/2889133) thread.

Fortunately old version can work with valid license for Intel version (at least with free license).

I have no idea what we should do next. :(