### PR TITLE
insomnia-alpha 8.4.0-beta.0

### DIFF
--- a/Casks/insomnia-alpha.rb
+++ b/Casks/insomnia-alpha.rb
@@ -1,6 +1,6 @@
 cask "insomnia-alpha" do
-  version "2023.5.0-beta.13"
-  sha256 "3bd3165d8d759b26ec6581d4be66f9ea0419fc6cba57a54d957e28698601128f"
+  version "8.4.0-beta.0"
+  sha256 "89eb1d0db403e5303f08eea8a5f00f35f9c70cbc56d89658bba329b765614451"
 
   url "https://github.com/Kong/insomnia/releases/download/core%40#{version}/Insomnia.Core-#{version}.dmg",
       verified: "github.com/Kong/insomnia/"
@@ -9,13 +9,23 @@ cask "insomnia-alpha" do
   homepage "https://insomnia.rest/"
 
   livecheck do
-    url "https://github.com/Kong/insomnia/releases"
-    regex(%r{href=["']?[^"' >]*?/tag/core%40(\d+(?:\.\d+)+[._-](?:alpha|beta)[._-]?\d*)["' >]}i)
-    strategy :page_match
+    url :url
+    regex(/^core@v?(\d+(?:\.\d+)+[._-](?:alpha|beta|rc)[._-]?\d*)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   auto_updates true
   conflicts_with cask: "insomnia"
+  depends_on macos: ">= :catalina"
 
   app "Insomnia.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `insomnia-alpha` to the latest unstable version, as that appears to be how this cask is updated (i.e., not just alpha versions). [To be clear, upstream previously used a date-based version scheme but has moved away from it and this version is newer despite being numerically lower.] This also adds `depends_on macos: ">= :catalina"`, to resolve the related audit error.

The primary impetus of this PR was to update the `livecheck` block to use the `GithubReleases` strategy instead of checking the GitHub releases page. This omits `release["prerelease"]` from the `strategy` block early return condition, as this cask needs to match unstable releases.