### PR TITLE
zulu13, zulu15: discontinued

### DIFF
--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -1,6 +1,5 @@
 cask "zulu13" do
   arch arm: "aarch64", intel: "x64"
-  choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "13.0.14,13.54.17-ca"
   sha256 arm:   "b7b41f43f6a76f84d579e1d7b4abfd536928b6472e0ca3a8188f474235137b8e",
@@ -12,17 +11,13 @@ cask "zulu13" do
   desc "OpenJDK distribution from Azul"
   homepage "https://www.azul.com/products/core/"
 
-  livecheck do
-    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
-    end
-  end
-
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"
 
   zap trash: "~/Library/Saved Application State/com.azul.zulu.#{version.major}*.java.savedState"
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/zulu15.rb
+++ b/Casks/zulu15.rb
@@ -1,6 +1,5 @@
 cask "zulu15" do
   arch arm: "aarch64", intel: "x64"
-  choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "15.0.10,15.46.17-ca"
   sha256 arm:   "f5d123cd149f245792d0d807086f4c58c493bd52db8162ed2d2609f97e493ac1",
@@ -12,14 +11,6 @@ cask "zulu15" do
   desc "Zulu OpenJDK 15"
   homepage "https://www.azul.com/products/core/"
 
-  livecheck do
-    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    regex(/zulu(\d+(?:\.\d+)*-.*?)-jdk(\d+(?:\.\d+)+)-macosx_#{arch}\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
-    end
-  end
-
   depends_on macos: ">= :sierra"
 
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
@@ -27,4 +18,8 @@ cask "zulu15" do
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"
 
   zap trash: "~/Library/Saved Application State/com.azul.zulu.#{version.major}*.java.savedState"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

Support for `zulu13` and `zulu15` [ended in 2023-03](https://www.azul.com/products/azul-support-roadmap/). This sets the casks as discontinued and removes their `livecheck` blocks (so they will be automatically skipped as discontinued).