### PR TITLE
google-chrome-canary: update minimum macOS

### DIFF
--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -1,5 +1,5 @@
 cask "google-chrome-canary" do
-  version "117.0.5876.0"
+  version "117.0.5877.0"
   sha256 :no_check
 
   url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -13,7 +13,7 @@ cask "google-chrome-canary" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :catalina"
 
   app "Google Chrome Canary.app"
 


### PR DESCRIPTION
Similar situation happening with Google Chrome: https://support.google.com/chrome/a/answer/7679408#noSuppMacOS114

Future dates:
* google-chrome-dev 117 - ~19 July
* google-chrome-beta 117 - ~16 August
* google-chrome 117 - 12 September

Chromium-derived browsers like Opera may be similarly affected.