### PR TITLE
Add firefox-cn

### DIFF
--- a/Casks/firefox-cn.rb
+++ b/Casks/firefox-cn.rb
@@ -1,0 +1,48 @@
+cask "firefox-cn" do
+  version "111.0"
+  sha256 :no_check # patch versions use the same URL
+
+  url "https://download-ssl.firefox.com.cn/releases/firefox/#{version}/zh-CN/Firefox-latest.dmg"
+  name "firefox-cn"
+  desc "Chinese version of Firefox"
+  homepage "https://www.firefox.com.cn/"
+
+  livecheck do
+    url "https://download-redirect.firefox.com.cn/?product=firefox-latest-ssl&os=osx"
+    strategy :header_match
+  end
+
+  auto_updates true
+  conflicts_with cask: [
+    "firefox",
+    "firefox-beta",
+    "firefox-developer-edition",
+    "firefox-esr",
+  ]
+  depends_on macos: ">= :sierra"
+
+  app "Firefox.app"
+
+  uninstall quit: "org.mozilla.firefox"
+
+  zap trash: [
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.firefox.sfl*",
+        "~/Library/Application Support/CrashReporter/firefox_*",
+        "~/Library/Application Support/Firefox",
+        "~/Library/Caches/Firefox",
+        "~/Library/Caches/Mozilla/updates/Applications/Firefox",
+        "~/Library/Caches/org.mozilla.crashreporter",
+        "~/Library/Caches/org.mozilla.firefox",
+        "~/Library/Preferences/org.mozilla.crashreporter.plist",
+        "~/Library/Preferences/org.mozilla.firefox.plist",
+        "~/Library/Saved Application State/org.mozilla.firefox.savedState",
+        "~/Library/WebKit/org.mozilla.firefox",
+        "/Library/Logs/DiagnosticReports/firefox_*",
+      ],
+      rmdir: [
+        "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
+        "~/Library/Caches/Mozilla/updates/Applications",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla",
+      ]
+end

--- a/Casks/firefox-cn.rb
+++ b/Casks/firefox-cn.rb
@@ -13,11 +13,11 @@ cask "firefox-cn" do
   end
 
   auto_updates true
-  conflicts_with cask: %w[
-    firefox
-    firefox-beta
-    firefox-developer-edition
-    firefox-esr
+  conflicts_with cask: [
+    "firefox",
+    "firefox-beta",
+    "firefox-developer-edition",
+    "firefox-esr",
   ]
   depends_on macos: ">= :sierra"
 

--- a/Casks/firefox-cn.rb
+++ b/Casks/firefox-cn.rb
@@ -13,11 +13,11 @@ cask "firefox-cn" do
   end
 
   auto_updates true
-  conflicts_with cask: [
-    "firefox",
-    "firefox-beta",
-    "firefox-developer-edition",
-    "firefox-esr",
+  conflicts_with cask: %w[
+    firefox
+    firefox-beta
+    firefox-developer-edition
+    firefox-esr
   ]
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
Special Chinese version of Firefox maintained by [Mozilla China](https://en.wikipedia.org/wiki/Mozilla_China) with some Chinsese-specific add-ons.

~~`brew style` complains about the `conflicts_with` block stating that I should use `%w[` but I don't know what's wrong.~~

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
