### PR TITLE
Pass regex into strategy block, use #scan

### DIFF
--- a/Casks/arduino-ide-beta.rb
+++ b/Casks/arduino-ide-beta.rb
@@ -9,11 +9,9 @@ cask "arduino-ide-beta" do
 
   livecheck do
     url "https://www.arduino.cc/en/software/"
-    strategy :page_match do |page|
-      match = page.match(/href=.*?arduino[._-]ide[._-]v?(\d+(?:\.\d+)+)[._-]beta\.(\d+)[._-]macos[._-]64bit\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(/href=.*?arduino[._-]ide[._-]v?(\d+(?:\.\d+)+)[._-]beta[._-]?(\d+)[._-]macos[._-]64bit\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/background-music-pre.rb
+++ b/Casks/background-music-pre.rb
@@ -7,10 +7,14 @@ cask "background-music-pre" do
   desc "Audio utility"
   homepage "https://github.com/kyleneideck/BackgroundMusic"
 
+  # When the leading version for two snapshot tags are the same, we can't
+  # determine which is newer based on the trailing hash. As such, this check
+  # treats the most recent snapshot tag as newest (if any).
   livecheck do
     url "https://github.com/kyleneideck/BackgroundMusic/releases.atom"
-    strategy :page_match do |page|
-      page[%r{href=.*?/tag/(\d+(?:\.\d+)*-SNAPSHOT-[0-9a-f]+)}i, 1]
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[._-]SNAPSHOT[._-][0-9a-f]+)["']}i)
+    strategy :page_match do |page, regex|
+      page[regex, 1]
     end
   end
 

--- a/Casks/citra-nightly.rb
+++ b/Casks/citra-nightly.rb
@@ -10,11 +10,9 @@ cask "citra-nightly" do
 
   livecheck do
     url :url
-    strategy :github_latest do |page|
-      match = page.match(%r{href=.*?/nightly[._-](\d+)/citra[._-]osx[._-](\d+[._-]\h+)\.tar\.gz}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(%r{href=.*?/nightly[._-](\d+)/citra[._-]osx[._-](\d+[._-]\h+)\.t}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/daedalus-flight.rb
+++ b/Casks/daedalus-flight.rb
@@ -10,11 +10,9 @@ cask "daedalus-flight" do
 
   livecheck do
     url "https://update-cardano-mainnet-flight.iohk.io/daedalus-latest-version.json"
-    strategy :page_match do |page|
-      match = page.match(%r{/daedalus-(\d+(?:\.\d+)*(?:-FC\d*)?)-mainnet_flight-(\d+)\.pkg}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(%r{/daedalus-(\d+(?:\.\d+)*(?:-FC\d*)?)-mainnet_flight-(\d+)\.pkg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/fork-dev.rb
+++ b/Casks/fork-dev.rb
@@ -9,8 +9,9 @@ cask "fork-dev" do
 
   livecheck do
     url "https://git-fork.com/update/feed.xml"
-    strategy :sparkle do |item|
-      item.url[%r{/Fork-(\d+(?:\.\d+)+)\.dmg}i, 1]
+    regex(%r{/Fork-(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :sparkle do |item, regex|
+      item.url[regex, 1]
     end
   end
 

--- a/Casks/freecad-pre.rb
+++ b/Casks/freecad-pre.rb
@@ -10,11 +10,9 @@ cask "freecad-pre" do
 
   livecheck do
     url "https://github.com/FreeCAD/FreeCAD/releases"
-    strategy :page_match do |page|
-      match = page.match(
-        %r{href=.*?/(\d+(?:\.\d+)+)/FreeCAD_(?:\d+(?:\.\d+)*)-(\d+(?:-pre\d+)?)-macOS-x86_64-conda\.dmg}i,
-      )
-      "#{match[1]},#{match[2]}"
+    regex(%r{href=.*?/(\d+(?:\.\d+)+)/FreeCAD_(?:\d+(?:\.\d+)*)-(\d+(?:-pre\d+)?)-macOS-x86_64-conda\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/geogebra5.rb
+++ b/Casks/geogebra5.rb
@@ -9,9 +9,9 @@ cask "geogebra5" do
 
   livecheck do
     url "https://download.geogebra.org/package/mac"
-    strategy :header_match do |headers|
-      v = headers["location"][%r{/GeoGebra-MacOS-Installer-withJava-(\d+(?:-\d+)*)\.zip}i, 1]
-      v.tr("-", ".")
+    regex(%r{/GeoGebra-MacOS-Installer-withJava-(\d+(?:-\d+)*)\.zip}i)
+    strategy :header_match do |headers, regex|
+      headers["location"][regex, 1].tr("-", ".")
     end
   end
 

--- a/Casks/local-beta.rb
+++ b/Casks/local-beta.rb
@@ -9,8 +9,9 @@ cask "local-beta" do
 
   livecheck do
     url "https://cdn.localwp.com/beta/latest/mac"
-    strategy :header_match do |headers|
-      match = headers["location"].match(%r{/(\d+(?:\.\d+)+)\+local-beta-(\d+)/})
+    regex(%r{/(\d+(?:\.\d+)+)\+local-beta-(\d+)/}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"

--- a/Casks/mumble-snapshot.rb
+++ b/Casks/mumble-snapshot.rb
@@ -9,8 +9,9 @@ cask "mumble-snapshot" do
 
   livecheck do
     url "https://dl.mumble.info/latest/snapshot/client-macos-x64"
-    strategy :header_match do |headers|
-      headers["content-disposition"][/mumble[._-]client[._-](.*)~snapshot\.dmg/i, 1].tr("~", "_")
+    regex(/mumble[._-]client[._-](.*)~snapshot\.dmg/i)
+    strategy :header_match do |headers, regex|
+      headers["content-disposition"][regex, 1].tr("~", "_")
     end
   end
 

--- a/Casks/openshot-video-editor-daily.rb
+++ b/Casks/openshot-video-editor-daily.rb
@@ -10,11 +10,9 @@ cask "openshot-video-editor-daily" do
 
   livecheck do
     url "https://www.openshot.org/download/"
-    strategy :page_match do |page|
-      match = page.match(/OpenShot[._-]v?(\d+(?:\.\d+)+)[._-]dev[._-]daily[._-](.*)[._-]x86[._-]64\.dmg"/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(/OpenShot[._-]v?(\d+(?:\.\d+)+)[._-]dev[._-]daily[._-](.*)[._-]x86[._-]64\.dmg"/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/processing-beta.rb
+++ b/Casks/processing-beta.rb
@@ -11,9 +11,8 @@ cask "processing-beta" do
   livecheck do
     url :url
     regex(/processing[._-](\d+)[._-]v?(\d+(?:\.\d+b\d)+)/i)
-    strategy :github_latest do |page|
-      page.scan(regex)
-          .map { |match| "#{match[1]},#{match[0]}" }
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/qgis-ltr.rb
+++ b/Casks/qgis-ltr.rb
@@ -9,11 +9,9 @@ cask "qgis-ltr" do
 
   livecheck do
     url "https://qgis.org/downloads/macos/qgis-macos-ltr.sha256sum"
-    strategy :page_match do |page|
-      match = page.match(/qgis_ltr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1].tr("_", ".")},#{match[2]}"
+    regex(/qgis_ltr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0].tr("_", ".")},#{match[1]}" }
     end
   end
 

--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -10,11 +10,9 @@ cask "rstudio-preview" do
 
   livecheck do
     url :homepage
-    strategy :page_match do |page|
-      match = page.match(/RStudio-(\d{4}\.\d{2}\.\d+)-(\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(/RStudio-(\d{4}\.\d{2}\.\d+)-(\d+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/semeru-jdk11-open.rb
+++ b/Casks/semeru-jdk11-open.rb
@@ -10,11 +10,9 @@ cask "semeru-jdk11-open" do
 
   livecheck do
     url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases"
-    strategy :github_latest do |page|
-      match = page.match(%r{href=.*?/tag/jdk[._-](\d+(?:[._+]\d+)+)[._-]([^&]+)&quot;}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(%r{href=.*?/tag/jdk[._-](\d+(?:[._+]\d+)+)[._-]([^&]+)&quot;}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/semeru-jdk8-open.rb
+++ b/Casks/semeru-jdk8-open.rb
@@ -10,11 +10,9 @@ cask "semeru-jdk8-open" do
 
   livecheck do
     url "https://github.com/ibmruntimes/semeru8-binaries/releases"
-    strategy :github_latest do |page|
-      match = page.match(%r{href=.*?/tag/jdk(\d+u\d+)[._-](b\d+)[._-]([^&]+)&quot;}i)
-      next if match.blank?
-
-      "#{match[1]}-#{match[2]},#{match[3]}"
+    regex(%r{href=.*?/tag/jdk(\d+u\d+)[._-](b\d+)[._-]([^&]+)&quot;}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]}-#{match[1]},#{match[2]}" }
     end
   end
 

--- a/Casks/smcfancontrol-beta.rb
+++ b/Casks/smcfancontrol-beta.rb
@@ -9,9 +9,9 @@ cask "smcfancontrol-beta" do
 
   livecheck do
     url "https://github.com/hholtmann/smcFanControl/releases/"
-    strategy :page_match do |page|
-      match = page[/smcFanControl[._-](\d+(?:.\d+)*)\.zip/i, 1]
-      match.tr("_", ".")
+    regex(/smcFanControl[._-](\d+(?:.\d+)*)\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.tr("_", ".") }
     end
   end
 

--- a/Casks/temurin11.rb
+++ b/Casks/temurin11.rb
@@ -10,13 +10,14 @@ cask "temurin11" do
 
   livecheck do
     url "https://api.adoptium.net/v3/assets/feature_releases/#{version.major}/ga?architecture=x64&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
-    strategy :page_match do |page|
+    regex(/^jdk-(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)$/i)
+    strategy :page_match do |page, regex|
       JSON.parse(page).map do |release|
-        match = release["release_name"].match(/^jdk-(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)$/i)
+        match = release["release_name"]&.match(regex)
         next if match.blank?
 
         "#{match[1]},#{match[2]}"
-      end.compact
+      end
     end
   end
 

--- a/Casks/temurin17.rb
+++ b/Casks/temurin17.rb
@@ -17,13 +17,14 @@ cask "temurin17" do
 
   livecheck do
     url "https://api.adoptium.net/v3/info/release_versions?release_type=ga&architecture=#{arch}&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
-    strategy :page_match do |page|
+    regex(/^(\d+(?:\.\d+)*)\+(\d+(?:\.\d+)*)$/i)
+    strategy :page_match do |page, regex|
       JSON.parse(page)["versions"].map do |version|
-        match = version["openjdk_version"].match(/^(\d+(?:\.\d+)*)\+(\d+(?:\.\d+)*)$/i)
+        match = version["openjdk_version"]&.match(regex)
         next if match.blank?
 
         "#{match[1]},#{match[2]}"
-      end.compact
+      end
     end
   end
 

--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -10,13 +10,14 @@ cask "temurin8" do
 
   livecheck do
     url "https://api.adoptium.net/v3/assets/feature_releases/8/ga?architecture=x64&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
-    strategy :page_match do |page|
+    regex(/^jdk(\d+)u(\d+)-b(\d+)$/i)
+    strategy :page_match do |page, regex|
       JSON.parse(page).map do |release|
-        match = release["release_name"].match(/^jdk(\d+)u(\d+)-b(\d+)$/)
+        match = release["release_name"]&.match(regex)
         next if match.blank?
 
         "#{match[1]},#{match[2]},#{match[3]}"
-      end.compact
+      end
     end
   end
 

--- a/Casks/zulu11.rb
+++ b/Casks/zulu11.rb
@@ -18,11 +18,9 @@ cask "zulu11" do
 
   livecheck do
     url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    strategy :page_match do |page|
-      match = page.match(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
+    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -18,11 +18,9 @@ cask "zulu13" do
 
   livecheck do
     url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    strategy :page_match do |page|
-      match = page.match(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
+    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/zulu15.rb
+++ b/Casks/zulu15.rb
@@ -18,11 +18,9 @@ cask "zulu15" do
 
   livecheck do
     url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    strategy :page_match do |page|
-      match = page.match(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
+    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/zulu17.rb
+++ b/Casks/zulu17.rb
@@ -18,11 +18,9 @@ cask "zulu17" do
 
   livecheck do
     url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    strategy :page_match do |page|
-      match = page.match(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
+    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/zulu7.rb
+++ b/Casks/zulu7.rb
@@ -10,11 +10,9 @@ cask "zulu7" do
 
   livecheck do
     url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=x86"
-    strategy :page_match do |page|
-      match = page.match(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_x64\.dmg/i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
+    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_x64\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/zulu8.rb
+++ b/Casks/zulu8.rb
@@ -18,11 +18,9 @@ cask "zulu8" do
 
   livecheck do
     url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    strategy :page_match do |page|
-      match = page.match(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
+    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` blocks in this PR contain a `strategy` block that uses a regex internally. This PR updates these `livecheck` blocks to define the regex using `#regex` and simply pass the regex into the `strategy` block. This approach is preferable, as it aligns with how most `livecheck` blocks work, makes it easy to add/remove a `strategy` block in the future (i.e., the regex doesn't have to be manually moved into/out of the `strategy` block), allows the regex value to be surfaced in the `brew livecheck` debug and JSON output, and allows us to audit the regex.

[This approach can only be used with a single regex at the moment but I'll be creating a brew PR in the near future to allow `#regex` to handle multiple regexes. Once this is done, we can standardize on this approach for all related `strategy` blocks. In the interim time, I'm cleaning up `strategy` blocks that use one regex internally (starting with the smaller cask repositories). This is partly related to my ongoing work to address livecheck RuboCop offenses, as these changes resolve the `A regex is required if strategy :page_match is present` audit.]

---

This PR also updates some of these `strategy` blocks to use the `page.scan(regex).map { |match| ... }` approach instead of the multiline `match = page.match(regex)`/`next if match.blank?`/`"#{match[1]},#{match[2]}"` approach. The `#scan` approach is generally preferred because it will handle all matches in the content, whereas `#match` will only handle the first match (though in contexts where the content will only ever contain one match, we use `[regex, 1]` if the regex only has one capture group and the `#match` approach for more than one capture group`). Besides that, the `#scan` approach is generally less verbose.

One thing to note about converting from `#match` to `#scan` is that the capture group index numbers have to be decremented by one. Basically, the first capture group from `#scan` is index 0 but the first capture group index for `#match` is 1 instead (index 0 is the full matched text).

---

There are some other casks in this tap that need to be updated like this but the changes were a little less simple. I'll be handling these in separate PRs, where I can explain the changes.