### PR TITLE
Add Cask for RStudio daily build

### DIFF
--- a/Casks/rstudio-daily.rb
+++ b/Casks/rstudio-daily.rb
@@ -1,0 +1,14 @@
+cask "rstudio-daily" do
+  version :latest
+  sha256 :no_check
+
+  url "https://www.rstudio.org/download/latest/daily/desktop/mac/RStudio-latest.dmg",
+      verified: "rstudio.org/"
+  name "RStudio"
+  desc "Data science software focusing on R and Python"
+  homepage "https://dailies.rstudio.com/"
+
+  app "RStudio.app"
+
+  zap trash: "~/.rstudio-desktop"
+end

--- a/Casks/rstudio-daily.rb
+++ b/Casks/rstudio-daily.rb
@@ -3,12 +3,25 @@ cask "rstudio-daily" do
   sha256 :no_check
 
   url "https://www.rstudio.org/download/latest/daily/desktop/mac/RStudio-latest.dmg",
-      verified: "rstudio.org/"
+      verified: "rstudio.org/download/latest/daily/desktop/mac/"
   name "RStudio"
   desc "Data science software focusing on R and Python"
   homepage "https://dailies.rstudio.com/"
 
+  conflicts_with cask: "rstudio"
+  depends_on macos: ">= :big_sur"
+
   app "RStudio.app"
 
   zap trash: "~/.rstudio-desktop"
+
+  caveats <<~EOS
+    #{token} depends on R. The R Project provides official binaries:
+
+      brew install --cask r
+
+    Alternatively, the Homebrew-compiled version of R omits the GUI app:
+
+      brew install r
+  EOS
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).  ***Not applicable for dailies in `homebrew-cask-versions`***
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


---

This re-adds the previously [removed](https://github.com/Homebrew/homebrew-cask-versions/pull/15628) RStudio Daily cask, which had a URL that pointed to an old page of the vendor, and an unstable download link.  The vendor has since have since updated their URL scheme for downloads, including stable "latest" links for downloading dailies: https://dailies.rstudio.com/links/