### PR TITLE
insomnia-alpha 2022.7.0-beta.1

### DIFF
--- a/Casks/insomnia-alpha.rb
+++ b/Casks/insomnia-alpha.rb
@@ -1,6 +1,6 @@
 cask "insomnia-alpha" do
-  version "2022.6.0-beta.3"
-  sha256 "3d1d575eb116c3fc1d00183ed37e9f027a8791ed743fd5f99d6cba3def7822d6"
+  version "2022.7.0-beta.1"
+  sha256 "1774a5cd7eef703ba02c9091ccbd0c2e5249016852e2ad0b1b8efcbec7908f0f"
 
   url "https://github.com/Kong/insomnia/releases/download/core%40#{version}/Insomnia.Core-#{version}.dmg",
       verified: "github.com/Kong/insomnia/"
@@ -10,8 +10,8 @@ cask "insomnia-alpha" do
 
   livecheck do
     url "https://github.com/Kong/insomnia/releases"
+    regex(%r{href=["']?[^"' >]*?/tag/core%40(\d+(?:\.\d+)+[._-](?:alpha|beta)[._-]?\d*)["' >]}i)
     strategy :page_match
-    regex(/Insomnia[._-]Core[._-](\d+(?:\.\d+)+[._-](?:alpha|beta)[._-]\d*)\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `insomnia-alpha` identifies versions from the dmg file in release asset lists. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

This PR addresses the issue by updating the `livecheck` block to match the version from release tag URLs instead. This also updates `insomnia-alpha` to the latest unstable release, 2022.7.0-beta.1.

For what it's worth, despite this cask using `-alpha` in the name, this uses any unstable version and I've simply maintained that here. There's probably something to be said for renaming this to a more generic name like `insomnia-unstable`.