### PR TITLE
affinity-publisher-beta: adjust livecheck

### DIFF
--- a/Casks/affinity-publisher-beta.rb
+++ b/Casks/affinity-publisher-beta.rb
@@ -7,9 +7,12 @@ cask "affinity-publisher-beta" do
   desc "Professional desktop publishing software"
   homepage "https://affinity.serif.com/en-us/publisher/"
 
+  # The link below is the new URL for v2 beta releases
+  # url "https://forum.affinity.serif.com/index.php?/forum/57-publisher-beta-on-macos/"
+  # regex(/Publisher.*?\|\s\s(\d+(?:\.\d+)+)/i)
+
   livecheck do
-    url "https://forum.affinity.serif.com/index.php?/topic/83296-affinity-range-mac-beta-release-notifications/"
-    regex(/Publisher.*?\|\s\s(\d+(?:\.\d+)+)/i)
+    skip "Beta information for v2 is not yet available"
   end
 
   app "Affinity Publisher Beta.app"


### PR DESCRIPTION
The Affinity apps had a major version release recently. The old beta links have been archived, and no new v2 betas have been posted.