### PR TITLE
blender-lts: 3.3.8 to 3.6.0

### DIFF
--- a/Casks/blender-lts.rb
+++ b/Casks/blender-lts.rb
@@ -22,7 +22,7 @@ cask "blender-lts" do
       next if lts_page[:content].blank?
 
       lts_versions =
-        lts_page[:content].scan(%r{href=["'].*/download/lts/(\d+(?:[.-]\d+)+)/["' >]}i)
+        lts_page[:content].scan(%r{href=["'].*/download/(?:lts|releases)/(\d+(?:[.-]\d+)+)/["' >]}i)
                           .flatten
                           .uniq
                           .map { |v| Version.new(v) }

--- a/Casks/blender-lts.rb
+++ b/Casks/blender-lts.rb
@@ -1,9 +1,9 @@
 cask "blender-lts" do
   arch arm: "arm64", intel: "x64"
 
-  version "3.3.8"
-  sha256 arm:   "c42ab21bfe0baa267e0453b256824b3da68edd6c57683ca570c7372720106110",
-         intel: "19fffcf276a7fc7cbff317cba8c4cbadc7437c0e5352ace090fa8792344b87da"
+  version "3.6.0"
+  sha256 arm:   "ab4e1793343b3d22d7481d30d7f2817b7eb19c9dbdc505db3765336545746e63",
+         intel: "9534dd39b764e11314da968043a982b5259741ecac55432c86aae3976defc183"
 
   url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg"
   name "Blender"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.*
- [x] `brew style --fix <cask>` reports no offenses.

*I'm not sure how to fix this, as the existing 3.3.8 cask had the same errors:

```
audit for blender-lts: failed
 - Version '3.6.0' differs from '3.3.8' retrieved by livecheck.
 - Version '3.6.0' differs from '3.3.8' retrieved by livecheck.
homebrew/core
  * audit_exceptions/versioned_dependencies_conflicts_allowlist.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: predictionio
  * pypi_formula_mappings.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: rtv
blender-lts
  * Version '3.6.0' differs from '3.3.8' retrieved by livecheck.
Error: 3 problems in 1 cask and 1 tap detected.
```