### PR TITLE
Remove Yosemite support

### DIFF
--- a/Casks/omnifocus2.rb
+++ b/Casks/omnifocus2.rb
@@ -1,9 +1,5 @@
 cask "omnifocus2" do
-  if MacOS.version <= :yosemite
-    version "2.7.4"
-    sha256 "a273e55c15f82540fe305344f9e49ad7d0d9c326ba2c37c312076ffd73780f80"
-    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "2.10"
     sha256 "e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8"
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"


### PR DESCRIPTION
This is the final stage of removing `:yosemite` references from Homebrew/cask-versions.

Homebrew 3.5.0 released on Monday 6th and since that release, `brew` no longer runs on Yosemite. Therefore we can now remove the remaining Yosemite conditionals here.

Homebrew taps are not expected to be backwards compatible with older releases, but I gave a few days of leeway anyway.