### PR TITLE
1password6, anaconda2: remove livecheck

### DIFF
--- a/Casks/1password6.rb
+++ b/Casks/1password6.rb
@@ -7,11 +7,6 @@ cask "1password6" do
   desc "Password manager that keeps all passwords secure behind one password"
   homepage "https://1password.com/"
 
-  livecheck do
-    url "https://app-updates.agilebits.com/product_history/OPM4"
-    regex(%r{href=.*?/1Password-(\d+(?:\.\d+)+)\.pkg}i)
-  end
-
   auto_updates true
 
   app "1Password #{version.major}.app"

--- a/Casks/anaconda2.rb
+++ b/Casks/anaconda2.rb
@@ -8,11 +8,6 @@ cask "anaconda2" do
   desc "Data science platform"
   homepage "https://www.anaconda.com/"
 
-  livecheck do
-    url "https://repo.anaconda.com/archive/"
-    regex(/href=.*?Anaconda2[._-]v?(\d+(?:\.\d+)+)-MacOSX-x86_64\.sh/i)
-  end
-
   container type: :naked
 
   installer script: {


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR removes the `livecheck` block from `1password6` and `anaconda2`, as there hasn't been a new release in years and the casks are discontinued. The most recent `1password6` release was 6.8.9 on 2018-05-18 and `anaconda2` was 2019.10 on 2019-10-15. Removing these `livecheck` blocks will ensure that livecheck will automatically skip these casks as discontinued.