### PR TITLE
tunnelblick-beta: update livecheck

### DIFF
--- a/Casks/tunnelblick-beta.rb
+++ b/Casks/tunnelblick-beta.rb
@@ -10,12 +10,9 @@ cask "tunnelblick-beta" do
 
   livecheck do
     url "https://github.com/Tunnelblick/Tunnelblick/releases"
-    regex(%r{href=.*?/Tunnelblick_(\d+(?:\.\d+)*beta(?:\d+))_build_(\d+)\.dmg}i)
+    regex(/Tunnelblick\s+?(\d+(?:\.\d+)*beta(?:\d+)[a-z]?)\s+?\(build\s+?(\d+)/i)
     strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `tunnelblick-beta` identifies versions from the dmg file in release asset lists. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

The Tunnelblick repository consistently creates releases with a title format like "Tunnelblick 3.8.8beta04 (build 5800)", so we can simply match against this text for now. This saves us from having to use the heavier approach of fetching the release page to identify beta versions and then fetching the assets list for the newest beta release, which would involve multiple requests. We can always revisit this if this breaks in the future (or misses a version we should match).

Besides that, this updates the `strategy` block logic to use the `page.scan(regex).map` approach (allowing livecheck to do version comparison) instead of assuming the first match will always be the highest version (i.e., we've seen some other repositories maintaining more than one major/minor version and this can trip us up if a lower version is released after a higher version).