### PR TITLE
Update Opera Crypto Browser Developer from 88.0.4412.11 to 88.0.4412.37

### DIFF
--- a/Casks/opera-crypto-developer.rb
+++ b/Casks/opera-crypto-developer.rb
@@ -1,6 +1,6 @@
 cask "opera-crypto-developer" do
-  version "88.0.4412.11"
-  sha256 "58fd80998ed34fd0ff9ef5df640d852ff1d12b48337748f7688913c28c123f12"
+  version "88.0.4412.37"
+  sha256 "dab91bbf73fe6938fa01b1b58bab2142c2abb01628c6b734397afd3dbe5ec867"
 
   url "https://ftp.opera.com/pub/opera_crypto-developer/#{version}/mac/Opera_Crypto_Developer_#{version}_Setup.dmg"
   name "Opera Crypto Browser Developer"


### PR DESCRIPTION
Update Opera Crypto Browser Developer from 88.0.4412.11 to 88.0.4412.37

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.