### PR TITLE
mullvadvpn-beta 2022.5-beta2

### DIFF
--- a/Casks/mullvadvpn-beta.rb
+++ b/Casks/mullvadvpn-beta.rb
@@ -1,6 +1,6 @@
 cask "mullvadvpn-beta" do
-  version "2022.3-beta3"
-  sha256 "ef6fbdf5f254955e188e31b6405ae71af8e3daeeb78ff00e7c95cc7d7cc807e9"
+  version "2022.5-beta2"
+  sha256 "78b2571f0ac4b5d8bc99086172225009924dbb7619658707416622f095eb58e9"
 
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg",
       verified: "github.com/mullvad/mullvadvpn-app/"
@@ -10,8 +10,8 @@ cask "mullvadvpn-beta" do
 
   livecheck do
     url "https://github.com/mullvad/mullvadvpn-app/releases"
+    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+[._-]beta\d*)["' >]}i)
     strategy :page_match
-    regex(/MullvadVPN-(\d+(?:\.\d+)*.+-beta\d+).pkg/i)
   end
 
   conflicts_with cask: "mullvadvpn"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `mullvadvpn-beta` identifies versions from the pkg file in release asset lists. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

This PR addresses the issue by updating the `livecheck` block regex to match versions from release tag URLs instead. This also updates the cask to the newest beta version, 2022.5-beta2.