### PR TITLE
Set lando-edge livecheck to use git tags instead of page_match

### DIFF
--- a/Casks/lando-edge.rb
+++ b/Casks/lando-edge.rb
@@ -12,9 +12,8 @@ cask "lando-edge" do
   homepage "https://docs.lando.dev/"
 
   livecheck do
-    url "https://github.com/lando/lando/releases?q=prerelease%3Atrue&expanded=true"
-    regex(%r{href=["']?[^"' >]*?/tag/\D*?(\d+(?:\.\d+)+)[^"' >]*?["' >]}i)
-    strategy :page_match
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   conflicts_with cask: "lando"


### PR DESCRIPTION

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
      This is for Edge release on cask-versions

- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Changed livecheck to use git tag instead of page_match because livecheck regex was picking up version numbers listed in the release notes. 

Example:
```
livecheck --debug lando-edge

Cask:             lando-edge
Livecheckable?:   Yes

URL:              https://github.com/lando/lando/releases?q=prerelease%3Atrue&expanded=true
Strategy:         PageMatch
Regex:            /href=["']?[^"' >]*?\/tag\/\D*?(\d+(?:\.\d+)+)[^"' >]*?["' >]/i

Matched Versions:
3.8.1, 3.8.0, 3.8.2, 0.7.0, 0.7.2, 3.6.5, 0.5.2, 0.5.1, 0.5.3, 0.5.9, 0.5.4, 3.6.3, 0.5.8, 3.6.1, 0.5.0, 3.5.1, 0.6.0, 3.5.0, 3.4.3, 3.1.3, 3.1.2

lando-edge: 3.6.5 ==> 3.8.2
```

Using git tags now it returns:

```
brew livecheck --debug lando-edge

Cask:             lando-edge
Livecheckable?:   Yes

URL (stable):     https://github.com/lando/lando/releases/download/v3.6.5/lando-arm64-v3.6.5.dmg
URL (processed):  https://github.com/lando/lando.git
Strategy:         Git
Regex:            /^v?(\d+(?:\.\d+)+)$/i

Matched Versions:
3.0.0, 3.0.1, 3.0.10, 3.0.11, 3.0.12, 3.0.13, 3.0.14, 3.0.15, 3.0.16, 3.0.17, 3.0.18, 3.0.19, 3.0.2, 3.0.20, 3.0.21, 3.0.22, 3.0.23, 3.0.24, 3.0.25, 3.0.26, 3.0.27, 3.0.28, 3.0.29, 3.0.3, 3.0.4, 3.0.5, 3.0.6, 3.0.7, 3.0.8, 3.0.9, 3.1.0, 3.1.1, 3.1.2, 3.1.3, 3.1.4, 3.3.0, 3.3.1, 3.3.2, 3.4.0, 3.4.1, 3.4.2, 3.4.3, 3.5.0, 3.5.1, 3.6.0, 3.6.1, 3.6.2, 3.6.3, 3.6.4, 3.6.5, 3.8.0, 3.8.1

lando-edge: 3.6.5 ==> 3.8.1
```