### PR TITLE
Add Paragon extFS for Mac 11

### DIFF
--- a/Casks/paragon-extfs11.rb
+++ b/Casks/paragon-extfs11.rb
@@ -1,0 +1,39 @@
+cask "paragon-extfs11" do
+  version "11.8.605"
+  sha256 :no_check
+
+  url "https://dl.paragon-software.com/demo/trial_extfs.dmg"
+  name "extFS for Mac by Paragon Software"
+  desc "Read/write support for ext2/3/4 formatted volumes"
+  homepage "https://www.paragon-software.com/home/extfs-mac/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist do |items|
+      items["com.paragon-software.filesystems.extfs"].short_version
+    end
+  end
+
+  conflicts_with cask: "paragon-extfs"
+  depends_on macos: ">= :sierra"
+
+  installer manual: "FSInstaller.app"
+
+  uninstall launchctl: "com.paragon-software.extfs*",
+            quit:      "com.paragon-software.extfs*",
+            signal:    [
+              ["KILL", "com.paragon-software.extfs.FSMenuApp"],
+              ["KILL", "com.paragon-software.extfs.notification-agent"],
+            ],
+            kext:      "com.paragon-software.filesystems.extfs",
+            pkgutil:   "com.paragon-software.pkg.extfs"
+
+  zap trash: [
+    "~/Library/Application Support/com.paragon-software.extfs.*",
+    "~/Library/Caches/com.paragon-software.extfs.fsapp",
+    "~/Library/HTTPStorages/com.paragon-software.extfs.*",
+    "~/Library/Preferences/com.paragon-software.extfs.fsapp.plist",
+    "~/Library/Saved Application State/com.paragon-software.extfs.fsapp.savedState",
+    "~/Library/WebKit/com.paragon-software.extfs.fsapp",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-versions/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

The only difference between versions 11 and 12 is the migration to the new licensing system. If you have a license in the old system, you must use version 11.

Per Paragon support:

> Using new Licensing Center is currently the only difference between these versions. [...] Download the compatible installer for this license using "Download" button, and remove current version.