### PR TITLE
Downgrade Blender-LTS=3.6.2 pending fix to 3.6.3

### DIFF
--- a/Casks/blender-lts.rb
+++ b/Casks/blender-lts.rb
@@ -1,9 +1,9 @@
 cask "blender-lts" do
   arch arm: "arm64", intel: "x64"
 
-  version "3.6.3"
-  sha256 arm:   "20145c50640ec9f0b646d80c712d650887baf943f14980ff66894079cc4abf50",
-         intel: "ae4050e87e5d546362212bd1948f1a2212d3b5adb53a754a22fd7a271ef636aa"
+  version "3.6.2"
+  sha256 arm:   "60b8b57d2d20dd8b47248c1eb34565372789813232663cea71fc1aaf968cb2a6",
+         intel: "661aa18604a38c0b25f132d5c176ae51c83c89cd89a752aa312aace1c730b204"
 
   url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg"
   name "Blender"


### PR DESCRIPTION
There is a known Segmentation Fault in Blender 3.6.3 that prevents it from starting on MacOS (Intel). Documented here: <https://projects.blender.org/blender/blender/issues/112681>. Therefore, the cask should be temporarily downgraded to the last known working version until a fix is released.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
