### PR TITLE
Use `deprecate!` instead of `discontinued`

### DIFF
--- a/Casks/1password6.rb
+++ b/Casks/1password6.rb
@@ -7,6 +7,8 @@ cask "1password6" do
   desc "Password manager that keeps all passwords secure behind one password"
   homepage "https://1password.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "1Password #{version.major}.app"
@@ -17,8 +19,4 @@ cask "1password6" do
     "~/Library/Containers/com.agilebits.onepassword-osx",
     "~/Library/Group Containers/2BUA8C4S2C.com.agilebits",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/ableton-live-intro10.rb
+++ b/Casks/ableton-live-intro10.rb
@@ -7,6 +7,8 @@ cask "ableton-live-intro10" do
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :el_capitan"
 
@@ -23,8 +25,4 @@ cask "ableton-live-intro10" do
     "~/Library/Preferences/com.ableton.live.plist*",
     "~/Music/Ableton",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/ableton-live-lite10.rb
+++ b/Casks/ableton-live-lite10.rb
@@ -7,6 +7,8 @@ cask "ableton-live-lite10" do
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/products/live-lite/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :el_capitan"
 
@@ -23,8 +25,4 @@ cask "ableton-live-lite10" do
     "~/Library/Preferences/com.ableton.live.plist*",
     "~/Music/Ableton",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/ableton-live-standard10.rb
+++ b/Casks/ableton-live-standard10.rb
@@ -7,6 +7,8 @@ cask "ableton-live-standard10" do
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :el_capitan"
 
@@ -23,8 +25,4 @@ cask "ableton-live-standard10" do
     "~/Library/Preferences/com.ableton.live.plist*",
     "~/Music/Ableton",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/ableton-live-suite10.rb
+++ b/Casks/ableton-live-suite10.rb
@@ -7,6 +7,8 @@ cask "ableton-live-suite10" do
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :el_capitan"
 
@@ -29,8 +31,4 @@ cask "ableton-live-suite10" do
     "~/Documents/Max [0-9]",
     "/Users/Shared/Max [0-9]",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/ableton-live-suite9.rb
+++ b/Casks/ableton-live-suite9.rb
@@ -7,14 +7,12 @@ cask "ableton-live-suite9" do
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Ableton Live #{version.major} Suite.app"
 
   zap trash: [
     "~/Library/*/*[Aa]bleton*",
     "~/Music/Ableton/Factory Packs",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -8,6 +8,8 @@ cask "adoptopenjdk8" do
   desc "Prebuilt OpenJDK binaries"
   homepage "https://adoptopenjdk.net/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "OpenJDK#{version.csv.first}U-jdk_x64_mac_hotspot_#{version.csv.first}u#{version.csv.second}#{version.csv.third}.pkg"
 
   uninstall pkgutil: "net.adoptopenjdk.#{version.csv.first}.jdk"
@@ -15,8 +17,6 @@ cask "adoptopenjdk8" do
   # No zap stanza required
 
   caveats do
-    discontinued
-
     <<~EOS
       Temurin is the official successor to this software:
 

--- a/Casks/alfred2.rb
+++ b/Casks/alfred2.rb
@@ -7,6 +7,8 @@ cask "alfred2" do
   desc "Application launcher and productivity software"
   homepage "https://www.alfredapp.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Alfred 2.app"
@@ -21,8 +23,4 @@ cask "alfred2" do
     "~/Library/Preferences/com.runningwithcrayons.Alfred-Preferences.plist",
     "~/Library/Saved Application State/com.runningwithcrayons.Alfred-Preferences.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/alfred3.rb
+++ b/Casks/alfred3.rb
@@ -7,6 +7,8 @@ cask "alfred3" do
   desc "Application launcher and productivity software"
   homepage "https://www.alfredapp.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Alfred #{version.major}.app"
@@ -20,8 +22,4 @@ cask "alfred3" do
     "~/Library/Preferences/com.runningwithcrayons.Alfred-Preferences-#{version.major}.plist",
     "~/Library/Saved Application State/com.runningwithcrayons.Alfred-Preferences-#{version.major}.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/anaconda2.rb
+++ b/Casks/anaconda2.rb
@@ -8,6 +8,8 @@ cask "anaconda2" do
   desc "Data science platform"
   homepage "https://www.anaconda.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   container type: :naked
 
   installer script: {
@@ -32,7 +34,6 @@ cask "anaconda2" do
   ]
 
   caveats do
-    discontinued
     files_in_usr_local
     path_environment_variable "#{HOMEBREW_PREFIX}/anaconda2/bin"
   end

--- a/Casks/arduino-nightly.rb
+++ b/Casks/arduino-nightly.rb
@@ -7,6 +7,8 @@ cask "arduino-nightly" do
   desc "Electronics prototyping platform"
   homepage "https://www.arduino.cc/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "arduino"
 
   app "Arduino.app"
@@ -16,8 +18,4 @@ cask "arduino-nightly" do
     "~/Library/Arduino15",
     "~/Library/Saved Application State/cc.arduino.Arduino.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/arq5.rb
+++ b/Casks/arq5.rb
@@ -7,6 +7,8 @@ cask "arq5" do
   desc "Multi-cloud backup application"
   homepage "https://www.arqbackup.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: "arq"
 
@@ -22,8 +24,4 @@ cask "arq5" do
     "~/Library/Preferences/com.haystacksoftware.Arq*.plist",
     "~/Library/Saved Application State/com.haystacksoftware.Arq.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/atom-beta.rb
+++ b/Casks/atom-beta.rb
@@ -8,6 +8,8 @@ cask "atom-beta" do
   desc "Cross-platform text editor"
   homepage "https://atom.io/beta"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Atom Beta.app"
@@ -28,8 +30,4 @@ cask "atom-beta" do
     "~/Library/Preferences/com.github.atom.plist",
     "~/Library/Saved Application State/com.github.atom.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/atom-nightly.rb
+++ b/Casks/atom-nightly.rb
@@ -8,6 +8,8 @@ cask "atom-nightly" do
   desc "Cross-platform text editor"
   homepage "https://atom.io/nightly"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Atom Nightly.app"
   binary "#{appdir}/Atom Nightly.app/Contents/Resources/app/apm/bin/apm", target: "apm-nightly"
   binary "#{appdir}/Atom Nightly.app/Contents/Resources/app/atom.sh", target: "atom-nightly"
@@ -26,8 +28,4 @@ cask "atom-nightly" do
     "~/Library/Preferences/com.github.atom.plist",
     "~/Library/Saved Application State/com.github.atom.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/calibre4.rb
+++ b/Casks/calibre4.rb
@@ -7,6 +7,8 @@ cask "calibre4" do
   desc "E-books management software"
   homepage "https://calibre-ebook.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "calibre"
   depends_on macos: ">= :mojave"
 
@@ -39,8 +41,4 @@ cask "calibre4" do
     "~/Library/Saved Application State/com.calibre-ebook.ebook-viewer.savedState",
     "~/Library/Saved Application State/net.kovidgoyal.calibre.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/charles-applejava.rb
+++ b/Casks/charles-applejava.rb
@@ -7,14 +7,12 @@ cask "charles-applejava" do
   desc "Web debugging Proxy application"
   homepage "https://www.charlesproxy.com/previous-release/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Charles.app"
 
   zap trash: [
     "~/Library/Application Support/Charles",
     "~/Library/Preferences/com.xk72.charles.config",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/cleanmymac3.rb
+++ b/Casks/cleanmymac3.rb
@@ -8,6 +8,8 @@ cask "cleanmymac3" do
   desc "Tool to remove unnecessary files and folders from disk"
   homepage "https://macpaw.com/cleanmymac"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "CleanMyMac #{version.major}.app"
 
   uninstall delete:     [
@@ -61,8 +63,4 @@ cask "cleanmymac3" do
     "~/Library/WebKit/com.macpaw.CleanMyMac#{version.major}",
     "~/Pictures/Photos Library.photoslibrary/private/com.macpaw.CleanMyMac#{version.major}",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/dash2.rb
+++ b/Casks/dash2.rb
@@ -7,6 +7,8 @@ cask "dash2" do
   desc "API documentation browser and code snippet manager"
   homepage "https://kapeli.com/dash"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Dash.app"
 
   zap trash: [
@@ -14,8 +16,4 @@ cask "dash2" do
     "~/Library/Preferences/com.kapeli.dash.plist",
     "~/Library/Preferences/com.kapeli.dashdoc.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/dash3.rb
+++ b/Casks/dash3.rb
@@ -7,6 +7,8 @@ cask "dash3" do
   desc "API documentation browser and code snippet manager"
   homepage "https://kapeli.com/dash"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Dash.app"
@@ -17,8 +19,4 @@ cask "dash3" do
     "~/Library/Preferences/com.kapeli.dash.plist",
     "~/Library/Preferences/com.kapeli.dashdoc.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/dash4.rb
+++ b/Casks/dash4.rb
@@ -7,6 +7,8 @@ cask "dash4" do
   desc "API documentation browser and code snippet manager"
   homepage "https://kapeli.com/dash"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Dash.app"
@@ -19,8 +21,4 @@ cask "dash4" do
     "~/Library/Logs/Dash",
     "~/Library/Preferences/com.kapeli.dashdoc.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/dash5.rb
+++ b/Casks/dash5.rb
@@ -7,6 +7,8 @@ cask "dash5" do
   desc "API documentation browser and code snippet manager"
   homepage "https://kapeli.com/dash"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :mojave"
 
@@ -23,8 +25,4 @@ cask "dash5" do
     "~/Library/Saved Application State/com.kapeli.dashdoc.savedState",
     "~/Library/WebKit/com.kapeli.dashdoc",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -8,6 +8,8 @@ cask "docker-edge" do
   desc "App to build and share containerized applications and microservices"
   homepage "https://www.docker.com/products/docker-desktop"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :mojave"
 
@@ -54,7 +56,6 @@ cask "docker-edge" do
       ]
 
   caveats do
-    discontinued
     <<~EOS
       Starting with Docker Desktop 3.0.0, Stable and Edge releases
       are combined into a single, cumulative release stream.

--- a/Casks/forklift2.rb
+++ b/Casks/forklift2.rb
@@ -7,6 +7,8 @@ cask "forklift2" do
   desc "Finder replacement and FTP, SFTP, WebDAV and Amazon s3 client"
   homepage "https://www.binarynights.com/forklift/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "forklift"
 
   app "ForkLift.app"
@@ -15,8 +17,4 @@ cask "forklift2" do
     "~/Library/Preferences/com.binarynights.ForkLift#{version.major}.plist",
     "~/Library/Caches/com.binarynights.ForkLift#{version.major}",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/forklift3.rb
+++ b/Casks/forklift3.rb
@@ -7,6 +7,8 @@ cask "forklift3" do
   desc "Finder replacement and FTP, SFTP, WebDAV and Amazon s3 client"
   homepage "https://binarynights.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: "forklift"
   depends_on macos: ">= :sierra"
@@ -34,8 +36,4 @@ cask "forklift3" do
     "~/Library/Preferences/com.binarynights.ForkLiftMini.plist",
     "~/Library/Saved Application State/com.binarynights.ForkLift-#{version.major}.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/hancom-word-2014.rb
+++ b/Casks/hancom-word-2014.rb
@@ -8,6 +8,8 @@ cask "hancom-word-2014" do
   desc "Word processor"
   homepage "https://office.hancom.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "HwpMac2014VP_Home.pkg"
 
   uninstall quit:    "com.hancom.office.hwp.mac.general",
@@ -22,8 +24,4 @@ cask "hancom-word-2014" do
     "/private/var/db/receipts/com.hancom.office.hwp.mac.general.bom",
     "/private/var/db/receipts/com.hancom.office.hwp.mac.general.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/intellij-idea-ce19.rb
+++ b/Casks/intellij-idea-ce19.rb
@@ -8,6 +8,8 @@ cask "intellij-idea-ce19" do
   desc "IDE for Java development - community edition"
   homepage "https://www.jetbrains.com/idea/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: "intellij-idea-ce"
 
@@ -30,8 +32,4 @@ cask "intellij-idea-ce19" do
     "~/Library/Preferences/com.jetbrains.intellij.ce.plist",
     "~/Library/Saved Application State/com.jetbrains.intellij.ce.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/intellij-idea19.rb
+++ b/Casks/intellij-idea19.rb
@@ -7,6 +7,8 @@ cask "intellij-idea19" do
   desc "IDE for JVM languages"
   homepage "https://www.jetbrains.com/idea/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "IntelliJ IDEA.app"
@@ -28,8 +30,4 @@ cask "intellij-idea19" do
     "~/Library/Preferences/IntelliJIdea#{version.major_minor}",
     "~/Library/Saved Application State/com.jetbrains.intellij.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/iterm2-legacy.rb
+++ b/Casks/iterm2-legacy.rb
@@ -8,6 +8,8 @@ cask "iterm2-legacy" do
   desc "Terminal emulator as alternative to Apple's Terminal app"
   homepage "https://www.iterm2.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: [
     "iterm2",
@@ -18,8 +20,4 @@ cask "iterm2-legacy" do
   app "iTerm.app"
 
   zap trash: "~/Library/Preferences/com.googlecode.iterm2.plist"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/java6.rb
+++ b/Casks/java6.rb
@@ -22,9 +22,7 @@ cask "java6" do
   desc "Legacy runtime for the Java programming language"
   homepage "https://support.apple.com/kb/DL1572"
 
-  zap trash: "~/Library/Application Support/java"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  zap trash: "~/Library/Application Support/java"
 end

--- a/Casks/keyboard-maestro8.rb
+++ b/Casks/keyboard-maestro8.rb
@@ -8,6 +8,8 @@ cask "keyboard-maestro8" do
   desc "Automation software"
   homepage "https://www.keyboardmaestro.com/main/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Keyboard Maestro.app"
 
   zap trash: [
@@ -21,8 +23,4 @@ cask "keyboard-maestro8" do
     "~/Library/Preferences/com.stairways.keyboardmaestro.plist",
     "~/Library/Saved Application State/com.stairways.keyboardmaestro.editor.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/ksdiff2.rb
+++ b/Casks/ksdiff2.rb
@@ -7,6 +7,8 @@ cask "ksdiff2" do
   desc "Command-line tool for the App Store version of Kaleidoscope v2"
   homepage "https://kaleidoscope.app/ksdiff#{version.major}"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: [
     "kaleidoscope",
     "kaleidoscope2",
@@ -18,8 +20,4 @@ cask "ksdiff2" do
   uninstall pkgutil: "com.blackpixel.kaleidoscope.ksdiff.installer.pkg"
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/microsoft-office-2016.rb
+++ b/Casks/microsoft-office-2016.rb
@@ -8,6 +8,8 @@ cask "microsoft-office-2016" do
   desc "Office suite"
   homepage "https://products.office.com/mac/microsoft-office-for-mac/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: %w[
     microsoft-excel
@@ -105,8 +107,4 @@ cask "microsoft-office-2016" do
         "com.microsoft.update.agent",
       ],
       pkgutil:   "com.microsoft.package.Microsoft_AutoUpdate.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/microsoft-office-2019.rb
+++ b/Casks/microsoft-office-2019.rb
@@ -7,6 +7,8 @@ cask "microsoft-office-2019" do
   desc "Office suite"
   homepage "https://www.microsoft.com/en-us/microsoft-365/mac/microsoft-365-for-mac/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: %w[
     microsoft-excel
@@ -102,8 +104,4 @@ cask "microsoft-office-2019" do
         "com.microsoft.update.agent",
       ],
       pkgutil:   "com.microsoft.package.Microsoft_AutoUpdate.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/miniconda2.rb
+++ b/Casks/miniconda2.rb
@@ -8,6 +8,8 @@ cask "miniconda2" do
   desc "Minimal installer for conda"
   homepage "https://www.anaconda.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   container type: :naked
 
   installer script: {
@@ -29,7 +31,6 @@ cask "miniconda2" do
   ]
 
   caveats do
-    discontinued
     files_in_usr_local
     path_environment_variable "#{HOMEBREW_PREFIX}/miniconda2/bin"
   end

--- a/Casks/omnifocus2.rb
+++ b/Casks/omnifocus2.rb
@@ -16,6 +16,8 @@ cask "omnifocus2" do
   desc "Scheduling application focusing on organization"
   homepage "https://www.omnigroup.com/omnifocus/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "OmniFocus.app"
@@ -31,8 +33,4 @@ cask "omnifocus2" do
     "~/Library/Group Containers/34YW5XSRB7.com.omnigroup.OmniFocus",
     "~/Library/Saved Application State/com.omnigroup.OmniFocus#{version}.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/omnigraffle6.rb
+++ b/Casks/omnigraffle6.rb
@@ -7,6 +7,8 @@ cask "omnigraffle6" do
   desc "Visual communication software"
   homepage "https://www.omnigroup.com/omnigraffle/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "OmniGraffle.app"
 
   zap trash: [
@@ -17,8 +19,4 @@ cask "omnigraffle6" do
     "~/Library/Preferences/com.omnigroup.OmniGraffle6.plist",
     "~/Library/Saved Application State/com.omnigroup.OmniGraffle6.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/omniplan3.rb
+++ b/Casks/omniplan3.rb
@@ -16,6 +16,8 @@ cask "omniplan3" do
   desc "Project planning and management software"
   homepage "https://www.omnigroup.com/omniplan/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: "omniplan"
   depends_on macos: ">= :mojave"
@@ -28,8 +30,4 @@ cask "omniplan3" do
     "~/Library/Containers/com.omnigroup.OmniPlan#{version.major}",
     "~/Library/Preferences/com.omnigroup.OmniPlan#{version.major}.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/papers3.rb
+++ b/Casks/papers3.rb
@@ -8,6 +8,8 @@ cask "papers3" do
   desc "Reference management software for researchers"
   homepage "https://support.papersapp.com/support/solutions/articles/30000031865-existing-papers-3-users-accessing-papers-3-program-files-for-additional-device-installs"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Papers.app"
 
   uninstall login_item: "Citations"
@@ -19,8 +21,4 @@ cask "papers3" do
     "~/Library/Preferences/com.mekentosj.Citations.plist",
     "~/Library/Preferences/com.mekentosj.papers#{version.major}",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/powershell6.rb
+++ b/Casks/powershell6.rb
@@ -7,6 +7,8 @@ cask "powershell6" do
   desc "Command-line shell and scripting language"
   homepage "https://github.com/PowerShell/PowerShell"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "powershell"
   depends_on macos: ">= :high_sierra"
 
@@ -25,8 +27,4 @@ cask "powershell6" do
         "~/.local/share",
         "~/.local",
       ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/processing2.rb
+++ b/Casks/processing2.rb
@@ -7,6 +7,8 @@ cask "processing2" do
   desc "Flexible software sketchbook and a language for learning how to code"
   homepage "https://processing.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: [
     "processing",
     "processing3",
@@ -17,8 +19,4 @@ cask "processing2" do
   uninstall quit: "org.processing.app"
 
   zap trash: "~/Library/Processing/preferences.txt"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/propresenter6.rb
+++ b/Casks/propresenter6.rb
@@ -7,6 +7,8 @@ cask "propresenter6" do
   desc "Presentation and production application for live events"
   homepage "https://www.renewedvision.com/propresenter.php"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :high_sierra"
 
   app "ProPresenter #{version.major}.app"
@@ -26,8 +28,4 @@ cask "propresenter6" do
         "~/Library/Caches/KSCrashReports",
         "~/Library/Caches/Sessions",
       ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/quicktime-player7.rb
+++ b/Casks/quicktime-player7.rb
@@ -7,13 +7,11 @@ cask "quicktime-player7" do
   desc "Video player"
   homepage "https://support.apple.com/kb/dl923"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "QuickTimePlayer#{version}_SnowLeopard.pkg"
 
   uninstall pkgutil: "com.apple.pkg.QuickTimePlayer#{version}_SnowLeopard"
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/rambox-ce.rb
+++ b/Casks/rambox-ce.rb
@@ -8,6 +8,8 @@ cask "rambox-ce" do
   desc "Free and Open Source messaging and emailing app"
   homepage "https://rambox.pro/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "rambox"
 
   app "Rambox.app"
@@ -29,8 +31,4 @@ cask "rambox-ce" do
     "~/Library/Saved Application State/com.saenzramiro.rambox.savedState",
     "~/Library/WebKit/com.saenzramiro.rambox",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/skype7.rb
+++ b/Casks/skype7.rb
@@ -7,6 +7,8 @@ cask "skype7" do
   desc "Video chat, voice call and instant messaging application"
   homepage "https://www.skype.com/en/get-skype/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: "skype"
 
@@ -20,8 +22,4 @@ cask "skype7" do
     "~/Library/Preferences/com.skype.skypewifi.plist",
     "~/Library/Saved Application State/com.skype.skype.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/soulver2.rb
+++ b/Casks/soulver2.rb
@@ -8,6 +8,8 @@ cask "soulver2" do
   desc "Text editor and calculator"
   homepage "https://soulver.app/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :high_sierra"
 
@@ -18,8 +20,4 @@ cask "soulver2" do
     "~/Library/Autosave Information/Unsaved Soulver Document*",
     "~/Library/Preferences/com.acqualia.soulver.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/sublime-text2.rb
+++ b/Casks/sublime-text2.rb
@@ -7,6 +7,8 @@ cask "sublime-text2" do
   desc "Text editor for code, markup and prose"
   homepage "https://www.sublimetext.com/2"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Sublime Text 2.app"
   binary "#{appdir}/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
 
@@ -16,8 +18,4 @@ cask "sublime-text2" do
     "~/Library/Caches/com.sublimetext.2",
     "~/Library/Saved Application State/com.sublimetext.2.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/sublime-text3.rb
+++ b/Casks/sublime-text3.rb
@@ -7,6 +7,8 @@ cask "sublime-text3" do
   desc "Text editor for code, markup and prose"
   homepage "https://www.sublimetext.com/3"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: [
     "sublime-text",
@@ -26,8 +28,4 @@ cask "sublime-text3" do
     "~/Library/Preferences/com.sublimetext.#{version.major}.plist",
     "~/Library/Saved Application State/com.sublimetext.#{version.major}.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/temurin18.rb
+++ b/Casks/temurin18.rb
@@ -11,13 +11,11 @@ cask "temurin18" do
   desc "JDK from the Eclipse Foundation (Adoptium)"
   homepage "https://adoptium.net/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg"
 
   uninstall pkgutil: "net.temurin.#{version.major}.jdk"
-
-  caveats do
-    discontinued
-  end
 
   # No zap stanza required
 end

--- a/Casks/tower2.rb
+++ b/Casks/tower2.rb
@@ -8,6 +8,8 @@ cask "tower2" do
   desc "Git client focusing on power and productivity"
   homepage "https://www.git-tower.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Tower.app"
   binary "#{appdir}/Tower.app/Contents/MacOS/gittower"
 
@@ -16,8 +18,4 @@ cask "tower2" do
     "~/Library/Caches/com.fournova.Tower#{version.major}",
     "~/Library/Preferences/com.fournova.Tower#{version.major}.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/transmit4.rb
+++ b/Casks/transmit4.rb
@@ -7,14 +7,12 @@ cask "transmit4" do
   desc "File transfer application"
   homepage "https://panic.com/transmit/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Transmit.app"
 
   zap trash: [
     "~/Library/Preferences/com.panic.Transmit.plist",
     "~/Library/Application Support/Transmit",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/vmware-fusion10.rb
+++ b/Casks/vmware-fusion10.rb
@@ -7,6 +7,8 @@ cask "vmware-fusion10" do
   desc "Create, manage, and run virtual machines"
   homepage "https://www.vmware.com/products/fusion.html"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: %w[
     vmware-fusion
@@ -81,7 +83,6 @@ cask "vmware-fusion10" do
   ]
 
   caveats do
-    discontinued
     kext
   end
 end

--- a/Casks/vmware-fusion11.rb
+++ b/Casks/vmware-fusion11.rb
@@ -7,6 +7,8 @@ cask "vmware-fusion11" do
   desc "App to run other operating systems without rebooting"
   homepage "https://www.vmware.com/products/fusion.html"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: %w[
     vmware-fusion
@@ -84,7 +86,6 @@ cask "vmware-fusion11" do
   ]
 
   caveats do
-    discontinued
     kext
   end
 end

--- a/Casks/vmware-fusion12.rb
+++ b/Casks/vmware-fusion12.rb
@@ -6,7 +6,6 @@ cask "vmware-fusion12" do
     url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version.csv.first}-#{version.csv.second}.dmg"
 
     caveats do
-      discontinued
       kext
     end
   end
@@ -15,15 +14,13 @@ cask "vmware-fusion12" do
     sha256 "403d14e7609f1863bd46617c90f2e3642f6b68ed387c1b7f8c62722d580c633c"
 
     url "https://download3.vmware.com/software/FUS-#{version.csv.first.no_dots}/VMware-Fusion-#{version.csv.first}-#{version.csv.second}_x86.dmg"
-
-    caveats do
-      discontinued
-    end
   end
 
   name "VMware Fusion"
   desc "Create, manage, and run virtual machines"
   homepage "https://www.vmware.com/products/fusion.html"
+
+  deprecate! date: "2023-12-17", because: :discontinued
 
   auto_updates true
   conflicts_with cask: %w[

--- a/Casks/vmware-fusion7.rb
+++ b/Casks/vmware-fusion7.rb
@@ -7,6 +7,8 @@ cask "vmware-fusion7" do
   desc "Create, manage, and run virtual machines"
   homepage "https://www.vmware.com/products/fusion.html"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: %w[
     vmware-fusion
     vmware-fusion8
@@ -34,8 +36,4 @@ cask "vmware-fusion7" do
     "~/Library/Logs/VMware",
     "~/Library/Logs/VMware Fusion",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/vmware-fusion8.rb
+++ b/Casks/vmware-fusion8.rb
@@ -7,6 +7,8 @@ cask "vmware-fusion8" do
   desc "Create, manage, and run virtual machines"
   homepage "https://www.vmware.com/products/fusion.html"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: %w[
     vmware-fusion
@@ -77,8 +79,4 @@ cask "vmware-fusion8" do
     "~/Library/Saved Application State/com.vmware.fusion.savedState",
     "~/Library/WebKit/com.vmware.fusion",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/vox2.rb
+++ b/Casks/vox2.rb
@@ -8,14 +8,12 @@ cask "vox2" do
   desc "Music player for high resoluion (Hi-Res) music through the external sources"
   homepage "https://vox.rocks/mac-music-player/old-versions"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "VOX.app"
 
   zap trash: [
     "~/Library/Containers/com.coppertino.Vox",
     "~/Library/Preferences/com.coppertino.Vox.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/xmind8.rb
+++ b/Casks/xmind8.rb
@@ -7,6 +7,8 @@ cask "xmind8" do
   desc "Mind mapping and brainstorming tool"
   homepage "https://www.xmind.net/xmind8-pro/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "xmind"
 
   app "XMind.app"
@@ -15,8 +17,4 @@ cask "xmind8" do
     "~/Library/XMind",
     "~/Library/Saved Application State/org.xmind.cathy.application.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/zulu13.rb
+++ b/Casks/zulu13.rb
@@ -11,13 +11,11 @@ cask "zulu13" do
   desc "OpenJDK distribution from Azul"
   homepage "https://www.azul.com/products/core/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"
 
   zap trash: "~/Library/Saved Application State/com.azul.zulu.#{version.major}*.java.savedState"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/zulu15.rb
+++ b/Casks/zulu15.rb
@@ -11,6 +11,8 @@ cask "zulu15" do
   desc "Zulu OpenJDK 15"
   homepage "https://www.azul.com/products/core/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
@@ -18,8 +20,4 @@ cask "zulu15" do
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"
 
   zap trash: "~/Library/Saved Application State/com.azul.zulu.#{version.major}*.java.savedState"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/zulu7.rb
+++ b/Casks/zulu7.rb
@@ -8,13 +8,11 @@ cask "zulu7" do
   desc "OpenJDK distribution from Azul"
   homepage "https://www.azul.com/products/core/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"
 
   zap trash: "~/Library/Saved Application State/com.azul.zulu.#{version.major}*.java.savedState"
-
-  caveats do
-    discontinued
-  end
 end


### PR DESCRIPTION
See https://github.com/Homebrew/brew/pull/16292

Move all instances of `discontinued` in the `caveats` stanza to a `deprecate!` call.

For now, I've left the date for all of these as today (`2023-12-17`) because it doesn't seem to me like it will be a good use of my time to go through each and figure out an appropriate date. If that isn't the best solution, though, I'm happy to hear about alternatives.

This PR was made using `brew style --fix` with https://github.com/Homebrew/brew/pull/16351 checked out, and then the non-autocorrectable (when the `caveats` stanza includes more than just `discontinued`) offenses were handled manually.

Note: this PR cannot be merged until a new Homebrew/brew tag (4.2.0) is made.
