### PR TITLE
libreoffice-still: update `conflicts_with`

### DIFF
--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -17,7 +17,7 @@ cask "libreoffice-still" do
     regex(/LibreOffice\s+v?(\d+(?:\.\d+)+)(?:\s+\((?:\d+(?:-\d+)+)\))?\s*-\s*Still\s+Branch/i)
   end
 
-  conflicts_with cask: ["libreoffice", "libreoffice-language-pack"]
+  conflicts_with cask: "libreoffice"
   depends_on macos: ">= :sierra"
 
   app "LibreOffice.app"


### PR DESCRIPTION
Since `libreoffice-language-pack` depends on `libreoffice`, this is not needed.