### PR TITLE
firefox-nightly: update minimum macOS

### DIFF
--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -86,7 +86,7 @@ cask "firefox-nightly" do
   desc "Web browser"
   homepage "https://www.mozilla.org/firefox/channel/desktop/#nightly"
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :catalina"
 
   app "Firefox Nightly.app"
 


### PR DESCRIPTION
https://support.mozilla.org/en-US/kb/firefox-users-macos-1012-1013-1014-moving-to-extended-support

Upcoming action dates:

* 7th July 2023:
  - Update `homebrew/cask-versions/firefox-beta` minimum bound.
  - Update `homebrew/cask-versions/firefox-developer-edition` minimum bound.
* 1st August 2023:
  - Update `firefox` minimum bound, at the same time as updating to 116.0.
  - Update `homebrew/cask-versions/firefox-cn` minimum bound, at the same time as updating to 116.0.
* Summer 2024:
  - Update `homebrew/cask-versions/firefox-esr` minimum bound, at the same time as updating to the next major version after 115 (120 something).
  - Likely update `thunderbird` minimum bound, when updating to the same new major version number.