### PR TITLE
surge 4.11.2

### DIFF
--- a/Casks/surge4.rb
+++ b/Casks/surge4.rb
@@ -1,0 +1,36 @@
+cask "surge4" do
+  version "4.11.2,2016,b4c9dad3472594b01ef3d8ac9b05c78e"
+  sha256 "144ba12a3ea884f264ebe8fb5fc2c77003f51057fd9efe8662824acaf3805104"
+
+  url "https://dl.nssurge.com/mac/v#{version.major}/Surge-#{version.tr(",", "-")}.zip"
+  name "Surge"
+  desc "Network toolbox"
+  homepage "https://nssurge.com/"
+
+  livecheck do
+    url "https://www.nssurge.com/mac/v#{version.major}/appcast-signed.xml"
+    strategy :sparkle do |item|
+      match = item.url.match(/[._-](\d+(?:\.\d+)+)[._-](\d+)[._-](\h+)\.zip/i)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]},#{match[3]}"
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: "surge"
+  depends_on macos: ">= :high_sierra"
+
+  app "Surge.app"
+
+  uninstall launchctl: "com.nssurge.surge-mac.helper",
+            delete:    "/Library/PrivilegedHelperTools/com.nssurge.surge-mac.helper"
+
+  zap delete: [
+    "~/Library/Application Support/com.nssurge.surge-mac",
+    "~/Library/Caches/com.nssurge.surge-mac",
+    "~/Library/Caches/com.nssurge.surge-mac.plist",
+    "~/Library/Logs/Surge",
+    "~/Library/Preferences/com.nssurge.surge-mac.plist",
+  ]
+end


### PR DESCRIPTION
Checked out from 31c764c2791597b848ad6465de671f936286ee41 on homebrew-cask but upgraded from 4.11.0,2007,d63ca86cd3056a9ec16331bfdbc5f526 to 4.11.2,2016,b4c9dad3472594b01ef3d8ac9b05c78e.

Put surge 4 on homebrew-cask-versions because "surge" on homebrew-cask has been replaced by a paid upgrade ([surge 5.x](https://github.com/Homebrew/homebrew-cask/pull/144862)).

See also https://github.com/Homebrew/homebrew-cask/blob/31c764c2791597b848ad6465de671f936286ee41/Casks/surge.rb

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked suxccessfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
