### PR TITLE
rubocop: Fix `Cask/StanzaGrouping` offenses in `on_*` blocks

### DIFF
--- a/Casks/omnifocus2.rb
+++ b/Casks/omnifocus2.rb
@@ -2,11 +2,13 @@ cask "omnifocus2" do
   on_el_capitan :or_older do
     version "2.10"
     sha256 "e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
   end
   on_sierra :or_newer do
     version "2.12.4"
     sha256 "8a2dc53331dba804f6781773fef546a03c181fc4ff0eb7ee4f871c10342621f0"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
   end
 

--- a/Casks/omniplan3.rb
+++ b/Casks/omniplan3.rb
@@ -2,11 +2,13 @@ cask "omniplan3" do
   on_high_sierra :or_older do
     version "3.13"
     sha256 "82e0d7db2626d751f93f97d80dc032e4bc01bba1e05ea52c553e4771c8cfeec5"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPlan-#{version}.dmg"
   end
   on_mojave :or_newer do
     version "3.14.4"
     sha256 "34367f22766e5e420224e343d3cc2087c808f121f7c3f0fdfbd0e58f2d596e7e"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPlan-#{version}.dmg"
   end
 

--- a/Casks/openzfs-dev.rb
+++ b/Casks/openzfs-dev.rb
@@ -13,6 +13,7 @@ cask "openzfs-dev" do
   end
   on_intel do
     arch intel: "Catalina-10.15"
+
     version "2.1.6rc7,420"
     sha256 "6570087af4cda8efd47473c341852d10583e2357f221986745e9d7a407c111c4"
   end

--- a/Casks/virtualbox-beta.rb
+++ b/Casks/virtualbox-beta.rb
@@ -2,6 +2,7 @@ cask "virtualbox-beta" do
   on_arm do
     version "7.0.6_BETA4-155176"
     sha256 "0f3c380155a2bf8582058b1d7ae073a7fa76f9c1843f7e78c3dfe6cdcefe73bd"
+
     url "https://download.virtualbox.org/virtualbox/7.0.6/VirtualBox-7.0.6_BETA4-155176-macOSArm64.dmg"
 
     # TODO: Add a `livecheck` block if/when ARM64 dmg files are stored in a
@@ -17,6 +18,7 @@ cask "virtualbox-beta" do
   on_intel do
     version "7.0.0_BETA3,153829"
     sha256 "a97ad4e37f975ec3ec093a1dfc58f456cac2066f27ccc743a523a261235785b0"
+
     url "https://download.virtualbox.org/virtualbox/#{version.csv.first}/VirtualBox-#{version.csv.first}-#{version.csv.second}-OSX.dmg"
 
     # `LATEST-BETA.TXT` contains version text (e.g., `1.2.3_BETA4\n`) that


### PR DESCRIPTION
Companion PR to https://github.com/Homebrew/brew/pull/15211.

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
