### PR TITLE
temurin18: discontinue

### DIFF
--- a/Casks/temurin18.rb
+++ b/Casks/temurin18.rb
@@ -11,20 +11,11 @@ cask "temurin18" do
   desc "JDK from the Eclipse Foundation (Adoptium)"
   homepage "https://adoptium.net/"
 
-  livecheck do
-    url "https://api.adoptium.net/v3/assets/feature_releases/#{version.major}/ga?architecture=#{arch}&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
-    regex(/^jdk-(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)$/i)
-    strategy :page_match do |page, regex|
-      JSON.parse(page).map do |release|
-        match = release["release_name"]&.match(regex)
-        next if match.blank?
-
-        "#{match[1]},#{match[2]}"
-      end
-    end
-  end
-
   pkg "OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg"
 
   uninstall pkgutil: "net.temurin.#{version.major}.jdk"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Discontinued upstream, so Adoptium is following. Per their [support page](https://adoptium.net/support/):

>End of Service/Support Life - this code stream is no longer being maintained. No further builds of Eclipse Temurin are planned.

