### PR TITLE
Godot 4 alpha

### DIFF
--- a/Casks/godot-alpha.rb
+++ b/Casks/godot-alpha.rb
@@ -1,0 +1,30 @@
+cask "godot-master" do
+    version "4.0-alpha10"
+    sha256 "a4f6e466338253cbf2e5334534d9d7aad42773691f7a7749ebe97a3b95d9788a"
+
+    url "https://downloads.tuxfamily.org/godotengine/#{version.major_minor}/#{version.delete("#{version.major_minor}-")}/Godot_v#{version}_osx.universal.zip",
+      verified: "downloads.tuxfamily.org/godotengine/"
+    name "Godot Engine"
+    desc "Game development engine"
+    homepage "https://godotengine.org"
+
+    livecheck do
+      url "https://downloads.tuxfamily.org/godotengine/#{version.major_minor}/"
+      regex(/^alpha\d+$/i)
+    end
+
+    auto_updates true
+    conflicts_with cask: "godot"
+    depends_on macos: ">= :high_sierra"
+
+    app "Godot.app"
+    binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot"
+
+    uninstall quit: "org.godotengine.godot"
+
+    zap trash: [
+      "~/Library/Application Support/Godot",
+      "~/Library/Caches/Godot",
+      "~/Library/Saved Application State/org.godotengine.godot.savedState",
+    ]
+end

--- a/Casks/godot-alpha.rb
+++ b/Casks/godot-alpha.rb
@@ -2,7 +2,7 @@ cask "godot-alpha" do
     version "4.0-alpha10"
     sha256 "a4f6e466338253cbf2e5334534d9d7aad42773691f7a7749ebe97a3b95d9788a"
 
-    url "https://downloads.tuxfamily.org/godotengine/#{version.major_minor}/#{version.delete("#{version.major_minor}-")}/Godot_v#{version}_osx.universal.zip",
+    url "https://downloads.tuxfamily.org/godotengine/#{version.sub(%r{-alpha\d+}, '')}/#{version.minor.sub(%r{\d+-}, '')}/Godot_v#{version}_osx.universal.zip",
       verified: "downloads.tuxfamily.org/godotengine/"
     name "Godot Engine"
     desc "Game development engine"

--- a/Casks/godot-alpha.rb
+++ b/Casks/godot-alpha.rb
@@ -2,11 +2,11 @@ cask "godot-alpha" do
   version "4.0-alpha10"
   sha256 "a4f6e466338253cbf2e5334534d9d7aad42773691f7a7749ebe97a3b95d9788a"
 
-  url "https://downloads.tuxfamily.org/godotengine/#{version.sub(%r{-alpha\d+}, '')}/#{version.minor.sub(%r{\d+-}, '')}/Godot_v#{version}_osx.universal.zip",
-    verified: "downloads.tuxfamily.org/godotengine/"
+  url "https://downloads.tuxfamily.org/godotengine/#{version.sub(/-alpha\d+/, "")}/#{version.minor.sub(/\d+-/, "")}/Godot_v#{version}_osx.universal.zip",
+      verified: "downloads.tuxfamily.org/godotengine/"
   name "Godot Engine"
   desc "Game development engine"
-  homepage "https://godotengine.org"
+  homepage "https://godotengine.org/"
 
   livecheck do
     url "https://downloads.tuxfamily.org/godotengine/#{version.major_minor}/"

--- a/Casks/godot-alpha.rb
+++ b/Casks/godot-alpha.rb
@@ -1,4 +1,4 @@
-cask "godot-master" do
+cask "godot-alpha" do
     version "4.0-alpha10"
     sha256 "a4f6e466338253cbf2e5334534d9d7aad42773691f7a7749ebe97a3b95d9788a"
 

--- a/Casks/godot-alpha.rb
+++ b/Casks/godot-alpha.rb
@@ -1,30 +1,28 @@
 cask "godot-alpha" do
-    version "4.0-alpha10"
-    sha256 "a4f6e466338253cbf2e5334534d9d7aad42773691f7a7749ebe97a3b95d9788a"
+  version "4.0-alpha10"
+  sha256 "a4f6e466338253cbf2e5334534d9d7aad42773691f7a7749ebe97a3b95d9788a"
 
-    url "https://downloads.tuxfamily.org/godotengine/#{version.sub(%r{-alpha\d+}, '')}/#{version.minor.sub(%r{\d+-}, '')}/Godot_v#{version}_osx.universal.zip",
-      verified: "downloads.tuxfamily.org/godotengine/"
-    name "Godot Engine"
-    desc "Game development engine"
-    homepage "https://godotengine.org"
+  url "https://downloads.tuxfamily.org/godotengine/#{version.sub(%r{-alpha\d+}, '')}/#{version.minor.sub(%r{\d+-}, '')}/Godot_v#{version}_osx.universal.zip",
+    verified: "downloads.tuxfamily.org/godotengine/"
+  name "Godot Engine"
+  desc "Game development engine"
+  homepage "https://godotengine.org"
 
-    livecheck do
-      url "https://downloads.tuxfamily.org/godotengine/#{version.major_minor}/"
-      regex(/^alpha\d+$/i)
-    end
+  livecheck do
+    url "https://downloads.tuxfamily.org/godotengine/#{version.major_minor}/"
+    regex(/^alpha\d+$/i)
+  end
 
-    auto_updates true
-    conflicts_with cask: "godot"
-    depends_on macos: ">= :high_sierra"
+  conflicts_with cask: "godot"
 
-    app "Godot.app"
-    binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot"
+  app "Godot.app"
+  binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot"
 
-    uninstall quit: "org.godotengine.godot"
+  uninstall quit: "org.godotengine.godot"
 
-    zap trash: [
-      "~/Library/Application Support/Godot",
-      "~/Library/Caches/Godot",
-      "~/Library/Saved Application State/org.godotengine.godot.savedState",
-    ]
+  zap trash: [
+    "~/Library/Application Support/Godot",
+    "~/Library/Caches/Godot",
+    "~/Library/Saved Application State/org.godotengine.godot.savedState",
+  ]
 end


### PR DESCRIPTION
Hi!

Here is cask for Godot 4 alpha builds.

I have some issue with `brew audit` and I cannot find any solution. May be someone can help me.

Here is the command output:
```bash
> brew audit --cask --online godot-alpha
==> Downloading https://downloads.tuxfamily.org/godotengine/4.0/alpha10/Godot_v4.0-alpha10_osx.universal.zip
Already downloaded: /Users/dissfall/Library/Caches/Homebrew/downloads/53a5de0b0911b9da7475a47f3880f288d59238e65a70e1718485fd41ec130e23--Godot_v4.0-alpha10_osx.universal.zip
curl: (22) The requested URL returned error: 404
audit for godot-alpha: failed
 - exception while auditing godot-alpha: key not found: :latest
Error: 1 problem in 1 cask detected
```
</br></br>
After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
