### PR TITLE
Add auto-updates true to android studio versions

### DIFF
--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -16,6 +16,7 @@ cask "android-studio-preview-beta" do
     regex(%r{href=.*?/android[._-]studio[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.zip(.*\n*\s*.*)(Beta|RC)}i)
   end
 
+  auto_updates true
   conflicts_with cask: "android-studio"
 
   app "Android Studio.app"

--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -16,6 +16,7 @@ cask "android-studio-preview-canary" do
     regex(%r{href=.*?/android[._-]studio[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.zip}i)
   end
 
+  auto_updates true
   conflicts_with cask: "android-studio-preview-beta"
 
   app "Android Studio Preview.app"


### PR DESCRIPTION
This matches the main version cask file: 

https://github.com/Homebrew/homebrew-cask/blob/master/Casks/android-studio.rb#L21

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.