### PR TITLE
libreoffice-still: differentiate description

### DIFF
--- a/Casks/libreoffice-still.rb
+++ b/Casks/libreoffice-still.rb
@@ -9,7 +9,7 @@ cask "libreoffice-still" do
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"
   name "LibreOffice Still"
-  desc "Free cross-platform office suite"
+  desc "Free cross-platform office suite, stable version recommended for enterprises"
   homepage "https://www.libreoffice.org/"
 
   livecheck do


### PR DESCRIPTION
Differentiates description from [libreoffice.rb in homebrew-cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/libreoffice.rb), adding information from https://www.libreoffice.org/download/release-notes/#Still

`Free cross-platform office suite` -> `Free cross-platform office suite, stable version recommended for enterprises`

The wording "stable version recommended for enterprises" comes from (bolding added for emphasis):
> "The mature "still" version of LibreOffice, **recommended for enterprises**. As such, the version is **stable** and is suitable for all users."–https://www.libreoffice.org/download/release-notes/#Still

This differentiation is improved by https://github.com/Homebrew/homebrew-cask/pull/150996

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:
- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.~~