### PR TITLE
Remove `depends_on` references to Yosemite

### DIFF
--- a/Casks/1password6.rb
+++ b/Casks/1password6.rb
@@ -8,7 +8,6 @@ cask "1password6" do
   homepage "https://1password.com/"
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "1Password #{version.major}.app"
 

--- a/Casks/background-music-pre.rb
+++ b/Casks/background-music-pre.rb
@@ -19,7 +19,6 @@ cask "background-music-pre" do
   end
 
   conflicts_with cask: "background-music"
-  depends_on macos: ">= :yosemite"
 
   pkg "BackgroundMusic-#{version}.pkg"
 

--- a/Casks/iterm2-nightly.rb
+++ b/Casks/iterm2-nightly.rb
@@ -12,7 +12,7 @@ cask "iterm2-nightly" do
     "iterm2-beta",
     "iterm2-legacy",
   ]
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :mojave"
 
   app "iTerm.app"
 

--- a/Casks/keyboard-maestro8.rb
+++ b/Casks/keyboard-maestro8.rb
@@ -7,8 +7,6 @@ cask "keyboard-maestro8" do
   name "Keyboard Maestro"
   homepage "https://www.keyboardmaestro.com/main/"
 
-  depends_on macos: ">= :yosemite"
-
   app "Keyboard Maestro.app"
 
   zap trash: [

--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -21,7 +21,7 @@ cask "libreoffice-still" do
   end
 
   conflicts_with cask: "libreoffice"
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   app "LibreOffice.app"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"

--- a/Casks/macpass-dev.rb
+++ b/Casks/macpass-dev.rb
@@ -9,7 +9,7 @@ cask "macpass-dev" do
   homepage "https://macpass.github.io/"
 
   conflicts_with cask: "macpass"
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :high_sierra"
 
   app "MacPass.app"
 

--- a/Casks/parallels12.rb
+++ b/Casks/parallels12.rb
@@ -22,11 +22,7 @@ cask "parallels12" do
     "homebrew/cask-versions/parallels15",
     "homebrew/cask-versions/parallels16",
   ]
-  depends_on macos: [
-    :yosemite,
-    :el_capitan,
-    :sierra,
-  ]
+  depends_on macos: "<= :sierra"
 
   app "Parallels Desktop.app"
 

--- a/Casks/parallels13.rb
+++ b/Casks/parallels13.rb
@@ -22,12 +22,7 @@ cask "parallels13" do
     "homebrew/cask-versions/parallels15",
     "homebrew/cask-versions/parallels16",
   ]
-  depends_on macos: [
-    :yosemite,
-    :el_capitan,
-    :sierra,
-    :high_sierra,
-  ]
+  depends_on macos: "<= :high_sierra"
 
   app "Parallels Desktop.app"
 

--- a/Casks/soulver2.rb
+++ b/Casks/soulver2.rb
@@ -13,7 +13,6 @@ cask "soulver2" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "Soulver #{version.major}.app"
 

--- a/Casks/zulu8.rb
+++ b/Casks/zulu8.rb
@@ -24,7 +24,7 @@ cask "zulu8" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :mojave"
 
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
 


### PR DESCRIPTION
This is the first stages of removing `:yosemite` references from Homebrew/cask-versions (Yosemite support will be removed from Homebrew 3.5.0).

This PR removes, corrects or simplifies all `depends_on` lines referencing Yosemite. 

This PR does _not_ remove any conditions like `MacOS.version <= :yosemite`. I do not intend to make any changes that remove Yosemite support until _after_ 3.5.0 - the changes so far should be harmless for Yosemite users.