### PR TITLE
Update openzfs-dev from 2.1.99 to 2.1.6rc4

### DIFF
--- a/Casks/openzfs-dev.rb
+++ b/Casks/openzfs-dev.rb
@@ -1,12 +1,14 @@
 cask "openzfs-dev" do
-  if MacOS.version < :el_capitan
-    version "2.1.99,369"
-    sha256 "932db021cddc7de34aa9d50cdad723b0b437dfdf2161150ca416fc68cad8e1c9"
-    pkg "OpenZFSonOsX-#{version.csv.first}-EL.CAPITAN-10.11.pkg"
-  else
-    version "2.1.99,368"
-    sha256 "c64f103b696218202df7f758cc9d4c9995f56b2108fa072eb4c03aef9457219c"
+  on_intel do
+    version "2.1.6rc4,400"
+    sha256 "612a04c581a5ef9c5b3e6969d25513a75efa4c8c51d051a6e1230e5a5c31455d"
     pkg "OpenZFSonOsX-#{version.csv.first}-Catalina-10.15.pkg"
+  end
+  on_arm do
+    depends_on macos: ">= :monterey"
+    version "2.1.6rc4,401"
+    sha256 "948066fc6a59cff326d552952c31653f877ea947d2b00a691e982eda40742d91"
+    pkg "OpenZFSonOsX-#{version.csv.first}-Monterey-12-arm64.pkg"
   end
 
   url "https://openzfsonosx.org/forum/download/file.php?id=#{version.csv.second}"
@@ -19,8 +21,7 @@ cask "openzfs-dev" do
   end
 
   conflicts_with cask: "openzfs"
-  depends_on macos: ">= :el_capitan"
-  depends_on arch: :intel
+  depends_on macos: ">= :catalina"
 
   postflight do
     set_ownership "/usr/local/zfs"

--- a/Casks/openzfs-dev.rb
+++ b/Casks/openzfs-dev.rb
@@ -5,7 +5,6 @@ cask "openzfs-dev" do
     pkg "OpenZFSonOsX-#{version.csv.first}-Catalina-10.15.pkg"
   end
   on_arm do
-    depends_on macos: ">= :monterey"
     version "2.1.6rc4,401"
     sha256 "948066fc6a59cff326d552952c31653f877ea947d2b00a691e982eda40742d91"
     pkg "OpenZFSonOsX-#{version.csv.first}-Monterey-12-arm64.pkg"


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

Previous update was revererted in #14871:

> This reverts commit [c048260](https://github.com/Homebrew/homebrew-cask-versions/commit/c0482603897214979a159669683e976e140ae9de) & [eb8c0e4](https://github.com/Homebrew/homebrew-cask-versions/commit/eb8c0e493f7e8769c0d201d90d9bcfbb692ca5ba).
> 
> These changes can be reapplied after we have `brew readall` CI coverage.

I'm not sure is this `brew readall` CI coverage is implemented. If not, please provide a reference to a corresponding issue(-s).