### PR TITLE
rubocop: Fix `Cask/StanzaOrder` offenses for `on_*` blocks

### DIFF
--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -16,7 +16,7 @@ cask "java6" do
     end
   end
 
-  url "https://updates.cdn-apple.com/#{version.csv.first}/cert/#{version.csv.second}/JavaForOSX.dmg",
+  url "https://updates.cdn-apple.com/#{version.csv.second}/cert/#{version.csv.third}/JavaForOSX.dmg",
       verified: "updates.cdn-apple.com/"
   name "Apple Java 6 Standard Edition Development Kit"
   desc "Legacy runtime for the Java programming language"

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -2,12 +2,6 @@ cask "java6" do
   version "1.6.0_65-b14-468,2019,041-88384-20191011-3d8da658-dca4-4a5b-b67c-26e686876403"
   sha256 "3a91bd24a0524df4cde9433f2ac56182818f78aacda36c7529b3d548e0c12e63"
 
-  url "https://updates.cdn-apple.com/#{version.csv[1]}/cert/#{version.csv[2]}/JavaForOSX.dmg",
-      verified: "updates.cdn-apple.com/"
-  name "Apple Java 6 Standard Edition Development Kit"
-  desc "Legacy runtime for the Java programming language"
-  homepage "https://support.apple.com/kb/DL1572"
-
   on_mojave :or_older do
     pkg "JavaForOSX.pkg"
 
@@ -21,6 +15,12 @@ cask "java6" do
       system_command "pkgutil", chdir: staged_path, args: ["--expand-full", "JavaForOSX.pkg", "JavaForOSX"]
     end
   end
+
+  url "https://updates.cdn-apple.com/#{version.csv[1]}/cert/#{version.csv[2]}/JavaForOSX.dmg",
+      verified: "updates.cdn-apple.com/"
+  name "Apple Java 6 Standard Edition Development Kit"
+  desc "Legacy runtime for the Java programming language"
+  homepage "https://support.apple.com/kb/DL1572"
 
   caveats do
     discontinued

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -16,7 +16,7 @@ cask "java6" do
     end
   end
 
-  url "https://updates.cdn-apple.com/#{version.csv[1]}/cert/#{version.csv[2]}/JavaForOSX.dmg",
+  url "https://updates.cdn-apple.com/#{version.csv.first}/cert/#{version.csv.second}/JavaForOSX.dmg",
       verified: "updates.cdn-apple.com/"
   name "Apple Java 6 Standard Edition Development Kit"
   desc "Legacy runtime for the Java programming language"

--- a/Casks/vmware-fusion-tech-preview.rb
+++ b/Casks/vmware-fusion-tech-preview.rb
@@ -2,6 +2,17 @@ cask "vmware-fusion-tech-preview" do
   version "20486664"
   sha256 "8c74005d88edb0e37d2ac3517f4e72ce85613abb2dfaaea78fe3db8d2c7b17fd"
 
+  on_intel do
+    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vkd/bin/vctl"
+    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmrest"
+    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/VMware OVF Tool/ovftool"
+  end
+  on_catalina do
+    caveats do
+      kext
+    end
+  end
+
   url "https://download3.vmware.com/software/FUS-PUBTP-22H2/VMware-Fusion-e.x.p-#{version}_universal.dmg"
   name "VMware Fusion Tech Preview"
   desc "Create, manage, and run virtual machines"
@@ -50,12 +61,6 @@ cask "vmware-fusion-tech-preview" do
   binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmware-vmx-debug"
   binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmware-vmx-stats"
 
-  on_intel do
-    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vkd/bin/vctl"
-    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/vmrest"
-    binary "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/VMware OVF Tool/ovftool"
-  end
-
   postflight do
     system_command "#{appdir}/VMware Fusion Tech Preview.app/Contents/Library/Initialize VMware Fusion.tool",
                    args: ["set"],
@@ -99,10 +104,4 @@ cask "vmware-fusion-tech-preview" do
     "~/Library/Saved Application State/com.vmware.fusion.savedState",
     "~/Library/WebKit/com.vmware.fusion",
   ]
-
-  on_catalina do
-    caveats do
-      kext
-    end
-  end
 end


### PR DESCRIPTION
Fixes new RuboCop offenses from https://github.com/Homebrew/brew/pull/14976.

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
