### PR TITLE
fix: Add missing Tap migration: sublime-text3 -> homebrew/core/sublime-text

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,4 @@
 {
-  "java11": "homebrew/core"
+  "java11": "homebrew/core",
+  "sublime-text3": "homebrew/cask"
 }


### PR DESCRIPTION
It looks like this was missed, and I've got a few old macbooks that are apparently still stuck on this old version (not used anyway, but was preventing clean upgrade via automation).  

This PR should be merged with its companion: Homebrew/homebrew-cask#151961

Refs:

  - Cask removed in: 8d7ef627f6889b3ceabe0a7c4ad2ea9c1f2992b5
  - Rename PR: Homebrew/homebrew-cask#151961
  - Fixes: LyraPhase/sprout-wrap#196

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**: <kbd>N/A</kbd>

- [N/A] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [N/A] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [N/A] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [N/A] `brew audit --new-cask <cask>` worked successfully.
- [N/A] `brew install --cask <cask>` worked successfully.
- [N/A] `brew uninstall --cask <cask>` worked successfully.
