### PR TITLE
mono-mdk-for-visual-studio 6.12.0.188 + livecheck update

### DIFF
--- a/Casks/mono-mdk-for-visual-studio.rb
+++ b/Casks/mono-mdk-for-visual-studio.rb
@@ -1,6 +1,6 @@
 cask "mono-mdk-for-visual-studio" do
-  version "6.12.0.182"
-  sha256 "515b25097a53e8f5bf15585e5cc3e646b3a92e114e57bad2fd63370031931c1f"
+  version "6.12.0.188"
+  sha256 "07cdd4e5e72b562892960b7fc73af470db7a4ffc2f68bb834eb3d0a874bbd12c"
 
   url "https://download.mono-project.com/archive/#{version.major_minor_patch}/macos-10-universal/MonoFramework-MDK-#{version}.macos10.xamarin.universal.pkg"
   name "Mono"
@@ -10,8 +10,8 @@ cask "mono-mdk-for-visual-studio" do
   # The stable version is that listed on the download page. See:
   #   https://github.com/Homebrew/homebrew-cask-versions/pull/12974
   livecheck do
-    url "https://www.mono-project.com/download/vs/#download-mac"
-    regex(/MonoFramework-MDK-(\d+(?:\.\d+)+).macos10.xamarin.universal\.pkg/i)
+    url "https://software.xamarin.com/Service/Updates?v=2&m=d98c8b75-1a66-41bd-aa2f-9fca3bdb9c5d&pv964ebddd-1ffe-47e7-8128-5ce17ffffb05=516010000"
+    regex(/monoframework-mdk-(\d+(?:\.\d+)+).macos10.xamarin.universal\.pkg/i)
   end
 
   conflicts_with cask:    "mono-mdk",

--- a/Casks/mono-mdk-for-visual-studio.rb
+++ b/Casks/mono-mdk-for-visual-studio.rb
@@ -7,10 +7,8 @@ cask "mono-mdk-for-visual-studio" do
   desc "Open source implementation of Microsoft's .NET Framework"
   homepage "https://www.mono-project.com/"
 
-  # The stable version is that listed on the download page. See:
-  #   https://github.com/Homebrew/homebrew-cask-versions/pull/12974
   livecheck do
-    url "https://software.xamarin.com/Service/Updates?v=2&m=d98c8b75-1a66-41bd-aa2f-9fca3bdb9c5d&pv964ebddd-1ffe-47e7-8128-5ce17ffffb05=516010000"
+    url "https://software.xamarin.com/Service/Updates?v=2&pv964ebddd-1ffe-47e7-8128-5ce17ffffb05=1"
     regex(/monoframework-mdk-(\d+(?:\.\d+)+).macos10.xamarin.universal\.pkg/i)
   end
 


### PR DESCRIPTION
This PR is a reference to an earlier PR (#16883).

Due to version mismatching with the mono site and vs-updates, has the livecheck URL been updated to the Update Service used by Visual Studio for Mac itself (refer to [Microsoft Docs about VS firewall/proxy](https://learn.microsoft.com/en-us/visualstudio/install/install-and-use-visual-studio-behind-a-firewall-or-proxy-server?view=vs-2022)).

The Mono MDK package is still retrieved from the original archive servers of Mono.

- - - -

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `mono-mdk-for-visual-studio` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
