### PR TITLE
Creates omegat-latest

### DIFF
--- a/Casks/omegat-latest.rb
+++ b/Casks/omegat-latest.rb
@@ -1,0 +1,25 @@
+cask "omegat-latest" do
+  version "5.7.1"
+  sha256 "557a4f21533e8f73a4463f4b195c2d81996fbc25e576e447add9f5ce68661949"
+
+  url "https://downloads.sourceforge.net/omegat/OmegaT%20-%20Latest/OmegaT%20#{version}/OmegaT_#{version}_Beta_Mac_Notarized.zip",
+      verified: "downloads.sourceforge.net/omegat/"
+  name "OmegaT 5"
+  desc "Translation memory tool"
+  homepage "https://omegat.org/"
+
+  livecheck do
+    url "https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Latest"
+  end
+
+  conflicts_with cask: "omegat"
+
+  app "OmegaT_#{version}_Beta_Mac_Notarized//OmegaT.app"
+
+  zap trash: [
+    "~/Library/Application Support/OmegaT",
+    "~/Library/Caches/OmegaT",
+    "~/Library/Preferences/OmegaT",
+    "~/Library/Saved Application State/org.omegat.OmegaT.savedState",
+  ]
+end


### PR DESCRIPTION
OmegaT (https://omegat.org) has two versions available as of now, 4.3.3 and 5.7.1, with the former labelled "Standard" and the latter "Latest". The standard version is available in homebrew/casks and I propose the latest variant here since the standard has more downloads in Sourceforge. The latest has beta in its name, but well, it's version 5.7.1 already, so it looks more like LTS and Latest.

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
