### PR TITLE
Update java-beta from 18,35 to 19,20

### DIFF
--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -1,12 +1,12 @@
 cask "java-beta" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  version "18,35"
+  version "19,20"
 
   if Hardware::CPU.intel?
-    sha256 "5956dbd5f6c6bba49ecaf40547cd38be177e604a261f1cb62b4d013c0a0994b5"
+    sha256 "e3f3124cf799f24df542c112aaad1ab729e969d2a63ad977988cdde7073efd97"
   else
-    sha256 "649e81f6411fc3e01e19ce629d0f8482e1cf562451785fad3faeb80326d1c467"
+    sha256 "b2b2f68cfac363652cd273feba6a33f4be5855dcf56ad378252e4ed98a5ffba0"
   end
 
   url "https://download.java.net/java/early_access/jdk#{version.major}/#{version.csv.second}/GPL/openjdk-#{version.csv.first}-ea+#{version.csv.second}_macos-#{arch}_bin.tar.gz"
@@ -16,11 +16,9 @@ cask "java-beta" do
 
   livecheck do
     url "https://jdk.java.net/#{version.major}/"
-    strategy :page_match do |page|
-      match = page.match(/openjdk-(\d+)-ea\+(\d+)_macos-#{arch}_bin\.tar\.gz/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(/openjdk-(\d+)-ea\+(\d+)_macos-#{arch}_bin\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `java-beta` gives an "Unable to get versions" error because the `livecheck` block URL is determined by the cask's major version but version 18 is currently GA, not Early Access (EA). Due to how this works, the `livecheck` block breaks when a version is promoted from EA to GA but it can be fixed by updating the cask to a new beta version. This PR updates the cask to use the latest beta version, 19,20.

Besides that, this updates the `livecheck` block to use `#regex`, passing the regex into the strategy block, and the `page.scan(regex).map { |match| ... }` approach for version finding. An explanation of these changes can be found in #13818.

Lastly, this updates the regex to use the generic `\.t` extension instead of the specific `\.tar\.gz` extension, as tarball extensions can change over time and only matching one specific extension can cause unnecessary failures (and increase our maintenance burden). This resolves the related `livecheck` block RuboCop before I create a brew PR to have them also apply to casks (not just formulae).