### PR TITLE
Update `zed-preview` so that it doesn't conflict with `zed` anymore

### DIFF
--- a/Casks/zed-preview.rb
+++ b/Casks/zed-preview.rb
@@ -1,6 +1,6 @@
 cask "zed-preview" do
-  version "0.124.4"
-  sha256 "e586b05f18e84423e3552d1f9bd0c520d8e38a699413141f79c28fa911fe943f"
+  version "0.124.6"
+  sha256 "9759283b55cbe0e98efbacaaf3fe2f963b752549a2a7678a410de7b0f438bb66"
 
   url "https://zed.dev/api/releases/preview/#{version}/Zed.dmg"
   name "Zed Preview"

--- a/Casks/zed-preview.rb
+++ b/Casks/zed-preview.rb
@@ -13,11 +13,10 @@ cask "zed-preview" do
   end
 
   auto_updates true
-  conflicts_with cask: "zed"
   depends_on macos: ">= :catalina"
 
   app "Zed Preview.app"
-  binary "#{appdir}/Zed Preview.app/Contents/MacOS/cli", target: "zed"
+  binary "#{appdir}/Zed Preview.app/Contents/MacOS/cli", target: "zed-preview"
 
   zap trash: [
     "~/.config/Zed",


### PR DESCRIPTION
Zed preview shouldn't conflict with zed release

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
