### PR TITLE
Update ThunderBbird Beta app name

### DIFF
--- a/Casks/thunderbird-beta.rb
+++ b/Casks/thunderbird-beta.rb
@@ -54,12 +54,13 @@ cask "thunderbird-beta" do
   url "https://download.mozilla.org/?product=thunderbird-beta-latest-SSL&os=osx&lang=#{language}",
       verified: "download.mozilla.org/"
   name "Mozilla Thunderbird"
+  desc "Customizable email client"
   homepage "https://www.thunderbird.net/en-US/thunderbird/beta/all/"
 
   conflicts_with cask: "thunderbird"
   depends_on macos: ">= :catalina"
 
-  app "Thunderbird.app"
+  app "Thunderbird Beta.app"
 
   zap trash: [
     "~/Library/Thunderbird",


### PR DESCRIPTION
## Problem

Could not install current beta version of Thunderbird-beta

```
 $ brew install --cask thunderbird-beta --verbose
==> Downloading https://download.mozilla.org/?product=thunderbird-beta-latest-SSL&os=osx&lang=de
Already downloaded: /Users/miry/Library/Caches/Homebrew/downloads/9c7040d18e574ff40102169ee516f9df24da6a999e56666e751d6ff2a971e004--Thunderbird 121.0b1.dmg
Warning: No checksum defined for cask 'thunderbird-beta', skipping verification.
==> Installing Cask thunderbird-beta
/usr/bin/env hdiutil attach -plist -nobrowse -readonly -mountrandom /private/tmp/d20231125-45654-729vni /Users/miry/Library/Caches/Homebrew/downloads/9c7040d18e574ff40102169ee516f9df24da6a999e56666e751d6ff2a971e004--Thunderbird\ 121.0b1.dmg
/usr/bin/env mkbom -s -i /private/tmp/20231125-45654-19ll7v4.list -- /private/tmp/20231125-45654-1c3g7o6.bom
/usr/bin/env ditto --bom /private/tmp/20231125-45654-1c3g7o6.bom -- /private/tmp/d20231125-45654-729vni/dmg.kF9XrD /private/tmp/d20231125-45654-o94cz1
/usr/bin/env diskutil info -plist /private/tmp/d20231125-45654-729vni/dmg.kF9XrD
/usr/bin/env diskutil eject /private/tmp/d20231125-45654-729vni/dmg.kF9XrD
/usr/bin/env cp -pR /private/tmp/d20231125-45654-o94cz1/Thunderbird\ Beta.app/. /opt/homebrew/Caskroom/thunderbird-beta/latest/Thunderbird\ Beta.app
==> Purging files for version latest of Cask thunderbird-beta
Error: It seems the App source '/opt/homebrew/Caskroom/thunderbird-beta/latest/Thunderbird.app' is not there.
```

## Solution

In new version of dmg file there is Thunderbird Beta.app instead of expected Thunderbird.app

Tested for `Thunderbird 121.0b1.dmg`

```
$ ls -a1 /Volumes/Thunderbird\ Beta

.
..
.DS_Store
.VolumeIcon.icns
.background
Thunderbird Beta.app
```

### Sidecar

Add missing field `desc` to fix BrewTestBot warning.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
