### PR TITLE
inso-beta 3.6.1-beta.2

### DIFF
--- a/Casks/inso-beta.rb
+++ b/Casks/inso-beta.rb
@@ -1,6 +1,6 @@
 cask "inso-beta" do
-  version "3.5.1-beta.2"
-  sha256 "da06d8f85b1666b9e0c59e3db47ee8c73e0b7b0bc553a22e4a377cb952e2e0bc"
+  version "3.6.1-beta.2"
+  sha256 "d981b2abfb3d6b7acbcba451639833af0d0c0a09d86c8fdd2838eb583d966620"
 
   url "https://github.com/Kong/insomnia/releases/download/lib%40#{version}/inso-macos-#{version}.zip",
       verified: "github.com/Kong/insomnia/"
@@ -10,8 +10,8 @@ cask "inso-beta" do
 
   livecheck do
     url "https://github.com/Kong/insomnia/releases?q=prerelease%3Atrue+Inso+CLI"
+    regex(%r{href=["']?[^"' >]*?/tag/lib%40([^"' >]+?)["' >]}i)
     strategy :page_match
-    regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+)+[._-](?:beta)[._-]\d*)\.zip/i)
   end
 
   conflicts_with cask: "inso"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `inso-beta` identifies versions from the zip file in release asset lists. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

In this case, it's not necessary to identify the version from the zip file and we can simply match the version from release tags. This PR updates the `livecheck` block regex accordingly and also bumps the cask to the latest unstable version.