### PR TITLE
sequel-pro-nightly: revert to https

### DIFF
--- a/Casks/sequel-pro-nightly.rb
+++ b/Casks/sequel-pro-nightly.rb
@@ -2,12 +2,12 @@ cask "sequel-pro-nightly" do
   version :latest
   sha256 :no_check
 
-  url "http://sequelpro.com/builds/latest-test-build.xml" do |page|
-    page[%r{https://sequelpro.com/builds/Sequel-Pro-Build-\w+.zip}].sub("https:", "http:")
+  url "https://sequelpro.com/builds/latest-test-build.xml" do |page|
+    page[%r{https://sequelpro.com/builds/Sequel-Pro-Build-\w+.zip}]
   end
   name "Sequel Pro"
   desc "MySQL/MariaDB database management platform"
-  homepage "http://sequelpro.com/test-builds"
+  homepage "https://sequelpro.com/test-builds"
 
   app "Sequel Pro.app"
 


### PR DESCRIPTION
Revert of #13822 , certificate fixed at https://sequelpro.com (`Let's Encrypt, expiry: 2022-12-22`)

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
