### PR TITLE
libreoffice-still-language-pack: remove `conflicts_with`

### DIFF
--- a/Casks/libreoffice-still-language-pack.rb
+++ b/Casks/libreoffice-still-language-pack.rb
@@ -803,7 +803,6 @@ cask "libreoffice-still-language-pack" do
     cask "libreoffice-still"
   end
 
-  conflicts_with cask: ["libreoffice", "libreoffice-language-pack"]
   depends_on cask: "libreoffice-still"
   depends_on macos: ">= :sierra"
 

--- a/Casks/libreoffice-still-language-pack.rb
+++ b/Casks/libreoffice-still-language-pack.rb
@@ -845,6 +845,8 @@ cask "libreoffice-still-language-pack" do
   # See https://github.com/Homebrew/homebrew-cask/pull/52893
   uninstall delete: ["#{staged_path}/#{token}", "#{staged_path}/SilentInstall.sh"]
 
+  # No zap stanza required
+
   caveats <<~EOS
     #{token} cannot be upgraded, use brew reinstall --cask #{token} instead
   EOS


### PR DESCRIPTION
Not required as it depends on `libreoffice-still`.