### PR TITLE
Add Threema Multi Device Beta

### DIFF
--- a/Casks/threema-beta.rb
+++ b/Casks/threema-beta.rb
@@ -6,13 +6,13 @@ cask "threema-beta" do
          intel: "1f20ae86c78c65be029e17c0e07a3c07cc9a780f4376f451f39fbdcd10f3ec48"
 
   url "https://releases.threema.ch/desktop/#{version}/threema-desktop-v#{version}-macos-#{arch}.dmg"
-  name "Threema Desktop 2.0 Beta"
+  name "Threema"
   desc "End-to-end encrypted instant messaging application"
   homepage "https://threema.ch/download-md"
 
   livecheck do
     url "https://threema.ch/en/download-md"
-    regex(/(2.0-beta\s*\d+(?:)+)/i)
+    regex(/href=.*?threema[._-]desktop[._-]v?(\d+(?:(?:[.-]|(beta))+\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
   end
 
   app "Threema Beta.app"

--- a/Casks/threema-beta.rb
+++ b/Casks/threema-beta.rb
@@ -1,8 +1,9 @@
-cask "threema-multi-device-beta" do
+cask "threema-beta" do
   arch arm: "arm64", intel: "x64"
 
   version "2.0-beta17"
-  sha256 :no_check
+  sha256 arm:   "41dd788989a4bc859a71fc94d268fbef80f59f321274b622284f04a9c2627367",
+         intel: "1f20ae86c78c65be029e17c0e07a3c07cc9a780f4376f451f39fbdcd10f3ec48"
 
   url "https://releases.threema.ch/desktop/#{version}/threema-desktop-v#{version}-macos-#{arch}.dmg"
   name "Threema Desktop 2.0 Beta"

--- a/Casks/threema-multi-device-beta.rb
+++ b/Casks/threema-multi-device-beta.rb
@@ -1,0 +1,24 @@
+cask "threema-multi-device-beta" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.0-beta17"
+  sha256 :no_check
+
+  url "https://releases.threema.ch/desktop/#{version}/threema-desktop-v#{version}-macos-#{arch}.dmg"
+  name "Threema Desktop 2.0 Beta"
+  desc "End-to-end encrypted instant messaging application"
+  homepage "https://threema.ch/download-md"
+
+  livecheck do
+    url "https://threema.ch/en/download-md"
+    regex(/(2.0-beta\s*\d+(?:)+)/i)
+  end
+
+  app "Threema Beta.app"
+
+  zap trash: [
+    "~/Library/Application Support/ThreemaDesktop",
+    "~/Library/Preferences/ch.threema.threema-desktop.plist",
+    "~/Library/Saved Application State/ch.threema.threema-desktop.savedState",
+  ]
+end


### PR DESCRIPTION
Threema is a paid cross-platform encrypted instant messaging app developed by Threema GmbH in Switzerland. The multi device beta introduces a new multi device functionality to the existing desktop app. I have included multi device in the cask name to clearly distinguish it from the previous desktop application which would also be available as a beta version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
