### PR TITLE
Add Virtualbox.app v6.1

### DIFF
--- a/Casks/virtualbox6.rb
+++ b/Casks/virtualbox6.rb
@@ -1,0 +1,75 @@
+cask "virtualbox6" do
+  version "6.1.40,154048"
+  sha256 "bccf09995cd736a51d579dd12602eab4730df83bf4ac8196f31c4a22a6320936"
+
+  url "https://download.virtualbox.org/virtualbox/#{version.csv.first}/VirtualBox-#{version.csv.first}-#{version.csv.second}-OSX.dmg"
+  name "Oracle VirtualBox"
+  desc "Virtualizer for x86 hardware"
+  homepage "https://www.virtualbox.org/"
+
+  livecheck do
+    url "https://www.virtualbox.org/wiki/Download_Old_Builds_6_1"
+    strategy :page_match do |page|
+      match = page.match(/href=.*?VirtualBox-(\d+(?:\.\d+)+)-(\d+)-OSX.dmg/)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  conflicts_with cask: "homebrew/cask-versions/virtualbox-beta"
+  depends_on macos: ">= :high_sierra"
+  depends_on arch: :x86_64
+
+  pkg "VirtualBox.pkg",
+      choices: [
+        {
+          "choiceIdentifier" => "choiceVBoxKEXTs",
+          "choiceAttribute"  => "selected",
+          "attributeSetting" => 1,
+        },
+        {
+          "choiceIdentifier" => "choiceVBox",
+          "choiceAttribute"  => "selected",
+          "attributeSetting" => 1,
+        },
+        {
+          "choiceIdentifier" => "choiceVBoxCLI",
+          "choiceAttribute"  => "selected",
+          "attributeSetting" => 1,
+        },
+        {
+          "choiceIdentifier" => "choiceOSXFuseCore",
+          "choiceAttribute"  => "selected",
+          "attributeSetting" => 0,
+        },
+      ]
+
+  postflight do
+    # If VirtualBox is installed before `/usr/local/lib/pkgconfig` is created by Homebrew, it creates it itself
+    # with incorrect permissions that break other packages
+    # See https://github.com/Homebrew/homebrew-cask/issues/68730#issuecomment-534363026
+    set_ownership "/usr/local/lib/pkgconfig"
+  end
+
+  uninstall script:  {
+              executable: "VirtualBox_Uninstall.tool",
+              args:       ["--unattended"],
+              sudo:       true,
+            },
+            pkgutil: "org.virtualbox.pkg.*",
+            delete:  "/usr/local/bin/vboximg-mount"
+
+  zap trash: [
+        "/Library/Application Support/VirtualBox",
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.virtualbox.app.virtualbox*",
+        "~/Library/Preferences/org.virtualbox.app.VirtualBox*",
+        "~/Library/Saved Application State/org.virtualbox.app.VirtualBox*",
+        "~/Library/VirtualBox",
+      ],
+      rmdir: "~/VirtualBox VMs"
+
+  caveats do
+    kext
+  end
+end


### PR DESCRIPTION
Add actively maintained Virtualbox 6.1 to homebrew-cask-versions. 

The new version 7 is having stability issues. See [this thread at Virtualbox.org ](https://forums.virtualbox.org/viewtopic.php?f=1&t=107319&start=30)and [this thread on Reddit](https://www.reddit.com/r/virtualbox/comments/y56gpv/anything_i_should_know_before_upgrading_from/).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
