### PR TITLE
Use \.t instead of tarball extension in regexes

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -14,7 +14,7 @@ cask "wine-devel" do
   livecheck do
     url "https://github.com/Gcenx/macOS_Wine_builds/releases"
     strategy :page_match
-    regex(/wine[._-]devel[._-]v?(\d+(?:\.\d+)+)[._-]osx64\.tar\.xz/i)
+    regex(/href=.*?wine[._-]devel[._-]v?(\d+(?:\.\d+)+)[._-]osx64\.t/i)
   end
 
   conflicts_with cask: [

--- a/Casks/wine-staging.rb
+++ b/Casks/wine-staging.rb
@@ -14,7 +14,7 @@ cask "wine-staging" do
   livecheck do
     url "https://github.com/Gcenx/macOS_Wine_builds/releases"
     strategy :page_match
-    regex(/wine[._-]staging[._-]v?(\d+(?:\.\d+)+)[._-]osx64\.tar\.xz/i)
+    regex(/href=.*?wine[._-]staging[._-]v?(\d+(?:\.\d+)+)[._-]osx64\.t/i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The casks in this PR contain a `livecheck` block with a regex that matches a specific tarball extension (`\.tar\.xz`). When matching versions from a tarball file, we instead use a generic `\.t` extension, so the regex will continue to match if the tarball format changes (e.g., from `tar.gz` to `tar.xz`, etc.). We have a RuboCop that catches this particular issue and this PR is intended to fix these offenses before I modify the livecheck RuboCops to also apply to casks.

Besides that, this also updates the regexes to only match within `href` attributes, which is common behavior when matching versions from filenames on an HTML page.