### PR TITLE
Add Zulu 18 JDK

### DIFF
--- a/Casks/zulu18.rb
+++ b/Casks/zulu18.rb
@@ -1,0 +1,32 @@
+cask "zulu18" do
+  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+  choice = Hardware::CPU.intel? ? "x86" : "arm"
+
+  version "18.30.11-ca,18.0.1"
+
+  if Hardware::CPU.intel?
+    sha256 "e26f3c3f4d2a388aa0d7fa60f5473301155827192da2e09550ff5bf15982d166"
+  else
+    sha256 "6bf03aa424cd775eacd3530104c08319971ff1fb46eff8857f72fdff16409e94"
+  end
+
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
+      referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  name "Azul Zulu Java Standard Edition Development Kit"
+  desc "OpenJDK distribution from Azul"
+  homepage "https://www.azul.com/downloads/"
+
+  livecheck do
+    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
+    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    end
+  end
+
+  depends_on macos: ">= :mojave"
+
+  pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
+
+  uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"
+end


### PR DESCRIPTION
I'm adding Zulu18 as it's missing in `homebrew-cask-versions`.
SHAs and version numbers are from: 
https://www.azul.com/downloads/?version=java-18-sts&os=macos&package=jdk 

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
