### PR TITLE
clashx-pro 1.97.0

### DIFF
--- a/Casks/clashx-pro.rb
+++ b/Casks/clashx-pro.rb
@@ -1,17 +1,11 @@
 cask "clashx-pro" do
-  version "1.96.2.1"
-  sha256 "ec88bef259597515163fe8745a6daf96125b677a265284c0f959980a755474d3"
+  version "1.97.0"
+  sha256 "885f93cc0fb80bfc7c188795eec133610a4e6caf1ce31f3f76d42ac86c8b3ea4"
 
-  url "https://appcenter.vercel.app/clashx/clashx-pro/#{version}",
-      verified: "appcenter.vercel.app/clashx"
+  url "https://github.com/yichengchen/clashX/releases/download/#{version}/ClashX.dmg"
   name "ClashX Pro"
   desc "Rule-based custom proxy with GUI based on clash"
   homepage "https://github.com/yichengchen/clashX"
-
-  livecheck do
-    url "https://api.appcenter.ms/v0.1/public/sparkle/apps/1cd052f7-e118-4d13-87fb-35176f9702c1"
-    strategy :sparkle
-  end
 
   auto_updates true
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
Original AppCentre `url` is no longer working.