### PR TITLE
Add Godot LTS version

### DIFF
--- a/Casks/godot3.rb
+++ b/Casks/godot3.rb
@@ -13,6 +13,8 @@ cask "godot3" do
     regex(/^v?(3(?:\.\d+)+)[._-]stable$/i)
   end
 
+  conflicts_with cask: "godot"
+
   app "Godot.app"
   binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot"
 

--- a/Casks/godot3.rb
+++ b/Casks/godot3.rb
@@ -1,0 +1,26 @@
+cask "godot3" do
+  version "3.5.2"
+  sha256 "2a010b8fbf8241a20224c14ecfac01f4d364d68e14e477459c61ca40716bc0a9"
+
+  url "https://downloads.tuxfamily.org/godotengine/#{version}/Godot_v#{version}-stable_osx.universal.zip",
+      verified: "downloads.tuxfamily.org/godotengine/"
+  name "Godot Engine"
+  desc "Game development engine"
+  homepage "https://godotengine.org/"
+
+  livecheck do
+    url "https://github.com/godotengine/godot"
+    regex(/^v?(3(?:\.\d+)+)[._-]stable$/i)
+  end
+
+  app "Godot.app"
+  binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot3"
+
+  uninstall quit: "org.godotengine.godot"
+
+  zap trash: [
+    "~/Library/Application Support/Godot",
+    "~/Library/Caches/Godot",
+    "~/Library/Saved Application State/org.godotengine.godot.savedState",
+  ]
+end

--- a/Casks/godot3.rb
+++ b/Casks/godot3.rb
@@ -14,7 +14,7 @@ cask "godot3" do
   end
 
   app "Godot.app"
-  binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot3"
+  binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot"
 
   uninstall quit: "org.godotengine.godot"
 


### PR DESCRIPTION
Godot is currently available in [homebrew-cask](https://github.com/Homebrew/homebrew-cask) however that installs version 4 which is the latest stable version, which might not be suitable for production. However the LTS version 3.5 can no longer be installed via brew, this cask makes the LTS version available on homebrew again.

***

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
