### PR TITLE
update rstudio-preview.rb

### DIFF
--- a/Casks/rstudio-preview.rb
+++ b/Casks/rstudio-preview.rb
@@ -1,8 +1,8 @@
 cask "rstudio-preview" do
-  version "2022.07.0,543"
-  sha256 "dae4d48972b37c693a42739b590f975f7b7b4b4a107dca3c9502c082af28f709"
+  version "2022.07.1,554"
+  sha256 "7b1a22854f10a9647a01ba442a50c26f0177b4cc9aa6faf9321a72eb861e5ca8"
 
-  url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version.csv.first}-preview-#{version.csv.second}.dmg",
+  url "https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/RStudio-#{version.csv.first}-#{version.csv.second}.dmg",
       verified: "s3.amazonaws.com/rstudio-ide-build/"
   name "RStudio"
   desc "Data science software focusing on R and Python"
@@ -10,7 +10,7 @@ cask "rstudio-preview" do
 
   livecheck do
     url :homepage
-    regex(/RStudio[._-](\d{4}\.\d{2}\.\d+)[._-]preview[._-](\d+)\.dmg/i)
+    regex(/RStudio[._-](\d{4}\.\d{2}\.\d+)[._-](\d+)\.dmg/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end


### PR DESCRIPTION
with new version and changed URL scheme (does no longer include '-preview-' for files)

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
