### PR TITLE
Use `sha256 arm: "...", intel: "..."`

### DIFF
--- a/Casks/1password-beta.rb
+++ b/Casks/1password-beta.rb
@@ -2,13 +2,8 @@ cask "1password-beta" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "8.9.4-6.BETA"
-
-  on_intel do
-    sha256 "40e734a29a227f255bc07d5a72657df5db2b92b1a9eb082a3def22495a497c89"
-  end
-  on_arm do
-    sha256 "050fce59e9564b64fcba0c3a5780f22a6150f957ac126afeea7791d71a317391"
-  end
+  sha256 arm:   "050fce59e9564b64fcba0c3a5780f22a6150f957ac126afeea7791d71a317391",
+         intel: "40e734a29a227f255bc07d5a72657df5db2b92b1a9eb082a3def22495a497c89"
 
   url "https://downloads.1password.com/mac/1Password-#{version}-#{arch}.zip"
   name "1Password"

--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -2,13 +2,8 @@ cask "android-studio-preview-beta" do
   arch arm: "mac_arm", intel: "mac"
 
   version "2021.3.1.15"
-
-  on_intel do
-    sha256 "667f475b9b9e9f317ad0150a34372623333118bed4060e966c3e64cb46a87966"
-  end
-  on_arm do
-    sha256 "8cbe062c4012612a40a014a5ebb82bdf959b0601329cf3652aeb726b190c3673"
-  end
+  sha256 arm:   "8cbe062c4012612a40a014a5ebb82bdf959b0601329cf3652aeb726b190c3673",
+         intel: "667f475b9b9e9f317ad0150a34372623333118bed4060e966c3e64cb46a87966"
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version}/android-studio-#{version}-#{arch}.zip",
       verified: "dl.google.com/dl/android/studio/"

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -2,13 +2,8 @@ cask "android-studio-preview-canary" do
   arch arm: "mac_arm", intel: "mac"
 
   version "2022.1.1.9"
-
-  on_intel do
-    sha256 "75078236fe0bd9fc8224356763b25701fbffe7958a5ac8dd272ca478f27592b9"
-  end
-  on_arm do
-    sha256 "dea4623a3b837b5068a2c4cbf10598f722e69f21f7c6ec5320c7e9ca9f8d06b9"
-  end
+  sha256 arm:   "dea4623a3b837b5068a2c4cbf10598f722e69f21f7c6ec5320c7e9ca9f8d06b9",
+         intel: "75078236fe0bd9fc8224356763b25701fbffe7958a5ac8dd272ca478f27592b9"
 
   url "https://dl.google.com/dl/android/studio/ide-zips/#{version}/android-studio-#{version}-#{arch}.zip",
       verified: "dl.google.com/dl/android/studio/"

--- a/Casks/anki-beta.rb
+++ b/Casks/anki-beta.rb
@@ -2,13 +2,8 @@ cask "anki-beta" do
   arch arm: "apple", intel: "intel"
 
   version "2.1.54+rc3_a8e34ce4"
-
-  on_intel do
-    sha256 "05c02714d2f71ee6cc7b1332f7c90e10e88df4a3e23f07336817cb15bd0c71b5"
-  end
-  on_arm do
-    sha256 "1094c787826295aace1a89c624516aa48c9d533375db8cba82f694d2e0424fe9"
-  end
+  sha256 arm:   "1094c787826295aace1a89c624516aa48c9d533375db8cba82f694d2e0424fe9",
+         intel: "05c02714d2f71ee6cc7b1332f7c90e10e88df4a3e23f07336817cb15bd0c71b5"
 
   url "https://apps.ankiweb.net/downloads/beta/anki-#{version}-mac-#{arch}-qt6.dmg"
   name "Anki Beta"

--- a/Casks/appcode-eap.rb
+++ b/Casks/appcode-eap.rb
@@ -2,13 +2,8 @@ cask "appcode-eap" do
   arch arm: "-aarch64"
 
   version "2022.2,222.3345.83"
-
-  on_intel do
-    sha256 "49f789d858ab1ffbb75424138fa33113f4373e1390a379415763667ea7e18aa4"
-  end
-  on_arm do
-    sha256 "5f7b318f98086008c262f1d33dbed341c990b31a6dd16eb3c6e68d9e638299a1"
-  end
+  sha256 arm:   "5f7b318f98086008c262f1d33dbed341c990b31a6dd16eb3c6e68d9e638299a1",
+         intel: "49f789d858ab1ffbb75424138fa33113f4373e1390a379415763667ea7e18aa4"
 
   url "https://download.jetbrains.com/objc/AppCode-#{version.csv.second}#{arch}.dmg"
   name "AppCode EAP"

--- a/Casks/blender-lts.rb
+++ b/Casks/blender-lts.rb
@@ -2,13 +2,8 @@ cask "blender-lts" do
   arch arm: "arm64", intel: "x64"
 
   version "2.93.10"
-
-  on_intel do
-    sha256 "21bd814c76d2545c01064434448fad65d2254e726376f594091fda4fc8103e6c"
-  end
-  on_arm do
-    sha256 "314c82351dab9a9345f303587d9ec36154b06fd4151a83ab62d828c7567a43ae"
-  end
+  sha256 arm:   "314c82351dab9a9345f303587d9ec36154b06fd4151a83ab62d828c7567a43ae",
+         intel: "21bd814c76d2545c01064434448fad65d2254e726376f594091fda4fc8103e6c"
 
   url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg"
   name "Blender"

--- a/Casks/brave-browser-beta.rb
+++ b/Casks/brave-browser-beta.rb
@@ -3,13 +3,8 @@ cask "brave-browser-beta" do
   folder = on_arch_conditional arm: "beta-arm64", intel: "beta"
 
   version "1.43.74.0,143.74"
-
-  on_intel do
-    sha256 "a4a03ac1b80282ac6504b7115d298dbcc80267935af8cf5c55740ba1760407bc"
-  end
-  on_arm do
-    sha256 "31df7ee7aa80138e6d232d2d8dc9171e3d97de038d668c51112c39ca578c7b98"
-  end
+  sha256 arm:   "31df7ee7aa80138e6d232d2d8dc9171e3d97de038d668c51112c39ca578c7b98",
+         intel: "a4a03ac1b80282ac6504b7115d298dbcc80267935af8cf5c55740ba1760407bc"
 
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/#{folder}/#{version.csv.second}/Brave-Browser-Beta-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Browser/"

--- a/Casks/brave-browser-dev.rb
+++ b/Casks/brave-browser-dev.rb
@@ -3,13 +3,8 @@ cask "brave-browser-dev" do
   folder = on_arch_conditional arm: "dev-arm64", intel: "dev"
 
   version "1.43.75.0,143.75"
-
-  on_intel do
-    sha256 "451b0030323131721e743c24ebbc36460cbe7da234264bddd9a851cce5dbb847"
-  end
-  on_arm do
-    sha256 "e3ce0108d8ba2420284272ffe550bd777223949e1ec92e205b6e5c4a79437a57"
-  end
+  sha256 arm:   "e3ce0108d8ba2420284272ffe550bd777223949e1ec92e205b6e5c4a79437a57",
+         intel: "451b0030323131721e743c24ebbc36460cbe7da234264bddd9a851cce5dbb847"
 
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/#{folder}/#{version.csv.second}/Brave-Browser-Dev-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Browser/"

--- a/Casks/corretto11.rb
+++ b/Casks/corretto11.rb
@@ -2,13 +2,8 @@ cask "corretto11" do
   arch arm: "aarch64", intel: "x64"
 
   version "11.0.16.9.1"
-
-  on_intel do
-    sha256 "1b256d7104ebc0f72d7745962e0ab47cbbbd976f93481f31bd4a7d40812d739a"
-  end
-  on_arm do
-    sha256 "a460362f97e5371221e76386ea08ba0773c524f8ce7a2f85cb398b62f5c28aca"
-  end
+  sha256 arm:   "a460362f97e5371221e76386ea08ba0773c524f8ce7a2f85cb398b62f5c28aca",
+         intel: "1b256d7104ebc0f72d7745962e0ab47cbbbd976f93481f31bd4a7d40812d739a"
 
   url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "AWS Corretto JDK"

--- a/Casks/corretto17.rb
+++ b/Casks/corretto17.rb
@@ -2,13 +2,8 @@ cask "corretto17" do
   arch arm: "aarch64", intel: "x64"
 
   version "17.0.4.9.1"
-
-  on_intel do
-    sha256 "a91db130cbf99ab993d5d579a71ee7cd7c2682c2b6698d9353db1a5393b01f7f"
-  end
-  on_arm do
-    sha256 "d46bf6798a54c283cc4297dc86cb0173571b7dfc70b3609846911bb5ac3ffdb8"
-  end
+  sha256 arm:   "d46bf6798a54c283cc4297dc86cb0173571b7dfc70b3609846911bb5ac3ffdb8",
+         intel: "a91db130cbf99ab993d5d579a71ee7cd7c2682c2b6698d9353db1a5393b01f7f"
 
   url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "AWS Corretto JDK"

--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -2,13 +2,8 @@ cask "corretto8" do
   arch arm: "aarch64", intel: "x64"
 
   version "8.342.07.3"
-
-  on_intel do
-    sha256 "5bde0f3682e9f809d620220bbca414a3493af41ce219509d840b17da85e0070a"
-  end
-  on_arm do
-    sha256 "159d27625838c12f0fa6f6edc7b3c50924362f022c4490605f3798d947bcf9bf"
-  end
+  sha256 arm:   "159d27625838c12f0fa6f6edc7b3c50924362f022c4490605f3798d947bcf9bf",
+         intel: "5bde0f3682e9f809d620220bbca414a3493af41ce219509d840b17da85e0070a"
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "Amazon Corretto JDK"

--- a/Casks/dropbox-beta.rb
+++ b/Casks/dropbox-beta.rb
@@ -2,13 +2,8 @@ cask "dropbox-beta" do
   arch arm: "&arch=arm64"
 
   version "156.3.4860"
-
-  on_intel do
-    sha256 "9c71460b5d405f57981b6244436b20fa46f773ee97b351eb4a1e96d036d4bf9d"
-  end
-  on_arm do
-    sha256 "a2916cb7d4e73145ff2fa6dda12b123c9f67febc098699133b8a12477cdd2b5e"
-  end
+  sha256 arm:   "a2916cb7d4e73145ff2fa6dda12b123c9f67febc098699133b8a12477cdd2b5e",
+         intel: "9c71460b5d405f57981b6244436b20fa46f773ee97b351eb4a1e96d036d4bf9d"
 
   url "https://www.dropbox.com/download?build=#{version}&plat=mac&type=full#{arch}",
       verified: "dropbox.com/"

--- a/Casks/ferdi-beta.rb
+++ b/Casks/ferdi-beta.rb
@@ -2,13 +2,8 @@ cask "ferdi-beta" do
   arch arm: "-arm64"
 
   version "5.8.1"
-
-  on_intel do
-    sha256 "fa802e2627dc2c9c5ccface1f9c830c5a2e0e9ae7a7339716651010e39928a50"
-  end
-  on_arm do
-    sha256 "ec7ccceba08f1c581290d6ce4f5fa5478bed2c713c592d0298856f7b2719f35d"
-  end
+  sha256 arm:   "ec7ccceba08f1c581290d6ce4f5fa5478bed2c713c592d0298856f7b2719f35d",
+         intel: "fa802e2627dc2c9c5ccface1f9c830c5a2e0e9ae7a7339716651010e39928a50"
 
   url "https://github.com/getferdi/ferdi/releases/download/v#{version}/Ferdi-#{version}#{arch}.dmg",
       verified: "github.com/getferdi/ferdi/"

--- a/Casks/figma-beta.rb
+++ b/Casks/figma-beta.rb
@@ -2,13 +2,8 @@ cask "figma-beta" do
   arch arm: "mac-arm", intel: "mac"
 
   version "116.3.5"
-
-  on_intel do
-    sha256 "a5e37de108288ed5aea27db5d51efe80b230aa82d3a8e459b7015cd13a6c9e7d"
-  end
-  on_arm do
-    sha256 "4ba3b691653fccd6f2fe9088d024fbf49ab6743534973b88a21196a6b70e08e1"
-  end
+  sha256 arm:   "4ba3b691653fccd6f2fe9088d024fbf49ab6743534973b88a21196a6b70e08e1",
+         intel: "a5e37de108288ed5aea27db5d51efe80b230aa82d3a8e459b7015cd13a6c9e7d"
 
   url "https://desktop.figma.com/#{arch}/beta/FigmaBeta-#{version}.zip"
   name "Figma Beta"

--- a/Casks/github-beta.rb
+++ b/Casks/github-beta.rb
@@ -3,13 +3,8 @@ cask "github-beta" do
   platform = on_arch_conditional arm: "darwin-arm64", intel: "darwin"
 
   version "3.0.6-beta3-b91c5ae9"
-
-  on_intel do
-    sha256 "3f9c412e2fb33ba4a6db878ddd5c99f1780b441848d2b432a75ef6b4b024b883"
-  end
-  on_arm do
-    sha256 "4feaf76c60499c4d0f9db139065f1227116efea0b44582894336525cceb576f4"
-  end
+  sha256 arm:   "4feaf76c60499c4d0f9db139065f1227116efea0b44582894336525cceb576f4",
+         intel: "3f9c412e2fb33ba4a6db878ddd5c99f1780b441848d2b432a75ef6b4b024b883"
 
   url "https://desktop.githubusercontent.com/github-desktop/releases/#{version}/GitHubDesktop-#{arch}.zip",
       verified: "desktop.githubusercontent.com/github-desktop/"

--- a/Casks/hyper-canary.rb
+++ b/Casks/hyper-canary.rb
@@ -2,13 +2,8 @@ cask "hyper-canary" do
   arch arm: "arm64", intel: "x64"
 
   version "3.4.0-canary.1"
-
-  on_intel do
-    sha256 "e1ca5dd3685613bc944c03285611ac2739c450800ed35048edaa9f69458ddfeb"
-  end
-  on_arm do
-    sha256 "66b3550de27ec0afde359e6fd5105176bd6446a7cfc11964636156bcbfb8724f"
-  end
+  sha256 arm:   "66b3550de27ec0afde359e6fd5105176bd6446a7cfc11964636156bcbfb8724f",
+         intel: "e1ca5dd3685613bc944c03285611ac2739c450800ed35048edaa9f69458ddfeb"
 
   url "https://github.com/vercel/hyper/releases/download/v#{version}/Hyper-#{version}-mac-#{arch}.zip",
       verified: "github.com/vercel/hyper/"

--- a/Casks/java-beta.rb
+++ b/Casks/java-beta.rb
@@ -2,13 +2,8 @@ cask "java-beta" do
   arch arm: "aarch64", intel: "x64"
 
   version "19,877d6127e982470ba2a7faa31cc93d04,35"
-
-  on_intel do
-    sha256 "e78eae7d8957f27d530196c59f9b6cba68931ee94ee30fb49f2fe6d17a44a882"
-  end
-  on_arm do
-    sha256 "a54aa5134e797c41c516937e555caa671ba70dafbac1b78d74751333f673061d"
-  end
+  sha256 arm:   "a54aa5134e797c41c516937e555caa671ba70dafbac1b78d74751333f673061d",
+         intel: "e78eae7d8957f27d530196c59f9b6cba68931ee94ee30fb49f2fe6d17a44a882"
 
   url "https://download.java.net/java/GA/jdk#{version.major}/#{version.csv.second}/#{version.csv.third}/GPL/openjdk-#{version.csv.first}_macos-#{arch}_bin.tar.gz"
   name "OpenJDK Early Access Java Development Kit"

--- a/Casks/keepassxc-beta.rb
+++ b/Casks/keepassxc-beta.rb
@@ -2,13 +2,8 @@ cask "keepassxc-beta" do
   arch arm: "arm64", intel: "x86_64"
 
   version "2.7.1"
-
-  on_intel do
-    sha256 "473f994698ec082f16bb20b4824dadbfb744f53a01b737b4016f6cc45f403b83"
-  end
-  on_arm do
-    sha256 "97e7c57b4695cf4a558186cd36b89605ec6d6dec8791f7add043a3a387089f01"
-  end
+  sha256 arm:   "97e7c57b4695cf4a558186cd36b89605ec6d6dec8791f7add043a3a387089f01",
+         intel: "473f994698ec082f16bb20b4824dadbfb744f53a01b737b4016f6cc45f403b83"
 
   url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-#{arch}.dmg",
       verified: "github.com/keepassxreboot/keepassxc/"

--- a/Casks/lando-edge.rb
+++ b/Casks/lando-edge.rb
@@ -2,13 +2,8 @@ cask "lando-edge" do
   arch arm: "arm64", intel: "x64"
 
   version "3.6.5"
-
-  on_intel do
-    sha256 "31efde4bc474ab63f2eb418fc0891704f31f1f16f0a3023440aada06f5229221"
-  end
-  on_arm do
-    sha256 "4e1789b78690ea0b430ee73460c747b9c234554fc108a581e1802f02eec87af6"
-  end
+  sha256 arm:   "4e1789b78690ea0b430ee73460c747b9c234554fc108a581e1802f02eec87af6",
+         intel: "31efde4bc474ab63f2eb418fc0891704f31f1f16f0a3023440aada06f5229221"
 
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-#{arch}-v#{version}.dmg",
       verified: "github.com/lando/lando/"

--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -3,13 +3,8 @@ cask "libreoffice-still" do
   folder = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
   version "7.3.5"
-
-  on_intel do
-    sha256 "9534e444b3102a653f3d0c0e3fb54efb20caf2c91ce121b2db00d2531ab8b7fa"
-  end
-  on_arm do
-    sha256 "dfd30d5d520959ee1b65a620d748a0ac5535d1a9e811f83fa35a14dc8d3d736d"
-  end
+  sha256 arm:   "dfd30d5d520959ee1b65a620d748a0ac5535d1a9e811f83fa35a14dc8d3d736d",
+         intel: "9534e444b3102a653f3d0c0e3fb54efb20caf2c91ce121b2db00d2531ab8b7fa"
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"

--- a/Casks/microsoft-edge-beta.rb
+++ b/Casks/microsoft-edge-beta.rb
@@ -4,13 +4,8 @@ cask "microsoft-edge-beta" do
   linkid = on_arch_conditional arm: "2099618", intel: "2069439"
 
   version "105.0.1343.7"
-
-  on_intel do
-    sha256 "98a95ef69c90f6bde4d91a23f3f138ab1910785d7decff8c949bc7d036c81cf7"
-  end
-  on_arm do
-    sha256 "5faadb8e000e4f7e5ec76cabfa970320e10c8dc03d331e99455048a6e557899d"
-  end
+  sha256 arm:   "5faadb8e000e4f7e5ec76cabfa970320e10c8dc03d331e99455048a6e557899d",
+         intel: "98a95ef69c90f6bde4d91a23f3f138ab1910785d7decff8c949bc7d036c81cf7"
 
   url "https://officecdn-microsoft-com.akamaized.net/pr/#{folder}/MacAutoupdate/MicrosoftEdgeBeta-#{version}.pkg",
       verified: "officecdn-microsoft-com.akamaized.net/"

--- a/Casks/microsoft-edge-dev.rb
+++ b/Casks/microsoft-edge-dev.rb
@@ -4,13 +4,8 @@ cask "microsoft-edge-dev" do
   linkid = on_arch_conditional arm: "2099619", intel: "2069340"
 
   version "106.0.1349.1"
-
-  on_intel do
-    sha256 "0d16b11a5766ca307c29b4280e85c33284457f1681fbca5e21ec2d1e224167a1"
-  end
-  on_arm do
-    sha256 "6318031f9e68eecf70533a0079db1ae4d7e05603a5ce44b7535fffac034c9d49"
-  end
+  sha256 arm:   "6318031f9e68eecf70533a0079db1ae4d7e05603a5ce44b7535fffac034c9d49",
+         intel: "0d16b11a5766ca307c29b4280e85c33284457f1681fbca5e21ec2d1e224167a1"
 
   url "https://officecdn-microsoft-com.akamaized.net/pr/#{folder}/MacAutoupdate/MicrosoftEdgeDev-#{version}.pkg",
       verified: "officecdn-microsoft-com.akamaized.net/"

--- a/Casks/obs-beta.rb
+++ b/Casks/obs-beta.rb
@@ -2,13 +2,8 @@ cask "obs-beta" do
   arch arm: "arm64", intel: "x86_64"
 
   version "28.0.0-rc1"
-
-  on_intel do
-    sha256 "597445b2fcba4288266b71d3d313e6356dff08815499ec62301c439b1a30a579"
-  end
-  on_arm do
-    sha256 "65f34b8f517abffc8bd6f612e5109148b7ef2f3e19020134fb6c1359b09f506c"
-  end
+  sha256 arm:   "65f34b8f517abffc8bd6f612e5109148b7ef2f3e19020134fb6c1359b09f506c",
+         intel: "597445b2fcba4288266b71d3d313e6356dff08815499ec62301c439b1a30a579"
 
   url "https://github.com/obsproject/obs-studio/releases/download/#{version}/obs-studio-#{version}-macos-#{arch}.dmg",
       verified: "github.com/obsproject/obs-studio/"

--- a/Casks/powershell-preview.rb
+++ b/Casks/powershell-preview.rb
@@ -2,13 +2,8 @@ cask "powershell-preview" do
   arch arm: "arm64", intel: "x64"
 
   version "7.3.0-preview.7"
-
-  on_intel do
-    sha256 "5400440394789bb4befd276445f0d7b8e2a5d69248d28235b120fc11a41614af"
-  end
-  on_arm do
-    sha256 "53bab97898b7e23d65393f47661745f8c376928ba711b08bef2f3eea2395fa10"
-  end
+  sha256 arm:   "53bab97898b7e23d65393f47661745f8c376928ba711b08bef2f3eea2395fa10",
+         intel: "5400440394789bb4befd276445f0d7b8e2a5d69248d28235b120fc11a41614af"
 
   url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-#{arch}.pkg"
   name "PowerShell"

--- a/Casks/signal-beta.rb
+++ b/Casks/signal-beta.rb
@@ -2,13 +2,8 @@ cask "signal-beta" do
   arch arm: "arm64", intel: "x64"
 
   version "5.56.0-beta.1"
-
-  on_intel do
-    sha256 "91117ef684ef8985bea49b04f39fcb6ce9873100399c39594fd2a1715c6dfdb8"
-  end
-  on_arm do
-    sha256 "da3ccf3039de3f48ce07701823da218802b8c1be8fee8e71978d6b5c797f95f1"
-  end
+  sha256 arm:   "da3ccf3039de3f48ce07701823da218802b8c1be8fee8e71978d6b5c797f95f1",
+         intel: "91117ef684ef8985bea49b04f39fcb6ce9873100399c39594fd2a1715c6dfdb8"
 
   url "https://updates.signal.org/desktop/signal-desktop-beta-mac-#{arch}-#{version}.dmg"
   name "Signal Beta"

--- a/Casks/slack-beta.rb
+++ b/Casks/slack-beta.rb
@@ -2,13 +2,8 @@ cask "slack-beta" do
   arch arm: "arm64", intel: "x64"
 
   version "4.28.163"
-
-  on_intel do
-    sha256 "e05fba133693a508b145d9014befe5ea2ba097ae67ce8470fbf56e01205f4ff7"
-  end
-  on_arm do
-    sha256 "e0e649c470e2bcdc687d825a5291359ec5299fb0db70cce4e2031f15aac98795"
-  end
+  sha256 arm:   "e0e649c470e2bcdc687d825a5291359ec5299fb0db70cce4e2031f15aac98795",
+         intel: "e05fba133693a508b145d9014befe5ea2ba097ae67ce8470fbf56e01205f4ff7"
 
   url "https://downloads.slack-edge.com/releases/macos/#{version}/prod/#{arch}/Slack-#{version}-macOS.dmg",
       verified: "downloads.slack-edge.com/releases/macos/"

--- a/Casks/temurin11.rb
+++ b/Casks/temurin11.rb
@@ -2,13 +2,8 @@ cask "temurin11" do
   arch arm: "aarch64", intel: "x64"
 
   version "11.0.16,8"
-
-  on_intel do
-    sha256 "d0607b02fbaf95bffc5ccb44798883111e5fd277e589865f58647335a1334139"
-  end
-  on_arm do
-    sha256 "7478f20b24db0c7904902fbaa2915943a9d9fd492d556d85a4cc83a802735ecb"
-  end
+  sha256 arm:   "7478f20b24db0c7904902fbaa2915943a9d9fd492d556d85a4cc83a802735ecb",
+         intel: "d0607b02fbaf95bffc5ccb44798883111e5fd277e589865f58647335a1334139"
 
   url "https://github.com/adoptium/temurin#{version.major}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg",
       verified: "github.com/adoptium/"

--- a/Casks/temurin17.rb
+++ b/Casks/temurin17.rb
@@ -2,13 +2,8 @@ cask "temurin17" do
   arch arm: "aarch64", intel: "x64"
 
   version "17.0.4,8"
-
-  on_intel do
-    sha256 "c67a539ab49d64de71d62dcdbed9f64c81ecddf67b654299cf0e2521ca0008c5"
-  end
-  on_arm do
-    sha256 "632e8220e4a71f73c51fe518551d8a7919eea7943339e435cd6fd61f6089cf0d"
-  end
+  sha256 arm:   "632e8220e4a71f73c51fe518551d8a7919eea7943339e435cd6fd61f6089cf0d",
+         intel: "c67a539ab49d64de71d62dcdbed9f64c81ecddf67b654299cf0e2521ca0008c5"
 
   url "https://github.com/adoptium/temurin#{version.major}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg",
       verified: "github.com/adoptium/"

--- a/Casks/zulu11.rb
+++ b/Casks/zulu11.rb
@@ -3,13 +3,8 @@ cask "zulu11" do
   choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "11.0.16,11.58.15-ca"
-
-  on_intel do
-    sha256 "debf7d2adde7555fe22aab6f7aad2401cc01f279e7ef869a3e9af186b794942e"
-  end
-  on_arm do
-    sha256 "b87a7d2567e4e0bde7fd631b56d1f1598c0ab4566afbf801d14203dc3e1c9508"
-  end
+  sha256 arm:   "b87a7d2567e4e0bde7fd631b56d1f1598c0ab4566afbf801d14203dc3e1c9508",
+         intel: "debf7d2adde7555fe22aab6f7aad2401cc01f279e7ef869a3e9af186b794942e"
 
   url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
       referer: "https://www.azul.com/downloads/zulu/zulu-mac/"

--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -3,13 +3,8 @@ cask "zulu13" do
   choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "13.0.12,13.50.15-ca"
-
-  on_intel do
-    sha256 "c69dfddd23342c893af78a4d4298ee330fd6bcae6256913bdebbd1ba7438814a"
-  end
-  on_arm do
-    sha256 "9a8bf5f71097cc4b51285bb6f6ea909697573767306852c4cb91dcf4ceea6c3d"
-  end
+  sha256 arm:   "9a8bf5f71097cc4b51285bb6f6ea909697573767306852c4cb91dcf4ceea6c3d",
+         intel: "c69dfddd23342c893af78a4d4298ee330fd6bcae6256913bdebbd1ba7438814a"
 
   url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
       referer: "https://www.azul.com/downloads/zulu/zulu-mac/"

--- a/Casks/zulu15.rb
+++ b/Casks/zulu15.rb
@@ -3,13 +3,8 @@ cask "zulu15" do
   choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "15.0.8,15.42.15-ca"
-
-  on_intel do
-    sha256 "27f19d400458de8414d2844f6f0d5f86d6220c4aea3e58ecd5aa136c3191b41f"
-  end
-  on_arm do
-    sha256 "4093ee1d83f176d561c14980d5e39b869c9c1c61aea50c5914fd857f12e473ac"
-  end
+  sha256 arm:   "4093ee1d83f176d561c14980d5e39b869c9c1c61aea50c5914fd857f12e473ac",
+         intel: "27f19d400458de8414d2844f6f0d5f86d6220c4aea3e58ecd5aa136c3191b41f"
 
   url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
       referer: "https://www.azul.com/downloads/zulu/zulu-mac/"

--- a/Casks/zulu17.rb
+++ b/Casks/zulu17.rb
@@ -3,13 +3,8 @@ cask "zulu17" do
   choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "17.0.4,17.36.13-ca"
-
-  on_intel do
-    sha256 "3a3143b0f89ad5b07b44fa81078f38ef181d6f4e03649ab04360a261be64284a"
-  end
-  on_arm do
-    sha256 "7a945596e479b2e3aeb40a89d05fd54652ba9c96d69b8dddae7656c7e171eb47"
-  end
+  sha256 arm:   "7a945596e479b2e3aeb40a89d05fd54652ba9c96d69b8dddae7656c7e171eb47",
+         intel: "3a3143b0f89ad5b07b44fa81078f38ef181d6f4e03649ab04360a261be64284a"
 
   url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
       referer: "https://www.azul.com/downloads/zulu/zulu-mac/"

--- a/Casks/zulu8.rb
+++ b/Casks/zulu8.rb
@@ -3,13 +3,8 @@ cask "zulu8" do
   choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "8.0.345,8.64.0.19-ca"
-
-  on_intel do
-    sha256 "544634829882d81f2b10105838f1db34ace71dd117e01e3b3da52a01b6750840"
-  end
-  on_arm do
-    sha256 "8e7b33273a9f364394497635d470894458aefef9457c375e58bdc97cdd67df63"
-  end
+  sha256 arm:   "8e7b33273a9f364394497635d470894458aefef9457c375e58bdc97cdd67df63",
+         intel: "544634829882d81f2b10105838f1db34ace71dd117e01e3b3da52a01b6750840"
 
   url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
       referer: "https://www.azul.com/downloads/zulu/zulu-mac/"


### PR DESCRIPTION
This PR changes all casks in this repo to use the new `sha256 arm: "...", intel: "..."` DSL instead of nesting only a single `sha256` in `on_arm` and `on_intel` blocks.

The changes in this PR were made by running `brew style --fix homebrew/cask-versions` using the style rules that are being worked on in https://github.com/Homebrew/brew/pull/13703.

As before, I've run `brew info --json=v2 --all` both before and after these changes and compared the results. On both Intel and ARM, there were no differences.

See also: https://github.com/Homebrew/brew/pull/13702
See also: https://github.com/Homebrew/homebrew-cask/pull/130260
