### PR TITLE
microsoft-teams-classic 1.6.00.35956

### DIFF
--- a/Casks/microsoft-teams-classic.rb
+++ b/Casks/microsoft-teams-classic.rb
@@ -1,6 +1,6 @@
 cask "microsoft-teams-classic" do
-  version "1.6.00.34263"
-  sha256 "dc82c3a64d9d9f0f11c8c883048bcbae85c823b9ea446eaf224b0588f7f21a10"
+  version "1.6.00.35956"
+  sha256 "fae6654a4d0177ac47483c8fab0abfdb8328cbf5337968d787306e22060cc52b"
 
   url "https://statics.teams.cdn.office.net/production-osx/#{version}/Teams_osx.pkg",
       verified: "statics.teams.cdn.office.net/production-osx/"

--- a/audit_exceptions/secure_connection_audit_skiplist.json
+++ b/audit_exceptions/secure_connection_audit_skiplist.json
@@ -1,4 +1,3 @@
 {
-    "microsoft-office-2019": "https://www.microsoft.com/en-us/microsoft-365/mac/microsoft-365-for-mac/",
-    "microsoft-teams-classic": "https://www.microsoft.com/en-us/microsoft-teams/group-chat-software"
+    "microsoft-office-2019": "https://www.microsoft.com/en-us/microsoft-365/mac/microsoft-365-for-mac/"
 }


### PR DESCRIPTION
```
audit for microsoft-teams-classic: failed
 - https://www.microsoft.com/en-us/microsoft-teams/group-chat-software is in the secure connection audit skiplist but does not need to be skipped
homebrew/cask-versions/microsoft-teams-classic
Error: 1 problem in 1 cask detected.
Error: `brew audit` failed!
```