### PR TITLE
Add ableton-live-*11

### DIFF
--- a/Casks/ableton-live-intro11.rb
+++ b/Casks/ableton-live-intro11.rb
@@ -1,0 +1,30 @@
+cask "ableton-live-intro11" do
+  version "11.3.22"
+  sha256 "544bb47609c5e34bbbe834a049c2dfeb0f7bb72d3334db8e15812460d19765f0"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_universal.dmg"
+  name "Ableton Live Intro"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+
+  livecheck do
+    cask "ableton-live-suite11"
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Ableton Live #{version.major} Intro.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end

--- a/Casks/ableton-live-lite11.rb
+++ b/Casks/ableton-live-lite11.rb
@@ -1,0 +1,30 @@
+cask "ableton-live-lite11" do
+  version "11.3.22"
+  sha256 "3b7dab85e3e479c67387528231da324bfc613c7324b205a4981e68d6918e735b"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_universal.dmg"
+  name "Ableton Live Lite"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/products/live-lite/"
+
+  livecheck do
+    cask "ableton-live-suite11"
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Ableton Live #{version.major} Lite.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end

--- a/Casks/ableton-live-standard11.rb
+++ b/Casks/ableton-live-standard11.rb
@@ -1,0 +1,30 @@
+cask "ableton-live-standard11" do
+  version "11.3.22"
+  sha256 "0085a9d703709c71a6bbb4364860a02229c83714d3024c5bf7d4151f5f5f8010"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_universal.dmg"
+  name "Ableton Live Standard"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+
+  livecheck do
+    cask "ableton-live-suite11"
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Ableton Live #{version.major} Standard.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This PR migrates the remaining Ableton Live 11 casks to `homebrew-cask-versions` following their update to version 12 in `homebrew-cask` ([#168247](https://github.com/Homebrew/homebrew-cask/pull/168247)). Ableton Live 11 Suite has already been migrated in PR #19571.