### PR TITLE
libreoffice-still: update livecheck

### DIFF
--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -17,12 +17,7 @@ cask "libreoffice-still" do
 
   livecheck do
     url "https://www.libreoffice.org/download/release-notes/"
-    strategy :page_match do |page|
-      match = page.match(
-        /LibreOffice\s*(\d+(?:\.\d+)+)\s*\((\d+(?:-\d+)*)\)\s*-\s*Still\s*Branch/i,
-      )
-      (match[1]).to_s
-    end
+    regex(/LibreOffice\s+v?(\d+(?:\.\d+)+)(?:\s+\((?:\d+(?:-\d+)+)\))?\s*-\s*Still\s+Branch/i)
   end
 
   conflicts_with cask: "libreoffice"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `libreoffice-still` uses a `strategy` block to unnecessarily reimplement what the `PageMatch` strategy already does internally. This should simply use `#regex` to establish the regex and let the `PageMatch` strategy do the rest.

This also preemptively resolves the "A regex is required if strategy :page_match is present." audit error before I create a brew PR to make the livecheck RuboCops apply to casks as well (not just formulae).