### PR TITLE
Use `on_intel` and `on_arm` blocks

### DIFF
--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -1,11 +1,13 @@
 cask "brave-browser-beta" do
-  arch, folder = Hardware::CPU.intel? ? ["x64", "beta"] : ["arm64", "beta-arm64"]
+  arch arm: "arm64", intel: "x64"
+  folder = on_arch_conditional arm: "beta-arm64", intel: "beta"
 
   version "1.43.67.0,143.67"
 
-  if Hardware::CPU.intel?
+  on_intel do
     sha256 "c2cef2f378a84a4470bed1647c2f30cb3765f084f658612db89523c8b2702ceb"
-  else
+  end
+  on_arm do
     sha256 "223837b8a087cc6ba21481e00099983c72b58630164569ebaef347c2b57aff1a"
   end
 

--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -1,11 +1,13 @@
 cask "libreoffice-still" do
-  arch, folder = Hardware::CPU.intel? ? ["x86-64", "x86_64"] : ["aarch64", "aarch64"]
+  arch arm: "aarch64", intel: "x86-64"
+  folder = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
   version "7.2.7"
 
-  if Hardware::CPU.intel?
+  on_intel do
     sha256 "9e6215ff612885aa610bb90248d75dc1299b0e45fa80ced862380999381bc16e"
-  else
+  end
+  on_arm do
     sha256 "9b29a0cb5a658867d97718347bb4980a244a30b64dfe4ff38aed618b97930261"
   end
 

--- a/Casks/vmware-fusion-tech-preview.rb
+++ b/Casks/vmware-fusion-tech-preview.rb
@@ -19,7 +19,7 @@ cask "vmware-fusion-tech-preview" do
   depends_on macos: ">= :catalina"
 
   app "VMware Fusion Tech Preview.app"
-  if Hardware::CPU.intel?
+  on_intel do
     binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vkd/bin/vctl"
     binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmrest"
     binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/VMware OVF Tool/ovftool"


### PR DESCRIPTION
This PR changes the remaining casks in this repo to use `on_arm` and `on_intel` blocks instead of `if Hardware::CPU.intel?`. The changes in this PR were made by running `brew style --fix homebrew/cask` using the style rules that were added in https://github.com/Homebrew/brew/pull/13698, but then I did some manual work on them since some additional changes were needed.

As before, I've run `brew info --json=v2 --all` both before and after these changes and compared the results. On both Intel and ARM, there were no differences.

See also: https://github.com/Homebrew/homebrew-cask-versions/pull/14492
See also: https://github.com/Homebrew/homebrew-cask/pull/129760
