### PR TITLE
adding version 3 to archive now version 4 is out

### DIFF
--- a/Casks/processing3.rb
+++ b/Casks/processing3.rb
@@ -18,7 +18,7 @@ cask "processing3" do
   end
 
   conflicts_with cask: [
-    "homebrew/cask-versions/processing",
+    "homebrew/cask/processing",
     "homebrew/cask-versions/processing2",
     "homebrew/cask-versions/processing-beta",
   ]

--- a/Casks/processing3.rb
+++ b/Casks/processing3.rb
@@ -1,0 +1,35 @@
+cask "processing3" do
+  version "3.5.4,0270"
+  sha256 "4d64fe42a6c5c0863cc82e93a036e73731999ee9448be45bc322f91b0010bb6b"
+
+  url "https://github.com/processing/processing/releases/download/processing-#{version.csv.second}-#{version.csv.first}/processing-#{version.csv.first}-macosx.zip",
+      verified: "github.com/processing/processing/"
+  name "Processing"
+  desc "Flexible software sketchbook and a language for learning how to code"
+  homepage "https://processing.org/"
+
+  livecheck do
+    url :url
+    regex(%r{href=.*?tree/processing[._-](\d+)[._-]v?(\d+(?:\.\d+)+)}i)
+    strategy :github_latest do |page|
+      page.scan(regex)
+          .map { |match| "#{match[1]},#{match[0]}" }
+    end
+  end
+
+  conflicts_with cask: [
+    "homebrew/cask-versions/processing",
+    "homebrew/cask-versions/processing2",
+    "homebrew/cask-versions/processing-beta",
+  ]
+
+  app "Processing.app"
+
+  uninstall quit: "org.processing.app"
+
+  zap trash: [
+    "~/Library/Processing",
+    "~/Preferences/org.processing.app.plist",
+    "~/Preferences/processing.app.tools.plist",
+  ]
+end

--- a/Casks/processing3.rb
+++ b/Casks/processing3.rb
@@ -18,9 +18,9 @@ cask "processing3" do
   end
 
   conflicts_with cask: [
-    "homebrew/cask/processing",
-    "homebrew/cask-versions/processing2",
-    "homebrew/cask-versions/processing-beta",
+    "processing",
+    "processing2",
+    "processing-beta",
   ]
 
   app "Processing.app"


### PR DESCRIPTION
- brew-cask has updated processing to v4 which is also a different git repo
- this is a copy of the old processing cask from brew-cask at last version 3.5.4,0270
- changed name from cask "processing” -> “processing3"
- added processing2 as conflict

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
