### PR TITLE
android-studio-preview-canary: update `conflicts_with` and remove `depends_on`

### DIFF
--- a/Casks/android-studio-preview-canary.rb
+++ b/Casks/android-studio-preview-canary.rb
@@ -17,8 +17,10 @@ cask "android-studio-preview-canary" do
   end
 
   auto_updates true
-  conflicts_with cask: "android-studio-preview-beta"
-  depends_on macos: ">= :high_sierra"
+  conflicts_with cask: [
+    "android-studio",
+    "android-studio-preview-beta",
+  ]
 
   app "Android Studio Preview.app"
 


### PR DESCRIPTION
The `android-studio-preview-canary` and `android-studio-preview-beta` Casks often drop the `Preview` from the `app` name (see for example https://github.com/Homebrew/homebrew-cask-versions/pull/18069), so to be on the safe side I suggest we make all three `android-studio` Casks conflict with each other.

Also, the `LSMinimumSystemVersion` in the `plist` is macOS 10.8, so removing the `depends_on`.
