### PR TITLE
revert(casks): use latest version for azure-data-studio-insiders

### DIFF
--- a/Casks/azure-data-studio-insiders.rb
+++ b/Casks/azure-data-studio-insiders.rb
@@ -1,20 +1,14 @@
 cask "azure-data-studio-insiders" do
   arch arm: "-arm64"
 
-  version "1.41.0"
-  sha256 arm:   "9c621fbc13dfed72477463485ad74a9d1dd31e084d54116b3bc8ff615edd5a32",
-         intel: "686f0142423466741c1610e227324aa6b389c5f2f16aa9f08923207b986e88d3"
+  version :latest
+  sha256 :no_check
 
-  url "https://azuredatastudio-update.azurewebsites.net/#{version}/darwin#{arch}/insider",
+  url "https://azuredatastudio-update.azurewebsites.net/latest/darwin#{arch}/insider",
       verified: "azuredatastudio-update.azurewebsites.net"
   name "Azure Data Studio - Insiders"
   desc "Data management tool that enables working with SQL Server"
   homepage "https://docs.microsoft.com/en-us/sql/azure-data-studio/"
-
-  livecheck do
-    url "https://azuredatastudio-update.azurewebsites.net/api/update/darwin/insider/VERSION"
-    regex(/"productVersion"\s*:\s*"(\d+(:?\.\d+)+)"/i)
-  end
 
   app "Azure Data Studio - Insiders.app"
   binary "#{appdir}/Azure Data Studio - Insiders.app/Contents/Resources/app/bin/code",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

Reasoning:

Since `azure-data-studio-insiders` is a nightly-build, it makes more sense to revert back to using `version :latest` and `sha256 :no_check`, otherwise users will run into issues when trying to install as checksum will fail; which is something that happened to me today.
