### PR TITLE
chromedriver-beta: Fix version, add livecheck

### DIFF
--- a/Casks/chromedriver-beta.rb
+++ b/Casks/chromedriver-beta.rb
@@ -1,6 +1,6 @@
 cask "chromedriver-beta" do
-  version "107.0.5304.62"
-  sha256 "3a1e597791ea186e831911b280620c49381bb59910969cda9a9432f27b2a8d2b"
+  version "107.0.5304.18"
+  sha256 "2453d8feddce1c968e2e2fbcb70ddde409f798d8d11f7a16cf1611987f918b03"
 
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip",
       verified: "chromedriver.storage.googleapis.com/"
@@ -10,7 +10,7 @@ cask "chromedriver-beta" do
 
   livecheck do
     url :homepage
-    regex(/ChromeDriver\s(\d+(?:\.\d+)+)/i)
+    regex(/beta.*?ChromeDriver\s(\d+(?:\.\d+)+)</i)
   end
 
   conflicts_with cask: "chromedriver"


### PR DESCRIPTION
Stable releases were being pulled by `livecheck`.

https://github.com/Homebrew/homebrew-cask-versions/issues/14993