### PR TITLE
vmware-fusion-tech-preview: separate `on_intel` block

### DIFF
--- a/Casks/vmware-fusion-tech-preview.rb
+++ b/Casks/vmware-fusion-tech-preview.rb
@@ -19,11 +19,6 @@ cask "vmware-fusion-tech-preview" do
   depends_on macos: ">= :catalina"
 
   app "VMware Fusion Tech Preview.app"
-  on_intel do
-    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vkd/bin/vctl"
-    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmrest"
-    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/VMware OVF Tool/ovftool"
-  end
   binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmnet-bridge"
   binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmnet-cfgcli"
   binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmnet-cli"
@@ -47,6 +42,12 @@ cask "vmware-fusion-tech-preview" do
   binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmware-vmx"
   binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmware-vmx-debug"
   binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmware-vmx-stats"
+
+  on_intel do
+    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vkd/bin/vctl"
+    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmrest"
+    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/VMware OVF Tool/ovftool"
+  end
 
   postflight do
     system_command "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/Initialize VMware Fusion.tool",


### PR DESCRIPTION
This is a small PR to adjust the style of `vmware-fusion-tech-preview`. I moved the `on_intel` block surrounding some `binary` stanzas to be below the rest of the `binary` stanzas that aren't conditionally added. This allows for an empty line above the `on_intel` block which will be needed for some cask style changes that are needed to help finish the migration to `on_{system}` blocks.
