### PR TITLE
android-studio-preview-beta 2023.2.1.19

### DIFF
--- a/Casks/android-studio-preview-beta.rb
+++ b/Casks/android-studio-preview-beta.rb
@@ -2,18 +2,18 @@ cask "android-studio-preview-beta" do
   arch arm: "mac_arm", intel: "mac"
 
   version "2023.2.1.19"
-  sha256 arm:   "56021df81e1e0947c56a80dee6cee5241fe6ca61e5e8eefb3830368608a730dd",
-         intel: "eadaf1f9591e0b196084a40b47e1971d1e6b005c4c4c865bfac2dd499b96ce36"
+  sha256 arm:   "7e4c16dcca922d1a01d8e90a67b84245f2ece986c97405c6ab5a1f6e45a7f12c",
+         intel: "11574fe4a02893792625323271a771398e565467853923588c21ecb7655b0dae"
 
-  url "https://dl.google.com/dl/android/studio/ide-zips/#{version}/android-studio-#{version}-#{arch}.zip",
-      verified: "dl.google.com/dl/android/studio/"
+  url "https://redirector.gvt1.com/edgedl/android/studio/install/#{version}/android-studio-#{version}-#{arch}.dmg",
+      verified: "redirector.gvt1.com/edgedl/android/studio/install/"
   name "Android Studio Preview (Beta)"
   desc "Tools for building Android applications"
   homepage "https://developer.android.com/studio/preview/"
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/android[._-]studio[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.zip(.*\n*\s*.*)(Beta|RC)}i)
+    regex(%r{href=.*?/android[._-]studio[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg(.*\n*\s*.*)(Beta|RC)}i)
   end
 
   auto_updates true


### PR DESCRIPTION
Updated to match https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/a/android-studio.rb and https://github.com/Homebrew/homebrew-cask-versions/blob/HEAD/Casks/android-studio-preview-canary.rb.

Before these changes:
```
|-> brew livecheck android-studio-preview-beta --debug

Cask:             android-studio-preview-beta
Livecheckable?:   Yes

URL (homepage):   https://developer.android.com/studio/preview/
Strategy:         PageMatch
Regex:            /href=.*?\/android[._-]studio[._-]v?(\d+(?:\.\d+)+)[._-]mac_arm\.zip(.*\n*\s*.*)(Beta|RC)/i
Error: android-studio-preview-beta: Unable to get versions
```