### PR TITLE
Use `arch` and `on_arch_conditional` DSLs

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -1,5 +1,5 @@
 cask "1password-beta" do
-  arch = Hardware::CPU.intel? ? "x86_64" : "aarch64"
+  arch arm: "aarch64", intel: "x86_64"
 
   version "8.9.0-1.BETA"
 

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -1,5 +1,5 @@
 cask "android-studio-preview-beta" do
-  arch = Hardware::CPU.intel? ? "mac" : "mac_arm"
+  arch arm: "mac_arm", intel: "mac"
 
   version "2021.3.1.14"
 

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -1,5 +1,5 @@
 cask "android-studio-preview-canary" do
-  arch = Hardware::CPU.intel? ? "mac" : "mac_arm"
+  arch arm: "mac_arm", intel: "mac"
 
   version "2022.1.1.9"
 

--- a/Casks/anki-beta.rb
+++ b/Casks/anki-beta.rb
@@ -1,5 +1,5 @@
 cask "anki-beta" do
-  arch = Hardware::CPU.intel? ? "intel" : "apple"
+  arch arm: "apple", intel: "intel"
 
   version "2.1.54+rc3_a8e34ce4"
 

--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -1,5 +1,5 @@
 cask "appcode-eap" do
-  arch = Hardware::CPU.intel? ? "" : "-aarch64"
+  arch arm: "-aarch64"
 
   version "2022.2,222.3345.83"
 

--- a/Casks/blender-lts.rb
+++ b/Casks/blender-lts.rb
@@ -1,5 +1,5 @@
 cask "blender-lts" do
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  arch arm: "arm64", intel: "x64"
 
   version "2.93.10"
 

--- a/Casks/corretto11.rb
+++ b/Casks/corretto11.rb
@@ -1,5 +1,5 @@
 cask "corretto11" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+  arch arm: "aarch64", intel: "x64"
 
   version "11.0.16.8.3"
 

--- a/Casks/corretto17.rb
+++ b/Casks/corretto17.rb
@@ -1,5 +1,5 @@
 cask "corretto17" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+  arch arm: "aarch64", intel: "x64"
 
   version "17.0.4.8.1"
 

--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,5 +1,6 @@
 cask "corretto8" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+  arch arm: "aarch64", intel: "x64"
+
   version "8.342.07.3"
 
   if Hardware::CPU.intel?

--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -1,5 +1,5 @@
 cask "dropbox-beta" do
-  arch = Hardware::CPU.intel? ? "" : "&arch=arm64"
+  arch arm: "&arch=arm64"
 
   version "155.3.5473"
 

--- a/Casks/ferdi-beta.rb
+++ b/Casks/ferdi-beta.rb
@@ -1,5 +1,5 @@
 cask "ferdi-beta" do
-  arch = Hardware::CPU.intel? ? "" : "-arm64"
+  arch arm: "-arm64"
 
   version "5.8.1"
 

--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -1,6 +1,6 @@
 cask "github-beta" do
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
-  platform = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
+  arch arm: "arm64", intel: "x64"
+  platform = on_arch_conditional arm: "darwin-arm64", intel: "darwin"
 
   version "3.0.6-beta2-706ecf57"
 

--- a/Casks/google-chrome-dev.rb
+++ b/Casks/google-chrome-dev.rb
@@ -1,5 +1,5 @@
 cask "google-chrome-dev" do
-  arch = Hardware::CPU.intel? ? "" : "universal/"
+  arch arm: "universal/"
 
   version "106.0.5216.6"
   sha256 :no_check

--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -1,5 +1,5 @@
 cask "hyper-canary" do
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  arch arm: "arm64", intel: "x64"
 
   version "3.3.0-canary.2"
 

--- a/Casks/keepassxc-beta.rb
+++ b/Casks/keepassxc-beta.rb
@@ -1,5 +1,5 @@
 cask "keepassxc-beta" do
-  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
+  arch arm: "arm64", intel: "x86_64"
 
   version "2.7.1"
 

--- a/Casks/lando-edge.rb
+++ b/Casks/lando-edge.rb
@@ -1,5 +1,5 @@
 cask "lando-edge" do
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  arch arm: "arm64", intel: "x64"
 
   version "3.6.5"
 

--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -1,6 +1,7 @@
 cask "microsoft-edge-beta" do
-  folder = Hardware::CPU.intel? ? "C1297A47-86C4-4C1F-97FA-950631F94777" : "03adf619-38c6-4249-95ff-4a01c0ffc962"
-  linkid = Hardware::CPU.intel? ? "2069439" : "2099618"
+  folder = on_arch_conditional arm:   "03adf619-38c6-4249-95ff-4a01c0ffc962",
+                               intel: "C1297A47-86C4-4C1F-97FA-950631F94777"
+  linkid = on_arch_conditional arm: "2099618", intel: "2069439"
 
   version "104.0.1293.44"
 

--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -1,6 +1,7 @@
 cask "microsoft-edge-dev" do
-  folder = Hardware::CPU.intel? ? "C1297A47-86C4-4C1F-97FA-950631F94777" : "03adf619-38c6-4249-95ff-4a01c0ffc962"
-  linkid = Hardware::CPU.intel? ? "2069340" : "2099619"
+  folder = on_arch_conditional arm:   "03adf619-38c6-4249-95ff-4a01c0ffc962",
+                               intel: "C1297A47-86C4-4C1F-97FA-950631F94777"
+  linkid = on_arch_conditional arm: "2099619", intel: "2069340"
 
   version "105.0.1336.2"
 

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -1,5 +1,5 @@
 cask "powershell-preview" do
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  arch arm: "arm64", intel: "x64"
 
   version "7.3.0-preview.6"
 

--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -1,5 +1,5 @@
 cask "signal-beta" do
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  arch arm: "arm64", intel: "x64"
 
   version "5.55.0-beta.1"
 

--- a/Casks/slack-beta.rb
+++ b/Casks/slack-beta.rb
@@ -1,5 +1,5 @@
 cask "slack-beta" do
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  arch arm: "arm64", intel: "x64"
 
   version "4.28.163"
 

--- a/Casks/temurin11.rb
+++ b/Casks/temurin11.rb
@@ -1,5 +1,5 @@
 cask "temurin11" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+  arch arm: "aarch64", intel: "x64"
 
   version "11.0.16,8"
 

--- a/Casks/temurin17.rb
+++ b/Casks/temurin17.rb
@@ -1,5 +1,5 @@
 cask "temurin17" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+  arch arm: "aarch64", intel: "x64"
 
   version "17.0.4,8"
 

--- a/Casks/termius-beta.rb
+++ b/Casks/termius-beta.rb
@@ -1,5 +1,5 @@
 cask "termius-beta" do
-  arch = Hardware::CPU.intel? ? "mac-beta" : "mac-beta-arm64"
+  arch arm: "mac-beta-arm64", intel: "mac-beta"
 
   version "7.46.2"
   sha256 :no_check

--- a/Casks/visual-studio-code-insiders.rb
+++ b/Casks/visual-studio-code-insiders.rb
@@ -1,8 +1,8 @@
 cask "visual-studio-code-insiders" do
+  arch arm: "darwin-arm64", intel: "darwin"
+
   version :latest
   sha256 :no_check
-
-  arch = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
 
   url "https://code.visualstudio.com/sha/download?build=insider&os=#{arch}"
   name "Microsoft Visual Studio Code"

--- a/Casks/zulu11.rb
+++ b/Casks/zulu11.rb
@@ -1,6 +1,6 @@
 cask "zulu11" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
-  choice = Hardware::CPU.intel? ? "x86" : "arm"
+  arch arm: "aarch64", intel: "x64"
+  choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "11.0.16,11.58.15-ca"
 

--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -1,6 +1,6 @@
 cask "zulu13" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
-  choice = Hardware::CPU.intel? ? "x86" : "arm"
+  arch arm: "aarch64", intel: "x64"
+  choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "13.0.12,13.50.15-ca"
 

--- a/Casks/zulu15.rb
+++ b/Casks/zulu15.rb
@@ -1,6 +1,6 @@
 cask "zulu15" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
-  choice = Hardware::CPU.intel? ? "x86" : "arm"
+  arch arm: "aarch64", intel: "x64"
+  choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "15.0.8,15.42.15-ca"
 

--- a/Casks/zulu17.rb
+++ b/Casks/zulu17.rb
@@ -1,6 +1,6 @@
 cask "zulu17" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
-  choice = Hardware::CPU.intel? ? "x86" : "arm"
+  arch arm: "aarch64", intel: "x64"
+  choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "17.0.4,17.36.13-ca"
 

--- a/Casks/zulu8.rb
+++ b/Casks/zulu8.rb
@@ -1,6 +1,6 @@
 cask "zulu8" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
-  choice = Hardware::CPU.intel? ? "x86" : "arm"
+  arch arm: "aarch64", intel: "x64"
+  choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "8.0.345,8.64.0.19-ca"
 


### PR DESCRIPTION
This PR modifies some casks to use the new `arch` and `on_arch_conditional` DSLs instead of `arch = Hardware::CPU.intel? ? "intel" : "arm"`. All casks in this PR were modified using `brew style --fix` after checking out https://github.com/Homebrew/brew/pull/13681.

I've verified that everything is working as expected by running `brew info --json=v2` on these casks before and after the changes in this PR (I check on both Intel and ARM). There were no differences, indicating that all URLs remain the same after these changes.
