### PR TITLE
parallels*: update livecheck

### DIFF
--- a/Casks/parallels12.rb
+++ b/Casks/parallels12.rb
@@ -9,11 +9,9 @@ cask "parallels12" do
 
   livecheck do
     url "https://kb.parallels.com/123948"
-    strategy :page_match do |page|
-      match = page.match(/Parallels Desktop #{version.major} for Mac\s*(\d+(?:\.\d+)+)\s*\((\d+)\)/i)
-      next if match.blank?
-
-      "#{match[1]}-#{match[2]}"
+    regex(/(v?\d+(?:\.\d+)+\s*\(\d+\)|\(v?\d+(?:\.\d+)+-\d+\))/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.strip.tr("()", "").gsub(/\s+/, "-") }
     end
   end
 

--- a/Casks/parallels13.rb
+++ b/Casks/parallels13.rb
@@ -9,11 +9,9 @@ cask "parallels13" do
 
   livecheck do
     url "https://kb.parallels.com/124262"
-    strategy :page_match do |page|
-      match = page.match(/Parallels Desktop #{version.major} for Mac\s*(\d+(?:\.\d+)+)\s*\((\d+)\)/i)
-      next if match.blank?
-
-      "#{match[1]}-#{match[2]}"
+    regex(/(v?\d+(?:\.\d+)+\s*\(\d+\)|\(v?\d+(?:\.\d+)+-\d+\))/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.strip.tr("()", "").gsub(/\s+/, "-") }
     end
   end
 

--- a/Casks/parallels14.rb
+++ b/Casks/parallels14.rb
@@ -9,11 +9,9 @@ cask "parallels14" do
 
   livecheck do
     url "https://kb.parallels.com/en/124521"
-    strategy :page_match do |page|
-      match = page.match(/Parallels Desktop #{version.major} for Mac\s*(\d+(?:\.\d+)+)\s*\((\d+)\)/i)
-      next if match.blank?
-
-      "#{match[1]}-#{match[2]}"
+    regex(/(v?\d+(?:\.\d+)+\s*\(\d+\)|\(v?\d+(?:\.\d+)+-\d+\))/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.strip.tr("()", "").gsub(/\s+/, "-") }
     end
   end
 

--- a/Casks/parallels15.rb
+++ b/Casks/parallels15.rb
@@ -9,11 +9,9 @@ cask "parallels15" do
 
   livecheck do
     url "https://kb.parallels.com/en/124724"
-    strategy :page_match do |page|
-      match = page.match(/Parallels Desktop #{version.major} for Mac\s*(\d+(?:\.\d+)+)\s*\((\d+)\)/i)
-      next if match.blank?
-
-      "#{match[1]}-#{match[2]}"
+    regex(/(v?\d+(?:\.\d+)+\s*\(\d+\)|\(v?\d+(?:\.\d+)+-\d+\))/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.strip.tr("()", "").gsub(/\s+/, "-") }
     end
   end
 

--- a/Casks/parallels16.rb
+++ b/Casks/parallels16.rb
@@ -9,11 +9,9 @@ cask "parallels16" do
 
   livecheck do
     url "https://kb.parallels.com/en/125053"
-    strategy :page_match do |page|
-      match = page.match(/Parallels Desktop #{version.major} for Mac\s*(\d+(?:\.\d+)+)\s*\((\d+)\)/i)
-      next if match.blank?
-
-      "#{match[1]}-#{match[2]}"
+    regex(/(v?\d+(?:\.\d+)+\s*\(\d+\)|\(v?\d+(?:\.\d+)+-\d+\))/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.strip.tr("()", "").gsub(/\s+/, "-") }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR is primarily intended to modify the existing `livecheck` blocks for the versioned `parallels` casks (i.e., `parallels12` through `parallels16`) to use `#regex`, passing the regex into the `strategy` block, and the `page.scan(regex).map { |match| ... }` approach to version finding. An explanation of these changes can be found in #13818.

Besides that, this establishes a common regex that works for all of these casks, despite variation in the page format for each major version. This new regex also matches versions that were missed by the existing regexes (made apparent after switching to `#scan`, which works with all matches on the page and not just the first).