### PR TITLE
Remove unnecessary strategy calls

### DIFF
--- a/Casks/aerial-beta.rb
+++ b/Casks/aerial-beta.rb
@@ -10,7 +10,6 @@ cask "aerial-beta" do
 
   livecheck do
     url :url
-    strategy :git
     regex(/^v?(\d+(?:\.\d+)*beta\d+)$/i)
   end
 

--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -10,7 +10,6 @@ cask "atom-beta" do
 
   livecheck do
     url :url
-    strategy :git
     regex(/^v?(\d+(?:\.\d+)*-beta\d*)$/i)
   end
 

--- a/Casks/ferdi-beta.rb
+++ b/Casks/ferdi-beta.rb
@@ -17,7 +17,6 @@ cask "ferdi-beta" do
 
   livecheck do
     url :url
-    strategy :git
     regex(/^v?(\d+(?:\.\d+)*((?:[._-]beta)?)*([._-]\d+)?)$/i)
   end
 

--- a/Casks/keka-beta.rb
+++ b/Casks/keka-beta.rb
@@ -10,7 +10,6 @@ cask "keka-beta" do
 
   livecheck do
     url :url
-    strategy :git
     regex(/^v?((?:\d+(?:\.\d+)+)-(?:beta|dev)(?:\.(\d+))?)?/i)
   end
 

--- a/Casks/netnewswire-beta.rb
+++ b/Casks/netnewswire-beta.rb
@@ -10,7 +10,6 @@ cask "netnewswire-beta" do
 
   livecheck do
     url :url
-    strategy :git
     regex(/^mac-(\d+(?:\.\d+)*b\d+)$/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `#strategy` calls in the `livecheck` blocks in this PR are redundant, as the specified strategy is the same as the default strategy for the `livecheck` block URL. This PR removes these `#strategy` calls, as we only use `#strategy` to override the default strategy or when a `strategy` block is used.

To be clear, the verbose JSON output from `brew livecheck` is unchanged after these `#strategy` call removals, confirming that they were unnecessary.