### PR TITLE
Add QLC+ beta (`qlc-plus-beta`) cask

### DIFF
--- a/Casks/qlc-plus-beta.rb
+++ b/Casks/qlc-plus-beta.rb
@@ -1,0 +1,20 @@
+cask "qlc-plus-beta" do
+  version "5.0.0_beta3"
+  sha256 "eb10d1c4a666df264bc6f7c1eed955f107fef7c42eed15933a87725fc4408b0d"
+
+  url "https://www.qlcplus.org/downloads/#{version}/QLC+_#{version}.dmg"
+  name "Q Light Controller+"
+  desc "Control DMX or analog lighting systems"
+  homepage "https://www.qlcplus.org/"
+
+  livecheck do
+    url "https://www.qlcplus.org/download"
+    regex(/href=.*?QLC\+[._-]v?(\d+(?:\.\d+)+_beta\d+)\.dmg/i)
+  end
+
+  conflicts_with cask: "qlc-plus"
+
+  app "QLC+.app"
+
+  zap trash: "~/Library/Application Support/QLC+"
+end


### PR DESCRIPTION
This adds the beta version of [QLC+](https://www.qlcplus.org), based on [the upstream `qlc-plus` cask](https://formulae.brew.sh/cask/qlc-plus).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
  - It's a beta version, therefore I'm targeting this repo
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
