### PR TITLE
Add kaleidoscope3

### DIFF
--- a/Casks/kaleidoscope2.rb
+++ b/Casks/kaleidoscope2.rb
@@ -5,18 +5,32 @@ cask "kaleidoscope2" do
   url "https://updates.kaleidoscope.app/v#{version.major}/prod/Kaleidoscope-#{version.tr(",", "-")}.app.zip"
   name "Kaleidoscope v2"
   desc "Spot and merge differences in text and image files or folders"
-  homepage "https://www.kaleidoscope.app/"
+  homepage "https://kaleidoscope.app/"
 
+  # Upstream also includes the newest version across all major versions, so we
+  # have to omit items with a different major version.
   livecheck do
     url "https://updates.kaleidoscope.app/v#{version.major}/prod/appcast"
-    regex(/Kaleidoscope-(\d+(?:\.\d+)+)-(\d+)-(\w+(?:-\d+)*)\.app\.zip/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
+    regex(/Kaleidoscope[._-]v?(\d+(?:\.\d+)+)-(\d+)-(\w+(?:-\d+)*)\.app\.zip/i)
+    strategy :sparkle do |items, regex|
+      items.map do |item|
+        next if item.short_version&.split(".")&.first != version.major
+
+        match = item.url.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]},#{match[3]}"
+      end
     end
   end
 
   auto_updates true
-  conflicts_with cask: "kaleidoscope"
+  conflicts_with cask: [
+    "kaleidoscope",
+    "ksdiff",
+    "homebrew/cask-versions/kaleidoscope3",
+    "homebrew/cask-versions/ksdiff2",
+  ]
   depends_on macos: ">= :sierra"
 
   app "Kaleidoscope.app"

--- a/Casks/kaleidoscope3.rb
+++ b/Casks/kaleidoscope3.rb
@@ -1,0 +1,60 @@
+cask "kaleidoscope3" do
+  version "3.9,2176"
+  sha256 "036eea0cfd11797a72e37aa41af3c3acf65f7d6e9d5d5f5945444d49e232b44e"
+
+  url "https://updates.kaleidoscope.app/v#{version.major}/prod/Kaleidoscope-#{version.csv.first}-#{version.csv.second}.app.zip"
+  name "Kaleidoscope v3"
+  desc "Spot and merge differences in text and image files or folders"
+  homepage "https://kaleidoscope.app/"
+
+  # Upstream also includes the newest version across all major versions, so we
+  # have to omit items with a different major version.
+  livecheck do
+    url "https://updates.kaleidoscope.app/v#{version.major}/prod/appcast"
+    regex(/Kaleidoscope[._-]v?(\d+(?:\.\d+)+)[._-](\d+)\.app\.zip/i)
+    strategy :sparkle do |items, regex|
+      items.map do |item|
+        next if item.short_version&.split(".")&.first != version.major
+
+        match = item.url.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: [
+    "kaleidoscope",
+    "ksdiff",
+    "homebrew/cask-versions/kaleidoscope2",
+    "homebrew/cask-versions/ksdiff2",
+  ]
+  depends_on macos: ">= :big_sur"
+
+  app "Kaleidoscope.app"
+
+  postflight do
+    contents = "#{appdir}/Kaleidoscope.app/Contents"
+    system_command "#{contents}/Resources/Integration/scripts/install_ksdiff",
+                   args: ["#{contents}/MacOS", "#{HOMEBREW_PREFIX}/bin"]
+  end
+
+  uninstall quit:    "app.kaleidoscope.v#{version.major}",
+            pkgutil: "app.kaleidoscope.uninstall_ksdiff"
+
+  zap trash: [
+    "~/Library/Application Support/app.kaleidoscope.v*",
+    "~/Library/Application Support/com.blackpixel.kaleidoscope",
+    "~/Library/Application Support/Kaleidoscope",
+    "~/Library/Caches/app.kaleidoscope.v*",
+    "~/Library/Caches/com.blackpixel.kaleidoscope",
+    "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.blackpixel.kaleidoscope",
+    "~/Library/Preferences/app.kaleidoscope.v*.plist",
+    "~/Library/Preferences/com.blackpixel.kaleidoscope.plist",
+    "~/Library/Saved Application State/app.kaleidoscope.v*.savedState",
+    "~/Library/Saved Application State/com.blackpixel.kaleidoscope.savedState",
+    "~/Library/WebKit/app.kaleidoscope.v*",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

This adds a versioned `kaleidoscope3` cask, to go along with the `kaleidoscope2` cask, as the main `kaleidoscope` cask is now v4. v3 doesn't require a subscription unlike v4, so I'm planning to stick with v3 until it breaks or I find a better solution. Since we already have `kaleidoscope2`, I figured creating a `kaleidoscope3` cask in this repository might also provide some value (instead of creating it in my personal/local tap).

The existing `kaleidoscope` casks use the `PageMatch` strategy in the `livecheck` block, even though the URL is for a Sparkle appcast. In the case of `kaleidoscope2`, this may be done as a way of avoiding the newer `item` in the feed for the newest version across major versions (i.e., the newest 4.x version). However, we can omit items with a different major version in a `Sparkle` `strategy` block, so using `PageMatch` isn't necessary/appropriate here.

With that in mind, `kaleidoscope3` uses a `Sparkle` `livecheck` block and I've added another commit to update `kaleidoscope2`'s `livecheck` block to bring it in line. Past that, this also brings `conflicts_with` in `kaleidoscope2` up to date.

-----

If/when this is merged, I will create a PR to update the `kaleidoscope` cask (updating the `livecheck` block and `conflicts_with`).