### PR TITLE
wine-devel: Add dependency gstreamer-runtime

### DIFF
--- a/Casks/wine-devel.rb
+++ b/Casks/wine-devel.rb
@@ -20,6 +20,7 @@ cask "wine-devel" do
     "wine-stable",
     "wine-staging",
   ]
+  depends_on cask: "gstreamer-runtime"
 
   app "Wine Devel.app"
   binary "#{appdir}/Wine Devel.app/Contents/Resources/start/bin/appdb"


### PR DESCRIPTION
GStreamer.framework has been a requirement since 8.16 packages, as there's now a cask available install it.