### PR TITLE
Tsh13

### DIFF
--- a/Casks/tsh13.rb
+++ b/Casks/tsh13.rb
@@ -13,8 +13,8 @@ cask "tsh13" do
     regex(/tsh[._-]v?(13(?:\.\d+)+)\.pkg/i)
   end
 
-  conflicts_with formula: "teleport",
-                 cask:    "tsh"
+  conflicts_with cask:    "tsh",
+                 formula: "teleport"
 
   pkg "tsh-#{version}.pkg"
 

--- a/Casks/tsh13.rb
+++ b/Casks/tsh13.rb
@@ -1,6 +1,6 @@
 cask "tsh13" do
-  version "13.3.8"
-  sha256 "c4678ce55cf030388363d7e12780e6b79e54b89e2e9d0b0635959a41c3ab7931"
+  version "13.4.0"
+  sha256 "4d6d27492bf7ddf6a5ef3482dee404a9dfc060b3f06a161dca4d9a2471d57b63"
 
   url "https://cdn.teleport.dev/tsh-#{version}.pkg",
       verified: "cdn.teleport.dev/"
@@ -10,7 +10,7 @@ cask "tsh13" do
 
   livecheck do
     url "https://goteleport.com/download/"
-    regex(/tsh[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+    regex(/tsh[._-]v?(13(?:\.\d+)+)\.pkg/i)
   end
 
   conflicts_with formula: "teleport",

--- a/Casks/tsh13.rb
+++ b/Casks/tsh13.rb
@@ -1,0 +1,24 @@
+cask "tsh13" do
+  version "13.3.8"
+  sha256 "c4678ce55cf030388363d7e12780e6b79e54b89e2e9d0b0635959a41c3ab7931"
+
+  url "https://cdn.teleport.dev/tsh-#{version}.pkg",
+      verified: "cdn.teleport.dev/"
+  name "Teleport TSH (v13)"
+  desc "SSH server for teams managing distributed infrastructure"
+  homepage "https://goteleport.com/"
+
+  livecheck do
+    url "https://goteleport.com/download/"
+    regex(/tsh[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+  end
+
+  conflicts_with formula: "teleport",
+                 cask:    "tsh"
+
+  pkg "tsh-#{version}.pkg"
+
+  uninstall pkgutil: "(.*).com.gravitational.teleport.tsh"
+
+  zap trash: "~/.tsh"
+end


### PR DESCRIPTION
## Context

Teleport is generally not compatible across major versions. With the recent release of Teleport 14, it is valuable to have an alternate cask targeting the latest release of `tsh` 13.

For more, see: https://github.com/Homebrew/homebrew-cask/issues/156128

### Horizontal Diff

This new cask is based heavily on the existing [tsh.rb in homebrew-cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/t/tsh.rb). A diff may be useful here:

```sh
curl https://raw.githubusercontent.com/Homebrew/homebrew-cask/7673a9eea0a288e40731872eee43962f7a933c58/Casks/t/tsh.rb > /tmp/tsh.rb
git diff --no-index /tmp/tsh.rb Casks/tsh13.rb
```

```diff
diff --git a/tmp/tsh.rb b/Casks/tsh13.rb
index c59154125b..0794f36db2 100644
--- a/tmp/tsh.rb
+++ b/Casks/tsh13.rb
@@ -1,19 +1,20 @@
-cask "tsh" do
-  version "14.0.0"
-  sha256 "5222d60d691e2830bf7b89fcdf0eb6fc70122719509c4a2d011b34f64dd055c2"
+cask "tsh13" do
+  version "13.4.0"
+  sha256 "4d6d27492bf7ddf6a5ef3482dee404a9dfc060b3f06a161dca4d9a2471d57b63"
 
   url "https://cdn.teleport.dev/tsh-#{version}.pkg",
       verified: "cdn.teleport.dev/"
-  name "Teleport TSH"
+  name "Teleport TSH (v13)"
   desc "SSH server for teams managing distributed infrastructure"
   homepage "https://goteleport.com/"
 
   livecheck do
     url "https://goteleport.com/download/"
-    regex(/tsh[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+    regex(/tsh[._-]v?(13(?:\.\d+)+)\.pkg/i)
   end
 
-  conflicts_with formula: "teleport"
+  conflicts_with formula: "teleport",
+                 cask:    "tsh"
 
   pkg "tsh-#{version}.pkg"
```

## Checklist
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
