### PR TITLE
add temurin20.rb

### DIFF
--- a/Casks/temurin20.rb
+++ b/Casks/temurin20.rb
@@ -1,0 +1,27 @@
+cask "temurin20" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "20.0.2,9"
+  sha256 arm:   "83e1539a97684fc30d291e104afc9df22deb83e0554e9df581010ebea284210a",
+         intel: "eeb481cf22c2c6ce30d6ed924b30bf1ab5d0df9e0ebfe6178649ad2819a6cd8c"
+
+  url "https://github.com/adoptium/temurin#{version.major}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg",
+      verified: "github.com/adoptium/"
+  name "Eclipse Temurin Java Development Kit"
+  desc "JDK from the Eclipse Foundation (Adoptium)"
+  homepage "https://adoptium.net/"
+
+  livecheck do
+    url :url
+    regex(/^jdk[._-](\d+(?:\.\d+)*)\+(\d+)$/i)
+    strategy :github_latest do |json, regex|
+      json["tag_name"]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+    end
+  end
+
+  pkg "OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg"
+
+  uninstall pkgutil: "net.temurin.#{version.major}.jdk"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


---

The base Java temurin homebrew Cask has been updated to v21. Adding v20 here so people can continue to manage their install via homebrew if desired. I copied the historic [temurin.rb](https://github.com/gdams/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/t/temurin.rb) when it was referencing the v20 binaries  and removed the livecheck as it's now referencing v21.

Similar to the https://github.com/Homebrew/homebrew-cask-versions/pull/14764 brew audit --new-cask temurin20 is failing with the following error:

```
audit for temurin20: failed
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
temurin20
  * line 8, col 2: GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 cask detected.
```
This requirement was waived for that PR as none of these repos are hosting actual source code, just binaries.

Thanks!
