### PR TITLE
Update temurin17 to 17.0.4+8

### DIFF
--- a/Casks/temurin17.rb
+++ b/Casks/temurin17.rb
@@ -1,12 +1,12 @@
 cask "temurin17" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
+  version "17.0.4,8"
+
   if Hardware::CPU.intel?
-    version "17.0.4,8"
     sha256 "c67a539ab49d64de71d62dcdbed9f64c81ecddf67b654299cf0e2521ca0008c5"
   else
-    version "17.0.3,7"
-    sha256 "46da5d1620e9ac231eb8d01cca6714dee67c0db9c67ad340dca2c17bc29763ff"
+    sha256 "632e8220e4a71f73c51fe518551d8a7919eea7943339e435cd6fd61f6089cf0d"
   end
 
   url "https://github.com/adoptium/temurin#{version.major}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg",

--- a/Casks/temurin17.rb
+++ b/Casks/temurin17.rb
@@ -1,11 +1,11 @@
 cask "temurin17" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  version "17.0.3,7"
-
   if Hardware::CPU.intel?
-    sha256 "70afd9b4f76d69a5f9ab3f740a9289f41d23558f02b133e684c80380c265455f"
+    version "17.0.4,8"
+    sha256 "c67a539ab49d64de71d62dcdbed9f64c81ecddf67b654299cf0e2521ca0008c5"
   else
+    version "17.0.3,7"
     sha256 "46da5d1620e9ac231eb8d01cca6714dee67c0db9c67ad340dca2c17bc29763ff"
   end
 


### PR DESCRIPTION
Eclipse Temurin 17.0.4+8 has been released. It is only available for Intel based Macs.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
