### PR TITLE
Add db-browser-for-sqlcipher-nightly cask

### DIFF
--- a/Casks/db-browser-for-sqlcipher-nightly.rb
+++ b/Casks/db-browser-for-sqlcipher-nightly.rb
@@ -1,0 +1,18 @@
+cask "db-browser-for-sqlcipher-nightly" do
+  arch arm: "arm64", intel: "intel"
+
+  version :latest
+  sha256 :no_check
+
+  url "https://nightlies.sqlitebrowser.org/latest/DB.Browser.for.SQLCipher-#{arch}.dmg"
+  name "DB Browser for SQLCipher Nightly"
+  desc "Database browser for SQLCipher"
+  homepage "https://sqlitebrowser.org/"
+
+  app "DB Browser for SQLCipher Nightly.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.sqlitebrowser.sqlitebrowser.plist",
+    "~/Library/Saved Application State/net.sourceforge.sqlitebrowser.savedState",
+  ]
+end


### PR DESCRIPTION
@sqlitebrowser has been split into 'SQLite' and 'SQLCipher' versions for the Mac nightly builds.
So this cask is a 'variant' of sorts. I read the documentation on the Homebrew side and didn't see anything that would be a problem. so I added Cask and created a this PR. Please review and let me know if have any issues. Thank you.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
