### PR TITLE
obs-beta 28.1.2

### DIFF
--- a/Casks/obs-beta.rb
+++ b/Casks/obs-beta.rb
@@ -1,9 +1,9 @@
 cask "obs-beta" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "28.1.0-rc1"
-  sha256 arm:   "d86037a28b32a45537cf4aa546c66eaec1388a821bf098060183c99ea97e625a",
-         intel: "93dd46eefde5304eb4f2f133586d5832b02d499dac8903704984cef61b68885a"
+  version "28.1.2"
+  sha256 arm:   "c0dfee808b58cff1b9de16d28f524195805cbf09cabfa0c023fb6270b10aef3f",
+         intel: "cf5edb7a6e27c142e70f7daf05a48d59ad377b6aed285b0f9e4ef58bdaad2674"
 
   url "https://github.com/obsproject/obs-studio/releases/download/#{version}/obs-studio-#{version}-macos-#{arch}.dmg",
       verified: "github.com/obsproject/obs-studio/"
@@ -11,10 +11,16 @@ cask "obs-beta" do
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/forum/list/test-builds.20/"
 
+  # We use the first matching tag on the releases page, as a version with an
+  # unstable suffix (e.g., `1.2.3-beta1`) would be erroneously treated as
+  # newer than a subsequent stable version (e.g., `1.2.3`) due to how `Version`
+  # comparison works.
   livecheck do
-    url "https://github.com/obsproject/obs-studio/releases?q=prerelease%3Atrue"
+    url "https://github.com/obsproject/obs-studio/releases"
     regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+[^"' >]*)["' >]}i)
-    strategy :page_match
+    strategy :page_match do |page, regex|
+      page[regex, 1]
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

Per [recent discussion](https://github.com/Homebrew/homebrew-cask-versions/pull/14970#issuecomment-1307224573), there's support among some maintainers to allow certain unstable casks to update to stable versions, when available/appropriate. This PR loosens the `livecheck` block for `obs-beta` so it will simply return the newest release version (whether unstable or stable).

This also updates the cask to the newest release, 28.1.2, which happens to be stable.