### PR TITLE
greenery-beta 0.9.4 (new Binary App Cask)

### DIFF
--- a/Casks/greenery-beta.rb
+++ b/Casks/greenery-beta.rb
@@ -1,0 +1,20 @@
+cask "greenery-beta" do
+  version "0.9.4"
+  sha256 "13ae6e2a240f977c818f85a7a047c6e3d995a0407bc811affe0c4a6d9e9e3cc9"
+
+  url "https://github.com/GreenfireInc/Releases.Greenery/releases/download/v#{version}/Greenery.#{version}.zip",
+      verified: "github.com/GreenfireInc/Releases.Greenery/"
+  name "greenery-beta"
+  desc "Cryptocurrency bookkeeping and accounting wallet"
+  homepage "https://www.greenery.finance/"
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Greenery.app"
+
+  zap trash: [
+    "~/Library/Application Support/Greenery",
+    "~/Library/Preferences/com.greenery.app.plist",
+    "~/Library/Saved Application State/com.greenery.app.savedState",
+  ]
+end


### PR DESCRIPTION
This is the intial submission of the Greenery Beta release, v0.9.4. This is a Binary App release only for the Beta Cask, there is no associated source code for this app.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
