### PR TITLE
Update `livecheck` blocks to use `Json` strategy

### DIFF
--- a/Casks/carbon-copy-cloner5.rb
+++ b/Casks/carbon-copy-cloner5.rb
@@ -10,9 +10,9 @@ cask "carbon-copy-cloner5" do
 
   livecheck do
     url "https://bombich.com/software/updates/ccc.php?os_major=11&os_minor=6&os_bugfix=0&ccc=6000&beta=0&locale=en"
-    strategy :page_match do |page|
-      version = JSON.parse(page)["stable"]["version"]
-      build = JSON.parse(page)["stable"]["build"]
+    strategy :json do |json|
+      version = json.dig("stable", "version")
+      build = json.dig("stable", "build")
       next if version.blank? || build.blank?
 
       "#{version}.#{build}"

--- a/Casks/figma-beta.rb
+++ b/Casks/figma-beta.rb
@@ -12,8 +12,8 @@ cask "figma-beta" do
 
   livecheck do
     url "https://desktop.figma.com/#{arch}/beta/RELEASE.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/olympus.rb
+++ b/Casks/olympus.rb
@@ -10,10 +10,10 @@ cask "olympus" do
 
   livecheck do
     url "https://dev.azure.com/EverestAPI/Olympus/_apis/build/builds"
-    strategy :page_match do |page|
-      JSON.parse(page)["value"].map do |build|
+    strategy :json do |json|
+      json["value"]&.map do |build|
         build["id"].to_s if build["sourceBranch"] == "refs/heads/stable"
-      end.compact
+      end
     end
   end
 

--- a/Casks/temurin11.rb
+++ b/Casks/temurin11.rb
@@ -14,8 +14,8 @@ cask "temurin11" do
   livecheck do
     url "https://api.adoptium.net/v3/assets/feature_releases/#{version.major}/ga?architecture=#{arch}&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
     regex(/^jdk-(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)$/i)
-    strategy :page_match do |page, regex|
-      JSON.parse(page).map do |release|
+    strategy :json do |json, regex|
+      json.map do |release|
         match = release["release_name"]&.match(regex)
         next if match.blank?
 

--- a/Casks/temurin17.rb
+++ b/Casks/temurin17.rb
@@ -14,8 +14,8 @@ cask "temurin17" do
   livecheck do
     url "https://api.adoptium.net/v3/assets/feature_releases/#{version.major}/ga?architecture=#{arch}&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
     regex(/^jdk-(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)$/i)
-    strategy :page_match do |page, regex|
-      JSON.parse(page).map do |release|
+    strategy :json do |json, regex|
+      json.map do |release|
         match = release["release_name"]&.match(regex)
         next if match.blank?
 

--- a/Casks/temurin8.rb
+++ b/Casks/temurin8.rb
@@ -11,8 +11,8 @@ cask "temurin8" do
   livecheck do
     url "https://api.adoptium.net/v3/assets/feature_releases/8/ga?architecture=x64&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
     regex(/^jdk(\d+)u(\d+)-b(\d+)$/i)
-    strategy :page_match do |page, regex|
-      JSON.parse(page).map do |release|
+    strategy :json do |json, regex|
+      json.map do |release|
         match = release["release_name"]&.match(regex)
         next if match.blank?
 

--- a/Casks/vmware-fusion-tech-preview.rb
+++ b/Casks/vmware-fusion-tech-preview.rb
@@ -20,8 +20,8 @@ cask "vmware-fusion-tech-preview" do
 
   livecheck do
     url "https://customerconnect.vmware.com/channel/public/api/v1.0/dlg/beta/header?locale=en_US&downloadGroup=FUS-TP2023"
-    strategy :page_match do |page|
-      JSON.parse(page)["buildNumber"]
+    strategy :json do |json|
+      json["buildNumber"]
     end
   end
 

--- a/Casks/whatsapp-legacy.rb
+++ b/Casks/whatsapp-legacy.rb
@@ -9,8 +9,8 @@ cask "whatsapp-legacy" do
 
   livecheck do
     url "https://web.whatsapp.com/desktop/mac/releases"
-    strategy :page_match do |page|
-      JSON.parse(page)["name"]
+    strategy :json do |json|
+      json["name"]
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to https://github.com/Homebrew/homebrew-cask/pull/161210, to update existing `livecheck` blocks that use `Json#parse` in a `PageMatch` `strategy` block to use the `Json` strategy instead. This approach preceded the `Json` strategy, so I'm bringing these up to date.

This also includes various tweaks to the livecheck blocks:

* carbon-copy-cloner5: Account for potentially-`nil` values
* olympus: Account for potentially-`nil` values. Remove `compact`, as livecheck already calls `uniq` and `compact` on a returned array from a `strategy` block (i.e., to simplify `strategy` block logic). [Fwiw, we do sometimes have to call `#compact` in parts of certain `GithubReleases` `strategy` blocks.]