### PR TITLE
hamsket-nightly: deprecate

### DIFF
--- a/Casks/hamsket-nightly.rb
+++ b/Casks/hamsket-nightly.rb
@@ -7,11 +7,7 @@ cask "hamsket-nightly" do
   desc "Free and Open Source messaging and emailing app"
   homepage "https://github.com/TheGoddessInari/hamsket"
 
-  livecheck do
-    url "https://github.com/TheGoddessInari/hamsket/releases/expanded_assets/nightly"
-    regex(/href=.*?Hamsket-(\d+(?:\.\d+)+)\.dmg/i)
-    strategy :page_match
-  end
+  deprecate! date: "2024-01-01", because: :discontinued
 
   depends_on macos: ">= :high_sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR deprecates the `hamsket-nightly` cask, as the related [GitHub repository](https://github.com/TheGoddessInari/hamsket) was archived on 2023-10-13.