### PR TITLE
Add Affinity Designer 1

### DIFF
--- a/Casks/affinity-designer1.rb
+++ b/Casks/affinity-designer1.rb
@@ -19,6 +19,6 @@ cask "affinity-designer1" do
   zap trash: [
     "~/Library/Application Support/Affinity Designer",
     "~/Library/Caches/com.seriflabs.affinitydesigner",
-    "~/Library/Saved Application State/com.seriflabs.affinitydesigner.savedState"
+    "~/Library/Saved Application State/com.seriflabs.affinitydesigner.savedState",
   ]
 end

--- a/Casks/affinity-designer1.rb
+++ b/Casks/affinity-designer1.rb
@@ -1,0 +1,24 @@
+cask "affinity-designer1" do
+  version "1.10.6"
+  sha256 :no_check
+
+  url "https://store.serif.com/download/aa4dee/"
+  name "Affinity Designer"
+  desc "Professional graphic design software"
+  homepage "https://affinity.serif.com/en-us/designer/"
+
+  livecheck do
+    url :url
+    strategy :header_match
+  end
+
+  auto_updates true
+
+  app "Affinity Designer.app"
+
+  zap trash: [
+    "~/Library/Application Support/Affinity Designer",
+    "~/Library/Caches/com.seriflabs.affinitydesigner",
+    "~/Library/Saved Application State/com.seriflabs.affinitydesigner.savedState"
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

## Notes

- Serif has publicly committed to patching their V1 suite so it continues working ([source](https://affinity.serif.com/en-us/affinity-2-faq/))

  > Upgrading is completely optional and, if you wish, you can continue to use the original apps for as long as you like. While V1 will no longer receive any feature updates, we will endeavour to fix any critical issues which may be caused by operating system updates for as long as is reasonable to do so.

- Since being [updated to V2 on `homebrew-cask`](https://github.com/Homebrew/homebrew-cask/pull/135689) there has already been a new release (`1.10.5` -> `1.10.6`); otherwise this file is largely unaltered

- V2 is a paid upgrade and it's not backwards-compatible in the sense that it does not accept a V1 license and gate the new features; they are decidedly separate applications and licensed to reflect that

- V1 was in development from [2014](https://github.com/unitof/homebrew-cask/commit/5acaab47c79dd9fa45e7d825797b8810098d89b5) until 2022 and has not been updated to include excessive or persistent upgrade marketing, so it's reasonable to think many users will continue to use V1

- If this is acceptable, I can open follow-up PRs for V1 Affinity Photo and Publisher so there's consistency across the suite