### PR TITLE
Update temurin11 to latest release

### DIFF
--- a/Casks/temurin11.rb
+++ b/Casks/temurin11.rb
@@ -1,11 +1,11 @@
 cask "temurin11" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  version "11.0.15,10"
-
   if Hardware::CPU.intel?
-    sha256 "ade3d0e0ace5783a097c094cc91a304e7ceaaba0b65bd6ac901529c1c0a157bc"
+    version "11.0.16,8"
+    sha256 "d0607b02fbaf95bffc5ccb44798883111e5fd277e589865f58647335a1334139"
   else
+    version "11.0.15,10"
     sha256 "44563c00c8df89e97aadd52b3bb6627c731882b435ef08ebf023ae432b131d68"
   end
 


### PR DESCRIPTION
For reasons not yet clear to me, they released updated binaries for x64 but not aarch64.

See: https://adoptium.net/temurin/releases?version=11

and: https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.16%2B8
vs: https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.15%2B10

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

FYI, I ran the commands above only on an x64 macOS laptop. I do not currently have access to an aarch64 laptop.