### PR TITLE
Fix new RuboCop `Cask/ArrayAlphabetization` offenses

### DIFF
--- a/Casks/docker-edge.rb
+++ b/Casks/docker-edge.rb
@@ -51,8 +51,8 @@ cask "docker-edge" do
         "~/Library/Saved Application State/com.electron.docker-frontend.savedState",
       ],
       rmdir: [
-        "~/Library/Caches/KSCrashReports",
         "~/Library/Caches/com.plausiblelabs.crashreporter.data",
+        "~/Library/Caches/KSCrashReports",
       ]
 
   caveats do

--- a/Casks/firefox-beta.rb
+++ b/Casks/firefox-beta.rb
@@ -97,8 +97,8 @@ cask "firefox-beta" do
       ],
       rmdir: [
         "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
-        "~/Library/Caches/Mozilla/updates/Applications",
-        "~/Library/Caches/Mozilla/updates",
         "~/Library/Caches/Mozilla",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla/updates/Applications",
       ]
 end

--- a/Casks/firefox-cn.rb
+++ b/Casks/firefox-cn.rb
@@ -41,8 +41,8 @@ cask "firefox-cn" do
       ],
       rmdir: [
         "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
-        "~/Library/Caches/Mozilla/updates/Applications",
-        "~/Library/Caches/Mozilla/updates",
         "~/Library/Caches/Mozilla",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla/updates/Applications",
       ]
 end

--- a/Casks/firefox-developer-edition.rb
+++ b/Casks/firefox-developer-edition.rb
@@ -74,8 +74,8 @@ cask "firefox-developer-edition" do
       ],
       rmdir: [
         "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
-        "~/Library/Caches/Mozilla/updates/Applications",
-        "~/Library/Caches/Mozilla/updates",
         "~/Library/Caches/Mozilla",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla/updates/Applications",
       ]
 end

--- a/Casks/firefox-esr.rb
+++ b/Casks/firefox-esr.rb
@@ -105,8 +105,8 @@ cask "firefox-esr" do
       ],
       rmdir: [
         "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
-        "~/Library/Caches/Mozilla/updates/Applications",
-        "~/Library/Caches/Mozilla/updates",
         "~/Library/Caches/Mozilla",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla/updates/Applications",
       ]
 end

--- a/Casks/firefox-nightly.rb
+++ b/Casks/firefox-nightly.rb
@@ -104,8 +104,8 @@ cask "firefox-nightly" do
       ],
       rmdir: [
         "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
-        "~/Library/Caches/Mozilla/updates/Applications",
-        "~/Library/Caches/Mozilla/updates",
         "~/Library/Caches/Mozilla",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla/updates/Applications",
       ]
 end

--- a/Casks/powershell6.rb
+++ b/Casks/powershell6.rb
@@ -24,7 +24,7 @@ cask "powershell6" do
       rmdir: [
         "~/.cache",
         "~/.config",
-        "~/.local/share",
         "~/.local",
+        "~/.local/share",
       ]
 end


### PR DESCRIPTION
- More fixes for https://github.com/Homebrew/brew/pull/16365 now we've made the decision to treat `zap` and `uninstall` the same, and hence we now scan all `zap` stanzas not just trash.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
