### PR TITLE
Add 1password7

### DIFF
--- a/Casks/1password7.rb
+++ b/Casks/1password7.rb
@@ -1,0 +1,28 @@
+cask "1password7" do
+  version "7.9.4"
+  sha256 "2d41a01d0bcc51f822170f36ddc067977f636efb71e419b588b366aa37a21a94"
+
+  url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
+  name "1Password"
+  desc "Password manager that keeps all passwords secure behind one password"
+  homepage "https://1password.com/"
+
+  livecheck do
+    url "https://app-updates.agilebits.com/product_history/OPM#{version.major}"
+    regex(%r{href=.*?/1Password-(\d+(?:\.\d+)+)\.pkg}i)
+  end
+
+  auto_updates true
+  conflicts_with cask: "homebrew/cask-versions/1password-beta"
+  depends_on macos: ">= :high_sierra"
+
+  app "1Password #{version.major}.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/*.agilebits.onepassword*",
+    "~/Library/Containers/*.agilebits.onepassword*",
+    "~/Library/Group Containers/2BUA8C4S2C.com.agilebits",
+    "~/Library/Logs/1Password",
+    "~/Library/Preferences/com.agilebits.onepassword*",
+  ]
+end


### PR DESCRIPTION
Just adding a 1password7 from the main homebrew-cask into homebrew-cask-versions repo

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
