### PR TITLE
shadow-beta: Fix Links and naming to reflect new App name

### DIFF
--- a/Casks/shadow-beta.rb
+++ b/Casks/shadow-beta.rb
@@ -1,12 +1,12 @@
 cask "shadow-beta" do
   arch arm: "arm64", intel: "x64"
 
-  version "8.0.10041"
-  sha256 arm:   "309af3518a51aa3539e574e7fcdc360d629c0b32bfb05d688a8e9fffebf5526b",
-         intel: "5cd4c2fb53a3153b381821972eb65aabab7dcbe54719007d5747bfe675c2a17a"
+  version "8.0.10084"
+  sha256 arm:   "8124db9ca5a9c2aa9acfc4b9cb88390f1771bd1d262bf470b9656c77e2b3fec8",
+         intel: "2807a81c349a61ee42655ad832c5a016205b23ec5d10e6508501c409724b7620"
 
-  url "https://update.shadow.tech/launcher/preprod/mac/#{arch}/ShadowBeta-#{version}.dmg"
-  name "Shadow Beta"
+  url "https://update.shadow.tech/launcher/preprod/mac/#{arch}/ShadowPCBeta-#{version}.dmg"
+  name "Shadow PC Beta"
   desc "Online virtualized computer"
   homepage "https://shadow.tech/"
 

--- a/Casks/shadow-beta.rb
+++ b/Casks/shadow-beta.rb
@@ -15,7 +15,7 @@ cask "shadow-beta" do
     strategy :electron_builder
   end
 
-  app "Shadow Beta.app"
+  app "Shadow PC Beta.app"
 
   zap trash: [
     "~/Library/Preferences/com.electron.shadow-beta.plist",


### PR DESCRIPTION
With the new beta version of the Shadow client, the client was renamed to "Shadow PC" to to avoid confusion with Shadow Drive.
This MR fix all problems (e.g. not removing the app when uninstalling the cask) and updates the version to the latest beta version.

Changelog for the renaming: https://forum.shadow.tech/roadmap-release-notes-24/shadow-update-week-09-03-03-2023-4517

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
