### PR TITLE
rstudio-preview-electron: fix URL template as well as update version

### DIFF
--- a/Casks/rstudio-preview-electron.rb
+++ b/Casks/rstudio-preview-electron.rb
@@ -1,8 +1,8 @@
 cask "rstudio-preview-electron" do
-  version "2022.07.0,543"
-  sha256 "6643fc31845de49e8a985338b872b6f2183e09b1519193b4a1dccde352e9cca8"
+  version "2022.07.2,576"
+  sha256 "ad3681003bbb243b800b55aafee7fcfbff2dbdb71fc0eba1cb21317bb9a608e3"
 
-  url "https://s3.amazonaws.com/rstudio-ide-build/electron/macos/RStudio-#{version.csv.first}-preview-#{version.csv.second}.dmg",
+  url "https://s3.amazonaws.com/rstudio-ide-build/electron/macos/RStudio-#{version.csv.first}-#{version.csv.second}.dmg",
       verified: "s3.amazonaws.com/rstudio-ide-build/"
   name "RStudio"
   desc "Data science software focusing on R and Python"
@@ -10,7 +10,7 @@ cask "rstudio-preview-electron" do
 
   livecheck do
     url :homepage
-    regex(/RStudio[._-](\d{4}\.\d{2}\.\d+)[._-]preview[._-](\d+)\.dmg/i)
+    regex(/RStudio[._-](\d{4}\.\d{2}\.\d+)[._-](\d+)\.dmg/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end


### PR DESCRIPTION
This is similar to https://github.com/Homebrew/homebrew-cask-versions/pull/14407, but for `rstudio-preview-electron` rather than `rstudio-preview`.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

