### PR TITLE
Add Mixxx snapshot cask

### DIFF
--- a/Casks/mixxx-snapshot.rb
+++ b/Casks/mixxx-snapshot.rb
@@ -1,0 +1,27 @@
+cask "mixxx-snapshot" do
+  arch arm: "arm", intel: "intel"
+
+  version "2.5-alpha-33-g3e500b1abc"
+  sha256 arm:   "6b67cf6c8559189b1ccfad7e8b011a23a470334d831deb7f497a300798399c45",
+         intel: "d0c0a4405961ec2f4cb256b0221d05380ebb828d3879226adcf572cece302988"
+
+  url "https://downloads.mixxx.org/snapshots/main/mixxx-#{version}-macos#{arch}.dmg"
+  name "Mixxx"
+  desc "Open-source DJ software"
+  homepage "https://www.mixxx.org/"
+
+  livecheck do
+    url "https://www.mixxx.org/download/"
+    regex(%r{href=["']?https://downloads\.mixxx\.org/snapshots/main/mixxx[._-]v?(\S+)[._-]macos(?:intel|arm)\.dmg}i)
+  end
+
+  conflicts_with cask: "mixxx"
+
+  app "Mixxx.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/org.mixxx.mixxx",
+    "~/Library/Containers/org.mixxx.mixxx",
+    "~/Music/Mixxx",
+  ]
+end

--- a/Casks/mixxx-snapshot.rb
+++ b/Casks/mixxx-snapshot.rb
@@ -12,7 +12,7 @@ cask "mixxx-snapshot" do
 
   livecheck do
     url "https://mixxx.org/download/"
-    regex(%r{href=.*?/snapshots/main/mixxx[._-]v?(.+)[._-]macosintel\.dmg}i)
+    regex(%r{href=.*?/snapshots/main/mixxx[._-]v?(.+)[._-]macos#{arch}\.dmg}i)
   end
 
   conflicts_with cask: "mixxx"

--- a/Casks/mixxx-snapshot.rb
+++ b/Casks/mixxx-snapshot.rb
@@ -11,8 +11,8 @@ cask "mixxx-snapshot" do
   homepage "https://www.mixxx.org/"
 
   livecheck do
-    url "https://www.mixxx.org/download/"
-    regex(%r{href=["']?https://downloads\.mixxx\.org/snapshots/main/mixxx[._-]v?(\S+)[._-]macos(?:intel|arm)\.dmg}i)
+    url "https://mixxx.org/download/"
+    regex(%r{href=.*?/snapshots/main/mixxx[._-]v?(.+)[._-]macosintel\.dmg}i)
   end
 
   conflicts_with cask: "mixxx"


### PR DESCRIPTION
This adds the [development snapshot version](https://mixxx.org/download/#testing) of the free DJ software [Mixxx](https://mixxx.org). The stable version is already available as a cask in the main repo.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
  - Since this is a snapshot version, this PR targets the cask-versions repo
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
