### PR TITLE
transmit4: remove appcast

### DIFF
--- a/Casks/transmit4.rb
+++ b/Casks/transmit4.rb
@@ -3,8 +3,8 @@ cask "transmit4" do
   sha256 "0d7095351378aa3c581de064f99fedecbfac683377048a4c0457976f5ce79f3b"
 
   url "https://download.panic.com/transmit/Transmit%20#{version.major}/Transmit%20#{version}.zip"
-  appcast "https://library.panic.com/releasenotes/transmit#{version.major}/"
   name "Transmit"
+  desc "File transfer application"
   homepage "https://panic.com/transmit/"
 
   app "Transmit.app"


### PR DESCRIPTION
This is the final cask in this repo that contains an `appcast` stanza.

Closes #14993.