### PR TITLE
zulu*: update version format, livecheck

### DIFF
--- a/Casks/zulu11.rb
+++ b/Casks/zulu11.rb
@@ -1,22 +1,26 @@
 cask "zulu11" do
   arch arm: "aarch64", intel: "x64"
-  choice = on_arch_conditional arm: "arm", intel: "x86"
 
-  version "11.0.21,11.68.17-ca"
+  version "11.0.21,11.68.17"
   sha256 arm:   "db2d52eec86d62ad42fc6a22e3f165d99070d77a98e55f7c45c5d07ae2f194b6",
          intel: "4bdb01ee04b804438e5c567a078da60e130e93ca2eec1739489876de2ea1a9b4"
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
-      referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-ca-jdk#{version.csv.first}-macosx_#{arch}.dmg",
+      referer: "https://www.azul.com/downloads/"
   name "Azul Zulu Java Standard Edition Development Kit"
   desc "OpenJDK distribution from Azul"
   homepage "https://www.azul.com/products/core/"
 
   livecheck do
-    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    regex(/zulu(\d+(?:[._]\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    url "https://api.azul.com/metadata/v1/zulu/packages?java_version=#{version.major}&os=macos&arch=#{arch}&archive_type=dmg&java_package_type=jdk&javafx_bundled=false&latest=true&release_status=ga&availability_types=ca"
+    regex(/zulu(\d+(?:[._]\d+)*)-ca-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
+    strategy :json do |json, regex|
+      json.map do |item|
+        match = item["download_url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+      end
     end
   end
 

--- a/Casks/zulu17.rb
+++ b/Casks/zulu17.rb
@@ -1,22 +1,26 @@
 cask "zulu17" do
   arch arm: "aarch64", intel: "x64"
-  choice = on_arch_conditional arm: "arm", intel: "x86"
 
-  version "17.0.9,17.46.19-ca"
+  version "17.0.9,17.46.19"
   sha256 arm:   "cec93e9bb5df6a77885d7b012c854a69ef5b4ba75e3db36e77b9df3aca149222",
          intel: "9a24939bfc5df574675c4d666d78a3211f00411cc08b4872dfc07a0bf7e5fd90"
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
-      referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-ca-jdk#{version.csv.first}-macosx_#{arch}.dmg",
+      referer: "https://www.azul.com/downloads/"
   name "Azul Zulu Java Standard Edition Development Kit"
   desc "OpenJDK distribution from Azul"
   homepage "https://www.azul.com/downloads/"
 
   livecheck do
-    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    regex(/zulu(\d+(?:[._]\d+)*-.*?)-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    url "https://api.azul.com/metadata/v1/zulu/packages?java_version=#{version.major}&os=macos&arch=#{arch}&archive_type=dmg&java_package_type=jdk&javafx_bundled=false&latest=true&release_status=ga&availability_types=ca"
+    regex(/zulu(\d+(?:[._]\d+)*)-ca-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
+    strategy :json do |json, regex|
+      json.map do |item|
+        match = item["download_url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+      end
     end
   end
 

--- a/Casks/zulu21.rb
+++ b/Casks/zulu21.rb
@@ -1,22 +1,26 @@
 cask "zulu21" do
   arch arm: "aarch64", intel: "x64"
-  choice = on_arch_conditional arm: "arm", intel: "x86"
 
-  version "21.0.1,21.30.15-ca"
+  version "21.0.1,21.30.15"
   sha256 arm:   "92d65ed61bf6c0bea0f9c44a6dd538da8a6c620a78f517c194913d1338fc39e7",
          intel: "f8f46bb00cfb8cecddcf71e10c77a577c9e9843a1e13a35ff05dbeec6f29788f"
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
-      referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-ca-jdk#{version.csv.first}-macosx_#{arch}.dmg",
+      referer: "https://www.azul.com/downloads/"
   name "Azul Zulu Java Standard Edition Development Kit"
   desc "OpenJDK distribution from Azul"
   homepage "https://www.azul.com/downloads/"
 
   livecheck do
-    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    regex(/zulu(\d+(?:[._]\d+)*-.*?)-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    url "https://api.azul.com/metadata/v1/zulu/packages?java_version=#{version.major}&os=macos&arch=#{arch}&archive_type=dmg&java_package_type=jdk&javafx_bundled=false&latest=true&release_status=ga&availability_types=ca"
+    regex(/zulu(\d+(?:[._]\d+)*)-ca-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
+    strategy :json do |json, regex|
+      json.map do |item|
+        match = item["download_url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+      end
     end
   end
 

--- a/Casks/zulu8.rb
+++ b/Casks/zulu8.rb
@@ -1,22 +1,26 @@
 cask "zulu8" do
   arch arm: "aarch64", intel: "x64"
-  choice = on_arch_conditional arm: "arm", intel: "x86"
 
-  version "8.0.392,8.74.0.17-ca"
+  version "8.0.392,8.74.0.17"
   sha256 arm:   "aa4126185a8b7c2d2f1b923ae5db216c5cd2e58a4072f39fed0e3db04acee4f2",
          intel: "843112f7543ea191c044b20f51ecdf7a3e17e3615b83e826d5b550820892228e"
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
-      referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-ca-jdk#{version.csv.first}-macosx_#{arch}.dmg",
+      referer: "https://www.azul.com/downloads/"
   name "Azul Zulu Java 8 Standard Edition Development Kit"
   desc "OpenJDK distribution from Azul"
   homepage "https://www.azul.com/"
 
   livecheck do
-    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    url "https://api.azul.com/metadata/v1/zulu/packages?java_version=#{version.major}&os=macos&arch=#{arch}&archive_type=dmg&java_package_type=jdk&javafx_bundled=false&latest=true&release_status=ga&availability_types=ca"
+    regex(/zulu(\d+(?:[._]\d+)*)-ca-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
+    strategy :json do |json, regex|
+      json.map do |item|
+        match = item["download_url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to https://github.com/Homebrew/homebrew-cask/pull/161748 and https://github.com/Homebrew/homebrew-cask/pull/161752, to bring the versioned `zulu` casks in line with the recent changes to `zulufx`. Namely this:

* Updates the `version` format to remove the `-ca` suffix, as we're only interested in releases with CA availability anyway. Removing the `-ca` suffix also brings the second part of the version in line with the upstream version format for that part (i.e., the download page uses "Azul Zulu: 21.30.15").
* Updates the `referer` (https://www.azul.com/downloads/zulu/zulu-mac/ redirects to https://www.azul.com/downloads/, so this brings it up to date)
* Updates the `livecheck` block to use the [Azul Metadata API](https://docs.azul.com/core/install/metadata-api), continuing to restrict results to the cask's major version (since these are versioned)

I've omitted `zulu13` and `zulu15`, as [support ended in 2023-03](https://www.azul.com/products/azul-support-roadmap/). I will create a separate PR to set those casks as discontinued (#18601).