### PR TITLE
Add typora-dev

### DIFF
--- a/Casks/typora-dev.rb
+++ b/Casks/typora-dev.rb
@@ -2,7 +2,7 @@ cask "typora-dev" do
   version "1.5.4"
   sha256 "3a0e36a87eb3f6441a0a822e85406d5d2a582bac7d0a01be4356bc93bb677742"
 
-  language "zh", "CN", "Hans" do # use official Chinese mirror
+  language "zh-Hans-CN" do # use official Chinese mirror
     url "https://download2.typoraio.cn/mac/Typora-#{version}-dev.dmg",
         verified: "typoraio.cn/"
   end

--- a/Casks/typora-dev.rb
+++ b/Casks/typora-dev.rb
@@ -1,0 +1,38 @@
+cask "typora-dev" do
+  version "1.5.4"
+  sha256 "3a0e36a87eb3f6441a0a822e85406d5d2a582bac7d0a01be4356bc93bb677742"
+
+  language "zh-Hans-CN" do
+    url "https://download2.typoraio.cn/mac/Typora-#{version}-dev.dmg",
+        verified: "typoraio.cn/"
+  end
+  language "en", default: true do
+    url "https://download.typora.io/mac/Typora-#{version}-dev.dmg"
+  end
+
+  name "typora-dev"
+  desc "Configurable document editor that supports Markdown"
+  homepage "https://typora.io/"
+
+  livecheck do
+    url "https://typora.io/releases/dev_macos.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  conflicts_with cask: "typora"
+  depends_on macos: ">= :high_sierra"
+
+  app "Typora.app"
+
+  zap trash: [
+    "~/Library/Application Support/abnerworks.Typora",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/abnerworks.typora.sfl*",
+    "~/Library/Application Support/Typora",
+    "~/Library/Caches/abnerworks.Typora",
+    "~/Library/Cookies/abnerworks.Typora.binarycookies",
+    "~/Library/Preferences/abnerworks.Typora.plist",
+    "~/Library/Saved Application State/abnerworks.Typora.savedState",
+    "~/Library/WebKit/abnerworks.Typora",
+  ]
+end

--- a/Casks/typora-dev.rb
+++ b/Casks/typora-dev.rb
@@ -2,7 +2,7 @@ cask "typora-dev" do
   version "1.5.4"
   sha256 "3a0e36a87eb3f6441a0a822e85406d5d2a582bac7d0a01be4356bc93bb677742"
 
-  language "zh-Hans-CN" do # use official Chinese mirror
+  language "zh", "CN", "Hans" do # use official Chinese mirror
     url "https://download2.typoraio.cn/mac/Typora-#{version}-dev.dmg",
         verified: "typoraio.cn/"
   end

--- a/Casks/typora-dev.rb
+++ b/Casks/typora-dev.rb
@@ -2,7 +2,7 @@ cask "typora-dev" do
   version "1.5.4"
   sha256 "3a0e36a87eb3f6441a0a822e85406d5d2a582bac7d0a01be4356bc93bb677742"
 
-  language "zh-Hans-CN" do
+  language "zh-Hans-CN" do # use official Chinese mirror
     url "https://download2.typoraio.cn/mac/Typora-#{version}-dev.dmg",
         verified: "typoraio.cn/"
   end


### PR DESCRIPTION
The `zh-Hans-CN` block is to use official mirror for Chinese users.

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
