### PR TITLE
Revert 1password7 from 7.9.7 to 7.9.6

### DIFF
--- a/Casks/1password7.rb
+++ b/Casks/1password7.rb
@@ -1,6 +1,6 @@
 cask "1password7" do
-  version "7.9.7"
-  sha256 "e0cce91c0096ea8742f0974fd03e7716da10f5e78f2972e3db75b18330968a39"
+  version "7.9.6"
+  sha256 "3aab2c425432a07faa629ab08ab0d82ed40af0cace13bbe83e8746c1cc3422b2"
 
   url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
   name "1Password"


### PR DESCRIPTION
Reverts 1Password back to version 7.9.6. Agilebits, the company behind 1Password, pulled version 7.9.7 back. It does not show up on their [Release Notes](https://app-updates.agilebits.com/product_history/OPM7) anymore, and software on version 7.9.6 do not see the update to 7.9.7. The download is still available. I found out about it after updating my 1Password, seeing that things were broken, and wanting to know what had changed.

Either we should wait for a newer version to be released or revert. Feel free to close this PR if you feel this PR is not the right approach.