### PR TITLE
Add zed-preview cask

### DIFF
--- a/Casks/zed-preview.rb
+++ b/Casks/zed-preview.rb
@@ -13,9 +13,7 @@ cask "zed-preview" do
   end
 
   auto_updates true
-  conflicts_with cask: [
-    "zed",
-  ]
+  conflicts_with cask: "zed"
   depends_on macos: ">= :catalina"
 
   app "Zed Preview.app"

--- a/Casks/zed-preview.rb
+++ b/Casks/zed-preview.rb
@@ -1,0 +1,30 @@
+cask "zed-preview" do
+  version "0.120.3"
+  sha256 "2c44a02b7667a324933e779488c3c70c949089741ee387b39cda463dd3f3558e"
+
+  url "https://zed.dev/api/releases/preview/#{version}/Zed.dmg"
+  name "Zed Preview"
+  desc "Multiplayer code editor"
+  homepage "https://zed.dev/"
+
+  livecheck do
+    url "https://zed.dev/releases/preview"
+    regex(%r{href=.*?/preview/(\d+(?:\.\d+)+)/Zed.dmg}i)
+  end
+
+  auto_updates true
+  conflicts_with cask: [
+    "zed",
+  ]
+  depends_on macos: ">= :catalina"
+
+  app "Zed Preview.app"
+  binary "#{appdir}/Zed Preview.app/Contents/MacOS/cli", target: "zed"
+
+  zap trash: [
+    "~/.config/Zed",
+    "~/Library/Application Support/Zed",
+    "~/Library/Logs/Zed",
+    "~/Library/Saved Application State/dev.zed.Zed.savedState",
+  ]
+end

--- a/Casks/zed-preview.rb
+++ b/Casks/zed-preview.rb
@@ -1,6 +1,6 @@
 cask "zed-preview" do
-  version "0.120.3"
-  sha256 "2c44a02b7667a324933e779488c3c70c949089741ee387b39cda463dd3f3558e"
+  version "0.121.1"
+  sha256 "9354c130c6c583560391278611c16777973606b55d061827895181b5d9640f27"
 
   url "https://zed.dev/api/releases/preview/#{version}/Zed.dmg"
   name "Zed Preview"


### PR DESCRIPTION
A preview version of the Zed editor - https://zed.dev/releases/preview

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
