### PR TITLE
utm-beta: add livecheck

### DIFF
--- a/Casks/utm-beta.rb
+++ b/Casks/utm-beta.rb
@@ -8,6 +8,12 @@ cask "utm-beta" do
   desc "Virtual machines UI using QEMU"
   homepage "https://mac.getutm.app/"
 
+  livecheck do
+    url "https://github.com/utmapp/UTM/releases?q=prerelease%3Atrue&expanded=true"
+    regex(%r{href=["']?[^"' >]*?/tag/\D*?(\d+(?:\.\d+)+)[^"' >]*?["' >]}i)
+    strategy :page_match
+  end
+
   conflicts_with cask: "utm"
 
   app "UTM.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

By default, livecheck checks the Git tags for `utm-beta` and this currently gives a stable version as newest (4.0.8). We discussed this in #14917 and it seemed reasonable to restrict this to unstable versions (e.g., beta, RC, RC2, etc.).

This PR adds a `livecheck` block that restricts matching to releases that are marked as "prerelease" on GitHub. At the moment, this is the easiest way to avoid stable versions in that particular repository (so long as they continue to be diligent about marking releases as "prerelease").