### PR TITLE
corretto21

### DIFF
--- a/Casks/corretto21.rb
+++ b/Casks/corretto21.rb
@@ -1,0 +1,25 @@
+cask "corretto21" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "21.0.0.35.1"
+  sha256 arm:   "4a877d133a3c2c524947a53f5f031cb87264c18c97c858acb084bbf8bf4e476c",
+         intel: "0201f564f99225e132399d358c52e80fe97945175d95681249741d6654e099e0"
+
+  url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
+  name "AWS Corretto JDK"
+  desc "OpenJDK distribution from Amazon"
+  homepage "https://corretto.aws/"
+
+  livecheck do
+    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch}-macos-jdk.pkg"
+    strategy :header_match do |headers|
+      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i, 1]
+    end
+  end
+
+  pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"
+
+  uninstall pkgutil: "com.amazon.corretto.#{version.major}"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
JDK 21 is the next LTS release of the Java Platform. Corretto 21 matches the Corretto 17, 11, and 8 casks already a part of this repo. This is currently a copy of the corretto formula with 21 added to the token, so that as JDK 22 starts development, this is a stable target for those that want the latest LTS release. Tested via `tap`-ing my fork

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ x ] `brew audit --cask --online <cask>` is error-free.
- [ x ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ x ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ x ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ x ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ x ] `brew audit --new-cask <cask>` worked successfully.
- [ x ] `brew install --cask <cask>` worked successfully.
- [ x ] `brew uninstall --cask <cask>` worked successfully.
