### PR TITLE
workflows: add autobump.yml

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,0 +1,67 @@
+name: Bump casks on schedule or request
+
+on:
+  workflow_dispatch:
+    inputs:
+      casks:
+        description: Custom list of casks to livecheck and bump if outdated
+        required: false
+  schedule:
+    # Every day at 5am
+    - cron: "0 5 * * *"
+
+env:
+  CASKS: >
+    1password-beta
+    android-studio-preview-canary
+    brave-browser-beta
+    brave-browser-dev
+    brave-browser-nightly
+    defold-alpha
+    dropbox-beta
+    emacs-nightly
+    google-chrome-beta
+    google-chrome-canary
+    google-chrome-dev
+    iterm2-nightly
+    macloggerdx-beta
+    microsoft-edge-beta
+    microsoft-edge-dev
+    mongodb-compass-beta
+    openscad-snapshot
+    openshot-video-editor-daily
+    opera-developer
+    signal-beta
+    sketch-beta
+    vivaldi-snapshot
+    vscodium-insiders
+    whatsapp-alpha
+    whatsapp-beta
+
+permissions:
+  contents: read
+
+jobs:
+  autobump:
+    if: github.repository == 'Homebrew/homebrew-cask-versions'
+    runs-on: macos-latest
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: false
+          cask: true
+          test-bot: false
+
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: ${{ (github.event_name == 'workflow_dispatch' && github.actor) || 'BrewTestBot' }}
+
+      - name: Bump casks
+        uses: Homebrew/actions/bump-packages@master
+        continue-on-error: true
+        with:
+          token: ${{ secrets.HOMEBREW_CASK_REPO_WORKFLOW_TOKEN }}
+          casks: ${{ github.event.inputs.casks || env.CASKS }}


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/pull/145518

This adds the autobump workflow from `homebrew/cask`. I added the top 25 casks that have been bumped most frequently in the past year. We can pare the list down if needed.

```fish
❯ git log --pretty=format: --name-only --since="1 year ago" | sort | uniq -c | sort -rg | head -26
4025
 232 Casks/google-chrome-canary.rb
 123 Casks/brave-browser-nightly.rb
  87 Casks/macloggerdx-beta.rb
  87 Casks/dropbox-beta.rb
  86 Casks/whatsapp-beta.rb
  77 Casks/brave-browser-beta.rb
  70 Casks/whatsapp-alpha.rb
  68 Casks/emacs-nightly.rb
  59 Casks/signal-beta.rb
  58 Casks/sketch-beta.rb
  57 Casks/google-chrome-beta.rb
  53 Casks/brave-browser-dev.rb
  52 Casks/vivaldi-snapshot.rb
  52 Casks/iterm2-nightly.rb
  48 Casks/opera-developer.rb
  48 Casks/microsoft-edge-beta.rb
  46 Casks/microsoft-edge-dev.rb
  45 Casks/openscad-snapshot.rb
  44 Casks/google-chrome-dev.rb
  44 Casks/1password-beta.rb
  43 Casks/android-studio-preview-canary.rb
  40 Casks/mongodb-compass-beta.rb
  40 Casks/defold-alpha.rb
  39 Casks/vscodium-insiders.rb
  38 Casks/openshot-video-editor-daily.rb
```