### PR TITLE
Add ableton-live-suite11 to cask-versions

### DIFF
--- a/Casks/ableton-live-suite11.rb
+++ b/Casks/ableton-live-suite11.rb
@@ -1,0 +1,32 @@
+cask "ableton-live-suite11" do
+  version "11.3.21"
+  sha256 "d4584282c6e0bbd27dfc5b2a1c4fe11508b2507532cb7acd4528c6ddc9a6b490"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
+  name "Ableton Live Suite"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+  livecheck do
+    url "https://www.ableton.com/en/release-notes/live-#{version.major}/"
+    regex(/(\d+(?:\.\d+)+)\s*Release\s*Notes/i)
+  end
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+  app "Ableton Live #{version.major} Suite.app"
+  uninstall quit: "com.ableton.live"
+  zap trash: [
+    "/Library/Logs/DiagnosticReports/Max_*.*_resource.diag",
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Application Support/CrashReporter/Max_*.plist",
+    "~/Library/Application Support/Cycling '74",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Library/Preferences/com.cycling74.Max*.plist*",
+    "~/Music/Ableton",
+    "~/Documents/Max [0-9]",
+    "/Users/Shared/Max [0-9]",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
