### PR TITLE
google-chrome-canary: switch to `version :latest`

### DIFF
--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -13,7 +13,6 @@ cask "google-chrome-canary" do
   #   regex(/"version":\s*"v?(\d+(?:\.\d+)+)"/i)
   # end
 
-  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "Google Chrome Canary.app"

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -7,6 +7,9 @@ cask "google-chrome-canary" do
   desc "Web browser"
   homepage "https://www.google.com/chrome/canary/"
 
+  # Canary releases are frequent, so this `strategy` block throttles livecheck
+  # to every fifth release. Ideally this should be handled outside of livecheck
+  # but this is an interim workaround.
   livecheck do
     url "https://chromiumdash.appspot.com/fetch_releases?channel=Canary&platform=Mac"
     strategy :page_match do |page|

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -9,7 +9,19 @@ cask "google-chrome-canary" do
 
   livecheck do
     url "https://chromiumdash.appspot.com/fetch_releases?channel=Canary&platform=Mac"
-    regex(/"version":\s*"v?(\d+(?:\.\d+)+)"/i)
+    strategy :page_match do |page|
+      current_version = page.match(/"version":\s*"v?(\d+(?:\.\d+)+)"/i)
+      previous_version = page.match(/"previous_version":\s*"v?(\d+(?:\.\d+)+)"/i)
+
+      # Throttle updates to every 5th release.
+      version = if current_version[1].tr(".", "").to_i >= previous_version[1].tr(".", "").to_i + 50
+        current_version[1]
+      else
+        previous_version[1]
+      end
+
+      version.to_s
+    end
   end
 
   auto_updates true

--- a/Casks/google-chrome-canary.rb
+++ b/Casks/google-chrome-canary.rb
@@ -1,5 +1,5 @@
 cask "google-chrome-canary" do
-  version "121.0.6101.0"
+  version :latest
   sha256 :no_check
 
   url "https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg"
@@ -7,27 +7,11 @@ cask "google-chrome-canary" do
   desc "Web browser"
   homepage "https://www.google.com/chrome/canary/"
 
-  # Canary releases are frequent, so this `strategy` block throttles livecheck
-  # to every fifth release. Ideally this should be handled outside of livecheck
-  # but this is an interim workaround.
-  livecheck do
-    url "https://chromiumdash.appspot.com/fetch_releases?channel=Canary&platform=Mac"
-    strategy :json do |json|
-      versions = json.map { |item| item["version"] }
-                     .compact
-                     .uniq
-                     .sort_by { |v| Version.new(v) }
-                     .reverse
-      current_pos = versions.index(version)
-
-      # Fall back to the newest version if the current version isn't found
-      next versions.first if current_pos.blank?
-
-      # Return the newest version if there have been five or more releases
-      # since the version in the cask.
-      (current_pos >= 5) ? versions.first : version
-    end
-  end
+  # Canary releases are frequent, so we use version :latest.
+  # livecheck do
+  #   url "https://chromiumdash.appspot.com/fetch_releases?channel=Canary&platform=Mac"
+  #   regex(/"version":\s*"v?(\d+(?:\.\d+)+)"/i)
+  # end
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
In the last week alone this Cask has been updated 12 times.

The `livecheck` `url` at https://chromiumdash.appspot.com/fetch_releases?channel=Canary&platform=Mac lists the current version and the previous version for each new release, which allows them to be compared.

I propose that we throttle the updates to every 5th release.

The `livecheck` may of course fail at the moment, but if other maintainers agree the `ci-skip-livecheck` label can be added to allow this to pass the CI checks if necessary.

Ping @samford for a review of my `livecheck` block and @reitermarkus who did something similar for the `bettertouchtool` Cask here: https://github.com/Homebrew/homebrew-cask/pull/142173